### PR TITLE
修复发布文件名格式错误

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     { "name": "Yangji", "email": "yangji01@baidu.com" }
   ],
   "description": "Enterprise Charts 【Baidu Hi : 1379172 | Email : echarts@baidu.com】",
-  "main": ["build/echarts-plain-original.js, build/echarts-plain-original-map.js"],
+  "main": ["build/echarts-plain-original.js", "build/echarts-plain-original-map.js"],
   "keywords": [
     "baidu",
     "echarts",


### PR DESCRIPTION
`main` 里的应该是一个文件一个字符串，不然在 wiredep 之类的工具里会被插入成

```
<script src="bower_components/ecomfe-echarts/build/echarts-plain-original.js, build/echarts-plain-original-map.js"></script>
```
