### PR TITLE
fix #9265 axis name overlapped with axis labels for `grid.containLabel: true`

### DIFF
--- a/src/component/axis/AxisBuilder.js
+++ b/src/component/axis/AxisBuilder.js
@@ -25,7 +25,7 @@ import {isRadianAroundZero, remRadian} from '../../util/number';
 import {createSymbol} from '../../util/symbol';
 import * as matrixUtil from 'zrender/src/core/matrix';
 import {applyTransform as v2ApplyTransform} from 'zrender/src/core/vector';
-import {shouldShowAllLabels} from '../../coord/axisHelper';
+import {shouldShowAllLabels, estimateLabelUnionRect} from '../../coord/axisHelper';
 
 
 var PI = Math.PI;
@@ -269,7 +269,22 @@ var builders = {
         var nameLocation = axisModel.get('nameLocation');
         var nameDirection = opt.nameDirection;
         var textStyleModel = axisModel.getModel('nameTextStyle');
-        var gap = axisModel.get('nameGap') || 0;
+        // label + gap
+        var distanceToAxis = calcDistanceToAxis();
+        function calcDistanceToAxis() {
+          var axis = axisModel.axis;
+          if (axis.grid.model.get('containLabel') && !axis.model.get('axisLabel.inside')) {
+            var labelUnionRect = estimateLabelUnionRect(axis);
+            if (!labelUnionRect) {
+              return 0;
+            }
+            var dim = axis.isHorizontal() ? 'height' : 'width';
+            var margin = axisModel.get('axisLabel.margin');
+            return labelUnionRect[dim] + margin;
+          }
+          return 0;
+        }
+        var gap = (axisModel.get('nameGap') || 0) + distanceToAxis;
 
         var extent = this.axisModel.axis.getExtent();
         var gapSignal = extent[0] > extent[1] ? -1 : 1;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes #9265 .  Axis.nameGap will be now be calculated upon `grid.containLabel: true` and axis labels.

### Fixed issues

- #9265 xAxis.nameGap and yAxis.nameGap should be set automatically given grid.containLabel

## Details

### Before: What was the problem?

For charts with grid.containLabel set to `true`, axis name could be overlapped with axis labels, if `yAxis.nameGap` is not manually tweaked.

Here is how echarts behaves by default (quoting: https://github.com/apache/incubator-echarts/issues/9265#issuecomment-433346995):

![image](https://user-images.githubusercontent.com/2012170/75886406-20020d00-5e63-11ea-8daa-3b16ec3903f2.png)

### After: How is it fixed in this PR?

now axis' name will always placed outside `grid + axis label` rect. `nameGap` only adds some additional gap.

![image](https://user-images.githubusercontent.com/25373337/47557905-306eb300-d912-11e8-9d72-419bba86e6b1.png)

## Usage

### Are there any API changes?

- [ ] The API has been changed.

### Related test cases or examples to use the new APIs

NA.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
