### PR TITLE
Modified the node's coordinates generate method

### DIFF
--- a/src/chart/graph/circularLayoutHelper.js
+++ b/src/chart/graph/circularLayoutHelper.js
@@ -45,8 +45,8 @@ export function circularLayout(seriesModel) {
         angle += unitAngle * (sum ? value : 1) / 2;
 
         node.setLayout([
-            r * Math.cos(angle) + cx,
-            r * Math.sin(angle) + cy
+            r * Math.sin(angle) + cx,
+            r * Math.cos(angle) + cy
         ]);
 
         angle += unitAngle * (sum ? value : 1) / 2;


### PR DESCRIPTION
When you use the circular layout,it can keep a parallel  bottom edge to make graph symmetry.(especially when you draw a triangle and other singular nodes graph)