### PR TITLE
保存图片弹出的窗口在浏览器屏幕绝对居中，遮罩背景全屏铺满

### DIFF
--- a/src/component/toolbox.js
+++ b/src/component/toolbox.js
@@ -611,14 +611,14 @@ define(function (require) {
             var image = zr.toDataURL('image/' + imgType); 
             var downloadDiv = document.createElement('div');
             downloadDiv.id = '__echarts_download_wrap__';
-            downloadDiv.style.cssText = 'position:absolute;'
+            downloadDiv.style.cssText = 'position:fixed;'
                 + 'z-index:99999;'
                 + 'display:block;'
                 + 'top:0;left:0;'
                 + 'background-color:rgba(33,33,33,0.5);'
                 + 'text-align:center;'
-                + 'width:' + document.documentElement.clientWidth + 'px;'
-                + 'height:' + document.documentElement.clientHeight + 'px;'
+                + 'width:100%;'
+                + 'height:100%;'
                 + 'line-height:' 
                 + document.documentElement.clientHeight + 'px;';
                 


### PR DESCRIPTION
1、当浏览器有滚动条时保存图片窗口位于文档最上方，修正为浏览器铺满。
2、遮罩背景当浏览器尺寸变化时，修正遮罩会有部分缺失的问题。
