### PR TITLE
Add null checks for setAxisModel

### DIFF
--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -481,8 +481,8 @@ function setAxisModel(axisProxy, isRestore) {
     var useOrigin = isRestore || (percentWindow[0] === 0 && percentWindow[1] === 100);
 
     axisModel.setRange(
-        useOrigin ? null : +valueWindow[0].toFixed(precision),
-        useOrigin ? null : +valueWindow[1].toFixed(precision)
+        (useOrigin || valueWindow[0] === null) ? null : +valueWindow[0].toFixed(precision),
+        (useOrigin || valueWindow[1] === null) ? null : +valueWindow[1].toFixed(precision)
     );
 }
 


### PR DESCRIPTION
The values in the `valueWindow` array could be `null`. When the `toFixed` function is invoked, that will cause a TypeError.

https://github.com/apache/incubator-echarts/blob/5cce1e77ee8096e32ca30654385c45d22335affd/src/component/dataZoom/AxisProxy.js#L204

https://github.com/apache/incubator-echarts/blob/5cce1e77ee8096e32ca30654385c45d22335affd/src/component/dataZoom/AxisProxy.js#L484-L485