### PR TITLE
Fix legend color with customized itemStyle

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -35,14 +35,10 @@ import {
     ZRRectLike,
     ECElement,
     CommonTooltipOption,
-    ColorString,
-    SeriesOption
 } from '../../util/types';
 import Model from '../../model/Model';
 import Displayable, { DisplayableState } from 'zrender/src/graphic/Displayable';
 import { PathStyleProps } from 'zrender/src/graphic/Path';
-import { parse, stringify } from 'zrender/src/tool/color';
-import SeriesModel from '../../model/Series';
 
 const curry = zrUtil.curry;
 const each = zrUtil.each;
@@ -210,7 +206,7 @@ class LegendView extends ComponentView {
                     name, dataIndex, itemModel, legendModel,
                     legendSymbolType, symbolType,
                     itemAlign, dataParams.color, borderColor,
-                    selectMode, seriesModel
+                    selectMode
                 );
 
                 itemGroup.on('click', curry(dispatchSelectAction, name, null, api, excludeSeriesId))
@@ -246,7 +242,7 @@ class LegendView extends ComponentView {
                             name, dataIndex, itemModel, legendModel,
                             legendSymbolType, null,
                             itemAlign, dataParams.color, borderColor,
-                            selectMode, seriesModel
+                            selectMode
                         );
 
                         // FIXME: consider different series has items with the same name.
@@ -328,9 +324,7 @@ class LegendView extends ComponentView {
         color: ZRColor,
         borderColor: ZRColor,
         selectMode: LegendOption['selectedMode'],
-        seriesModel: SeriesModel<SeriesOption<any, unknown>>,
     ) {
-        // legendModel.ecModel.option.series[0].itemStyle.color
         const itemWidth = legendModel.get('itemWidth');
         const itemHeight = legendModel.get('itemHeight');
         const inactiveColor = legendModel.get('inactiveColor');


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?


Fix the bug that when `itemStyle` with functional `color` is used, the color of legend will not be consist with the customized color.


### Fixed issues

#12977 


## Details

### Before: What was the problem?

When user customized the color of bar, the color of legend is not consist with it.

![image](https://user-images.githubusercontent.com/6800839/89612709-0dc54880-d8b3-11ea-8f3c-320bf1cf5aac.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The color of legend is consist with bar color customized by user

![image](https://user-images.githubusercontent.com/6800839/89612740-25043600-d8b3-11ea-9dd1-81f7e15b85e7.png)

(The first color is white, so it can not be seen very clearly)

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

No

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information

I use `const dataParams = seriesModel.getDataParams(dataIndex);` in my PR, and I found that `dataParams.color` is just the final result of color, no matter it is a function or a value, or user simply hadn't used `color` in `itemStyle`.
As a result, it is not necessary anymore to retrieve or do some transforming calculation from LegendView, just use this value.

