### PR TITLE
fix bug #11049

### DIFF
--- a/src/component/toolbox/feature/DataZoom.js
+++ b/src/component/toolbox/feature/DataZoom.js
@@ -269,7 +269,7 @@ echarts.registerPreprocessor(function (option) {
         }
 
         if (toolboxOpt && toolboxOpt.feature) {
-            var dataZoomOpt = toolboxOpt.feature.dataZoom;
+            var dataZoomOpt = toolboxOpt.feature.dataZoom || {};
             // FIXME: If add dataZoom when setOption in merge mode,
             // no axis info to be added. See `test/dataZoom-extreme.html`
             addForAxis('xAxis', dataZoomOpt);


### PR DESCRIPTION
The `toolbox` has been updated when using the dataZoom in dynamic added toolbox, but the `dataZoom` hasn't been updated.
![图片](https://user-images.githubusercontent.com/22974511/64550103-b8ac4a00-d364-11e9-994b-9ffb6b2e04c0.png)
