### PR TITLE
Handle dataExtend with function

### DIFF
--- a/src/component/dataZoom/AxisProxy.js
+++ b/src/component/dataZoom/AxisProxy.js
@@ -458,16 +458,32 @@ function fixExtentByAxis(axisProxy, dataExtent) {
     var isCategoryAxis = axisModel.get('type') === 'category';
     var axisDataLen = isCategoryAxis && axisModel.getCategories().length;
 
-    if (min != null && min !== 'dataMin' && typeof min !== 'function') {
-        dataExtent[0] = min;
+    if (min != null && min !== 'dataMin') {
+        if (typeof max === 'function') {
+            dataExtent[0] = min({
+                min: dataExtent[0],
+                max: dataExtent[1]
+            });
+        }
+        else {
+            dataExtent[0] = min;
+        }
     }
     else if (isCategoryAxis) {
         dataExtent[0] = axisDataLen > 0 ? 0 : NaN;
     }
 
     var max = axisModel.getMax(true);
-    if (max != null && max !== 'dataMax' && typeof max !== 'function') {
-        dataExtent[1] = max;
+    if (max != null && max !== 'dataMax') {
+        if (typeof max === 'function') {
+            dataExtent[1] = max({
+                min: dataExtent[0],
+                max: dataExtent[1]
+            });
+        }
+        else {
+            dataExtent[1] = max;
+        }
     }
     else if (isCategoryAxis) {
         dataExtent[1] = axisDataLen > 0 ? axisDataLen - 1 : NaN;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add ability to use **min** and **max** functions in **AxisProxy** component


### Fixed issues

There is problem with zoom when **min** and **max** properties are functions. So it's difficult to hand out with border cases.

### After: How is it fixed in this PR?

```js
xAxis: {
        max: val => val.max + val.max * 0.05
       ...
},
yAxis: {
        max: val => val.max + val.max * 0.05
       ...
},
```

will not affect on zoom options, so border points will be unavailable:
no zoom:
<img width="440" alt="Снимок экрана 2020-03-26 в 12 48 04" src="https://user-images.githubusercontent.com/22371328/77633134-10f11500-6f60-11ea-9e0c-d7b7a9657d58.png">

zoom:
<img width="555" alt="Снимок экрана 2020-03-26 в 12 48 51" src="https://user-images.githubusercontent.com/22371328/77633191-2b2af300-6f60-11ea-8cfc-6de8de741f1a.png">

Green dot is unavailable

So, right now I just find max value from data and pass it as option. So it works only with number:
<img width="553" alt="Снимок экрана 2020-03-26 в 12 51 15" src="https://user-images.githubusercontent.com/22371328/77633421-7fce6e00-6f60-11ea-9da9-d450151dfb0b.png">


### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.


### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
