### PR TITLE
fix radiusAxis.axisLabel show problem because text is long--issues #8791

### DIFF
--- a/src/coord/axisTickLabelBuilder.js
+++ b/src/coord/axisTickLabelBuilder.js
@@ -238,6 +238,10 @@ export function calculateCategoryInterval(axis) {
     isNaN(dw) && (dw = Infinity);
     isNaN(dh) && (dh = Infinity);
     var interval = Math.max(0, Math.floor(Math.min(dw, dh)));
+    // add showAll attrbute in radiusAxis.axisLabel to show All Labels
+    if (axis.getLabelModel().get('showAll')) {
+        interval = 0;
+    }
 
     var cache = inner(axis.model);
     var lastAutoInterval = cache.lastAutoInterval;


### PR DESCRIPTION
Issues: #8791 
问题：修复极坐标因为文字长度会影响显示问题
方案： 在radiusAxis.axisLabel中新增属性：showAll，用于显示所有标签
实例如下：
```javascript
var option = {
            angleAxis: {},
            radiusAxis: {
                type: 'category',
                data: ['周一11', '周二222', '周三333333333333', '周四4444444444444444444444444444'],
                z: 10,
                axisLabel: {
                    showAll: true
                }
            },
            polar: {},
            series: [{
                type: 'bar',
                data: [1, 2, 3, 4],
                coordinateSystem: 'polar',
                name: 'A',
                stack: 'a'
            }, {
                type: 'bar',
                data: [2, 4, 6, 8],
                coordinateSystem: 'polar',
                name: 'B',
                stack: 'a'
            }, {
                type: 'bar',
                data: [1, 2, 3, 4],
                coordinateSystem: 'polar',
                name: 'C',
                stack: 'a'
            }],
            legend: {
                show: true,
                data: ['A', 'B', 'C']
            }
        };

```