### PR TITLE
fix: #9337 setNormalStyle overwrite style cause new text not effected

### DIFF
--- a/src/util/graphic.js
+++ b/src/util/graphic.js
@@ -380,6 +380,9 @@ function doSingleRestoreHoverStyle(el) {
         if (normalStl) {
             rollbackDefaultTextStyle(style);
 
+            if (style.text !== normalStl.text) {
+                normalStl.text = style.text
+            }
             // Consider null/undefined value, should use
             // `setStyle` but not `extendFrom(stl, true)`.
             el.setStyle(normalStl);


### PR DESCRIPTION
consider case: 
in graphic.js:
```
function setElementHoverStyle(el, hoverStl) {
    if (el.__highlighted) {
        singleEnterNormal(el);
        singleEnterEmphasis(el);
    }
}
```

first time: in `singleEnterNormal`, we not cache `__normalStl` yet, then we cache `__normalStl` use `el.style`  in `singleEnterEmphasis`.

second time: in `singleEnterNormal`, we cached `__normalStl`, then call `setStyle(normalStl);`, so we got a changed style, and cache `__normalStl`.... so we always set normal style with first style.

i think solutions:
 1. upside down function call. but it will not keep emphasis style.
 2. find something need change, make sure cache correct normal style