### PR TITLE
fix bug #11528 Modify default value of tooltip and label

### DIFF
--- a/src/chart/helper/labelHelper.js
+++ b/src/chart/helper/labelHelper.js
@@ -25,7 +25,8 @@ import {retrieveRawValue} from '../../data/helper/dataProvider';
  * @return {string} label string. Not null/undefined
  */
 export function getDefaultLabel(data, dataIndex) {
-    var labelDims = data.mapDimension('defaultedLabel', true);
+    var dataDimsLen = data.dimensions.length;
+    var labelDims = data.mapDimension(dataDimsLen > 2 ? data.dimensions[dataDimsLen - 1] : 'defaultedLabel', true);
     var len = labelDims.length;
 
     // Simple optimization (in lots of cases, label dims length is 1)

--- a/src/model/Series.js
+++ b/src/model/Series.js
@@ -395,7 +395,8 @@ var SeriesModel = ComponentModel.extend({
         }
 
         var data = this.getData();
-        var tooltipDims = data.mapDimension('defaultedTooltip', true);
+        var dataDimsLen = data.dimensions.length;
+        var tooltipDims = data.mapDimension(dataDimsLen > 2 ? data.dimensions[dataDimsLen - 1] : 'defaultedTooltip', true);
         var tooltipDimLen = tooltipDims.length;
         var value = this.getRawValue(dataIndex);
         var isValueArr = zrUtil.isArray(value);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Modify default value of tooltip and label when using default configuration.

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
fixed issues #11528 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
In scatter chart, the label and tooltip use the value of 'y' when using default configuration.

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
Select the last value of data dimension as the label and tooltip by default

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
