### PR TITLE
fix bug in function setAxisModel if valueWindow[0] === null

### DIFF
--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -492,7 +492,7 @@ function setAxisModel(axisProxy, isRestore) {
     var percentWindow = axisProxy._percentWindow;
     var valueWindow = axisProxy._valueWindow;
 
-    if (!percentWindow) {
+    if (!percentWindow || valueWindow[0] === null || valueWindow[1] === null) {
         return;
     }
 


### PR DESCRIPTION
In some cases using zoom, I get fatal error

![alt text](https://coolswood.github.io/img/img/image.png)