### PR TITLE
fix(dataZoom): avoid freezing when range 'start' equals 'end' #11175

### DIFF
--- a/src/component/dataZoom/InsideZoomView.js
+++ b/src/component/dataZoom/InsideZoomView.js
@@ -114,11 +114,15 @@ var roamHandlers = {
         var directionInfo = getDirectionInfo[coordSysName](
             null, [e.originX, e.originY], axisModel, controller, coordInfo
         );
+
+        // diff=0 will freezing dataZoom
+        var rangeDiff = (range[1] - range[0]) || 0.1;
+
         var percentPoint = (
             directionInfo.signal > 0
                 ? (directionInfo.pixelStart + directionInfo.pixelLength - directionInfo.pixel)
                 : (directionInfo.pixel - directionInfo.pixelStart)
-            ) / directionInfo.pixelLength * (range[1] - range[0]) + range[0];
+            ) / directionInfo.pixelLength * (rangeDiff) + range[0];
 
         var scale = Math.max(1 / e.scale, 0);
         range[0] = (range[0] - percentPoint) * scale + percentPoint;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new featur
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->
#11175


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

`insideZoom` will be freezed when dataZoom.start=dataZoom.end.


<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

prevent `range[1] - range[0]` from zero value.


## Usage

### Are there any API changes?

- [ ] The API has been changed.
