### PR TITLE
feat(markLine): symbolRotate for markLine accepts an array as the parameter to specify symbol rotation at the two endpoints of the mark line.

### DIFF
--- a/src/component/marker/MarkLineView.js
+++ b/src/component/marker/MarkLineView.js
@@ -269,11 +269,15 @@ export default MarkerView.extend({
 
         var symbolType = mlModel.get('symbol');
         var symbolSize = mlModel.get('symbolSize');
+        var symbolRotate = mlModel.get('symbolRotate');
         if (!zrUtil.isArray(symbolType)) {
             symbolType = [symbolType, symbolType];
         }
         if (typeof symbolSize === 'number') {
             symbolSize = [symbolSize, symbolSize];
+        }
+        if (!zrUtil.isArray(symbolRotate)) {
+            symbolRotate = [symbolRotate, symbolRotate];
         }
 
         // Update visual and layout of from symbol and to symbol
@@ -320,7 +324,7 @@ export default MarkerView.extend({
                 data, idx, isFrom, seriesModel, api
             );
             data.setItemVisual(idx, {
-                symbolRotate: itemModel.get('symbolRotate'),
+                symbolRotate: itemModel.get('symbolRotate', true) || symbolRotate[isFrom ? 0 : 1],
                 symbolSize: itemModel.get('symbolSize') || symbolSize[isFrom ? 0 : 1],
                 symbol: itemModel.get('symbol', true) || symbolType[isFrom ? 0 : 1],
                 color: itemModel.get('itemStyle.color') || seriesData.getVisual('color')

--- a/test/markLine-symbolRotate.html
+++ b/test/markLine-symbolRotate.html
@@ -43,132 +43,164 @@ under the License.
 
                 var chart = echarts.init(document.getElementById('main'));
 
-                $.getJSON('./data/aqi/aqi-beijing.json', function(data) {
-                    var option = {
-                        title: {
-                            text: 'Beijing AQI',
-                            subtext: 'Fix #12388'
-                        },
-                        tooltip: {
-                            trigger: 'axis'
-                        },
-                        xAxis: {
-                            data: data.map(function (item) {
-                                return item[0];
-                            })
-                        },
-                        yAxis: {
-                            splitLine: {
-                                show: false
-                            }
-                        },
-                        toolbox: {
-                            left: 'center',
-                            feature: {
-                                dataZoom: {
-                                    yAxisIndex: 'none'
-                                },
-                                restore: {},
-                                saveAsImage: {}
-                            }
-                        },
-                        dataZoom: [{
-                            startValue: '2014-06-01'
-                        }, {
-                            type: 'inside'
-                        }],
-                        visualMap: {
-                            top: 10,
-                            right: 10,
-                            pieces: [{
-                                gt: 0,
-                                lte: 50,
-                                color: '#096'
-                            }, {
-                                gt: 50,
-                                lte: 100,
-                                color: '#ffde33'
-                            }, {
-                                gt: 100,
-                                lte: 150,
-                                color: '#ff9933'
-                            }, {
-                                gt: 150,
-                                lte: 200,
-                                color: '#cc0033'
-                            }, {
-                                gt: 200,
-                                lte: 300,
-                                color: '#660099'
-                            }, {
-                                gt: 300,
-                                color: '#7e0023'
-                            }],
-                            outOfRange: {
-                                color: '#999'
-                            }
-                        },
-                        series: [{
-                            name: 'Beijing AQI',
-                            type: 'line',
-                            data: data.map(function (item) {
-                                return item[1];
-                            }),
-                            markLine: {
-                                silent: true,
-                                // symbol: 'triangle',
-                                data: [
-                                {
-                                    yAxis: 50,
-                                    // symbolRotate: 0,
-                                    // symbolRotate: null,
-                                    symbol: 'triangle',
-                                    symbolSize: 20
-                                },{
-                                    yAxis: 100,
-                                    symbolRotate: 80,
-                                    symbol: 'rect',
-                                    symbolSize: 20
-                                }, {
-                                    yAxis: 150,
-                                    symbol: 'roundRect',
-                                    symbolRotate: 40
-                                }, {
-                                    yAxis: 200,
-                                    symbol: 'diamond',
-                                    symbolRotate: 70
-                                }, {
-                                    yAxis: 250,
-                                    symbol: 'pin',
-                                    symbolRotate: 45
-                                }, {
-                                    yAxis: 300,
-                                    symbol: 'circle',
-                                    symbolRotate: 90
-                                },
-                                [{
-                                    symbol: 'rect',
-                                    x: '90%',
-                                    yAxis: 'average'
-                                }, {
-                                    symbol: 'triangle',
-                                    symbolRotate: 180,
-                                    label: {
-                                        position: 'start',
-                                        formatter: 'Average',
-                                        distance: 10
-                                    },
-                                    type: 'average',
-                                    lineStyle: {
-                                        color: '#14c4ba'
-                                    }
-                                }]]
-                            }
-                        }]
-                    };
+                function generateData() {
+                    var data = [];
+                    var start = new Date(2020, 1, 1);
+                    for (var i = 1; i < 50; i++) {
+                        start.setDate(start.getDate() + 1);
+                        var num = ~~(Math.random() * 200);
+                        if (num < 0) num = -num;
+                        data.push([echarts.format.formatTime('yyyy-MM-dd', start), num])
+                    }
+                    return data
+                }
 
-                    chart.setOption(option);
-                })
+                var data = generateData();
+
+                var option = {
+                    title: {
+                        text: 'Beijing AQI',
+                        subtext: 'Fix #12388'
+                    },
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    xAxis: {
+                        data: data.map(function(item) {
+                            return item[0];
+                        })
+                    },
+                    yAxis: {
+                        splitLine: {
+                            show: false
+                        }
+                    },
+                    toolbox: {
+                        left: 'center',
+                        feature: {
+                            dataZoom: {
+                                yAxisIndex: 'none'
+                            },
+                            restore: {},
+                            saveAsImage: {}
+                        }
+                    },
+                    dataZoom: [{
+                        startValue: '2020-01-01'
+                    }, {
+                        type: 'inside'
+                    }],
+                    visualMap: {
+                        top: 10,
+                        right: 10,
+                        pieces: [{
+                            gt: 0,
+                            lte: 50,
+                            color: '#096'
+                        }, {
+                            gt: 50,
+                            lte: 100,
+                            color: '#ffde33'
+                        }, {
+                            gt: 100,
+                            lte: 150,
+                            color: '#ff9933'
+                        }, {
+                            gt: 150,
+                            lte: 200,
+                            color: '#cc0033'
+                        }, {
+                            gt: 200,
+                            lte: 300,
+                            color: '#660099'
+                        }, {
+                            gt: 300,
+                            color: '#7e0023'
+                        }],
+                        outOfRange: {
+                            color: '#999'
+                        }
+                    },
+                    series: [{
+                        name: 'Beijing AQI',
+                        type: 'line',
+                        data: data.map(function(item) {
+                            return item[1];
+                        }),
+                        markArea: {
+                            silent: true,
+                            data: [
+                                [{
+                                    name: '60到80',
+                                    yAxis: 60,
+                                    xAxis: '2020-02-10'
+                                },
+                                {
+                                    yAxis: 80,
+                                    xAxis: '2020-03-01'
+                                }]
+                            ]
+                        },
+                        markLine: {
+                            silent: true,
+                            // symbol: 'triangle',
+                            symbol: ['pin', 'triangle'],
+                            symbolRotate: [60, -45],
+                            //symbolRotate: 45,
+                            symbolSize: 20,
+                            data: [
+                                [{
+                                    name: 'Y 轴值为 100 的水平线',
+                                    yAxis: 100,
+                                    xAxis: '2020-02-10',
+                                    symbol: 'roundRect',
+                                    symbolRotate: 130
+                                }, {
+                                    yAxis: 100,
+                                    xAxis: '2020-03-10',
+                                    symbolRotate: 'default' // 设置一个非数值的旋转角度可使symbol采用默认旋转角度
+                                }],
+                                [{
+                                    name: '最小值到最大值',
+                                    type: 'min',
+                                    symbol: 'triangle'
+                                }, {
+                                    type: 'max',
+                                    symbol: 'rect',
+                                    symbolSize: [30, 60]
+                                }],
+                                [{
+                                    name: '两个坐标之间的标域',
+                                    coord: [10, 20]
+                                }, {
+                                    coord: [20, 30]
+                                }],
+                                [{
+                                    name: '两个屏幕坐标之间的标线',
+                                    x: 100,
+                                    y: 100
+                                }, {
+                                    x: 500,
+                                    y: 200
+                                }],
+                                [{
+                                    name: '60到80',
+                                    yAxis: 60,
+                                    xAxis: '2020-03-01',
+                                    symbol: 'circle'
+                                }, {
+                                    yAxis: 120,
+                                    xAxis: '2020-03-01',
+                                    symbol: 'rect',
+                                    symbolRotate: 30
+                                }],
+                            ]
+                        }
+                    }]
+                };
+
+
+                chart.setOption(option);
 
                 window.onresize = chart.resize;
             });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

`symbolRotate` for `markLine` accepts an array as the parameter to specify symbol rotation at the two ends of the mark line. I think it may be very helpful in some cases.


### Related issues

- https://github.com/apache/incubator-echarts/pull/12392#issuecomment-611116024


## Details

### Before: What was the problem?

We can not specify different rotations for symbols at the two endpoints of the mark line.

### After: How is it fixed in this PR?

By specifying an array like `[fromSymbolRotation, toSymbolRotation]` for `markLine.symbolRotate`, we can set different rotations for symbols at the two endpoints of the mark line

![image](https://user-images.githubusercontent.com/26999792/83522616-83a7df00-a513-11ea-9573-f2848460ac95.png)

## Usage

### Are there any API changes?

- [x] The API has been changed.

Added an option `markLine.symbolRotate`, which accepts a number or an array having two  numeric elements.

### Related test cases or examples to use the new APIs

Please reder to `test/markLine-symbolRotate.html`.

