### PR TITLE
feat(legend): add legend.color

### DIFF
--- a/src/component/legend/LegendView.js
+++ b/src/component/legend/LegendView.js
@@ -157,16 +157,7 @@ export default echarts.extendComponentView({
             // Series legend
             if (seriesModel) {
                 var data = seriesModel.getData();
-                // check if color is string, cause the default color is array
-                var color = typeof itemModel.get('color') === 'string' 
-                  ? itemModel.get('color') 
-                  : data.getVisual('color');
-
-                // If color is a callback function
-                if (typeof color === 'function') {
-                    // Use the first data
-                    color = color(seriesModel.getDataParams(0));
-                }
+                var color = getLegendColor(data, dataIndex, seriesModel, itemModel, ecModel)
 
                 // Using rect symbol defaultly
                 var legendSymbolType = data.getVisual('legendSymbol') || 'roundRect';
@@ -378,6 +369,28 @@ export default echarts.extendComponentView({
     }
 
 });
+
+function getLegendColor(data, dataIndex, seriesModel, itemModel, ecModel) {
+  var itemColor = itemModel.get('color');
+  var color = data.getVisual('color');
+  var useDataColor = true
+
+  if (itemColor !== ecModel.get('color')) {
+      color = itemColor;
+      useDataColor = false
+  }
+
+  if (zrUtil.isArray(color)) {
+    color = color[useDataColor ? 0 : dataIndex]
+  }
+  
+  // If color is a callback function
+  if (typeof color === 'function') {
+      // Use the first data
+      color = color(seriesModel.getDataParams(0));
+  }
+  return color
+}
 
 function dispatchSelectAction(name, api) {
     api.dispatchAction({

--- a/src/component/legend/LegendView.js
+++ b/src/component/legend/LegendView.js
@@ -157,7 +157,7 @@ export default echarts.extendComponentView({
             // Series legend
             if (seriesModel) {
                 var data = seriesModel.getData();
-                var color = data.getVisual('color');
+                var color = itemModel.get('color') || data.getVisual('color');
 
                 // If color is a callback function
                 if (typeof color === 'function') {

--- a/src/component/legend/LegendView.js
+++ b/src/component/legend/LegendView.js
@@ -157,7 +157,10 @@ export default echarts.extendComponentView({
             // Series legend
             if (seriesModel) {
                 var data = seriesModel.getData();
-                var color = itemModel.get('color') || data.getVisual('color');
+                // check if color is string, cause the default color is array
+                var color = typeof itemModel.get('color') === 'string' 
+                  ? itemModel.get('color') 
+                  : data.getVisual('color');
 
                 // If color is a callback function
                 if (typeof color === 'function') {


### PR DESCRIPTION
Fix #9916. When `itemStyle.color` is a function, the legend's color may be uncontrollable.