### PR TITLE
保存图片弹出的窗口在浏览器屏幕绝对居中

### DIFF
--- a/src/component/toolbox.js
+++ b/src/component/toolbox.js
@@ -611,7 +611,7 @@ define(function (require) {
             var image = zr.toDataURL('image/' + imgType); 
             var downloadDiv = document.createElement('div');
             downloadDiv.id = '__echarts_download_wrap__';
-            downloadDiv.style.cssText = 'position:absolute;'
+            downloadDiv.style.cssText = 'position:fixed;'
                 + 'z-index:99999;'
                 + 'display:block;'
                 + 'top:0;left:0;'


### PR DESCRIPTION
当浏览器有滚动条时，保存图片弹出的窗口一直在浏览器文档的top:0位置，滚动条滚动到下方时无法直接看到保存图片的窗口。
position修改为fixed保证弹出窗口一直在浏览器屏幕中央。
