### PR TITLE
添加require参数，解决加载顺序错误导致图表偶尔不出现的问题

### DIFF
--- a/src/util/ecQuery.js
+++ b/src/util/ecQuery.js
@@ -5,7 +5,7 @@
  * @author Kener (@Kener-林峰, linzhifeng@baidu.com)
  *
  */
-define(function() {
+define(function(require) {
     var zrUtil = require('zrender/tool/util');
     
     /**


### PR DESCRIPTION
RT，组内同事发现的，加上这个参数之后不再出错
