### PR TITLE
Update tooltip-setOption.html

### DIFF
--- a/test/tooltip-setOption.html
+++ b/test/tooltip-setOption.html
@@ -154,7 +154,9 @@ under the License.
                 }
 
                 var chart = echarts.init(document.getElementById('setOption2'));
+                myChart.setDataSource((genOption()).tooltip.series[0].data)) || chart.setDataSource(genOption()); 
                 chart.setOption(genOption());
+                
 
                 setTimeout(function () {
                     chart.dispatchAction({
@@ -169,7 +171,7 @@ under the License.
                         chart.dispose();
 
                         chart = echarts.init(document.getElementById('setOption2'));
-
+                             myChart.setDataSource((genOption()).tooltip.series[0].data)) || chart.setDataSource(genOption()); 
                         chart.setOption(genOption());
                     }, 2000)
                 }, 100);
@@ -213,6 +215,7 @@ under the License.
 
                 myChart.on('click', function (params) {
                     myChart.clear();
+                  
                     myChart.setOption({
                         "tooltip": {
                             "show": true


### PR DESCRIPTION
Attempting to fix issue: [11377](https://github.com/apache/incubator-echarts/issues/11377) but cannot find where it's pointing to in this repo.  This resolved the issue on my forked repo: 
```
var option = {
  series: [
    {
      type: 'treemap',
      data: [
        {
          name: 'A点我，是0？',
          value: 10
        },
        {
          name: 'B点我，dataIndex==1？',
          value: 20
        }
      ]
    }
  ],
  grid: {left:0,right:0,top:0,bottom:0}
};

var myChart = echarts.init(root);
myChart.setOption(option);
myChart.setDataSource(grid); 
myChart.on('click', params => {
  alert('dataIndex==' + params.dataIndex + '?');
})
```