### PR TITLE
fix(sankey): modify the calculation of node value

### DIFF
--- a/src/chart/sankey/sankeyLayout.js
+++ b/src/chart/sankey/sankeyLayout.js
@@ -92,9 +92,7 @@ function layoutSankey(nodes, edges, nodeWidth, nodeGap, width, height, iteration
  */
 function computeNodeValues(nodes) {
     zrUtil.each(nodes, function (node) {
-        var value1 = sum(node.outEdges, getEdgeValue);
-        var value2 = sum(node.inEdges, getEdgeValue);
-        var value = Math.max(value1, value2);
+        var value = node.getValue();
         node.setLayout({value: value}, true);
     });
 }


### PR DESCRIPTION
使用桑吉图的时候遇到一个问题:
我的数据中，从**第一列**的nodes流出的数据可能会有流失，而**第一列**nodes流入又是0，所以**第一列**nodes的高度计算就出问题了。
![image](https://user-images.githubusercontent.com/13739947/49501208-4bd3c300-f8ad-11e8-9071-bf31da00b7b5.png)

出问题的原因，看了下源码，发现node的dy的计算方式为:
![image](https://user-images.githubusercontent.com/13739947/49501318-876e8d00-f8ad-11e8-9a50-e3539deb6f8f.png)
是根据max(inLinks总值, outLinks总值)得出的，在node的流入为0同时流出又有流失的情况下，dy的值就会小于node应有的dy。

所以做了如下改动:
![image](https://user-images.githubusercontent.com/13739947/49501438-cd2b5580-f8ad-11e8-949e-63a8c46dd3ec.png)
我觉得这样做，不仅不影响sankey原来的效果，还能适应我说的这种流失情况。
