### PR TITLE
feat(TooltipView): provide a way to set the customized tooltip renderer

### DIFF
--- a/src/component/tooltip/TooltipView.js
+++ b/src/component/tooltip/TooltipView.js
@@ -54,8 +54,15 @@ export default echarts.extendComponentView({
         var renderMode = tooltipModel.get('renderMode');
         this._renderMode = getTooltipRenderMode(renderMode);
 
+        var renderer = tooltipModel.get('renderer');
         var tooltipContent;
-        if (this._renderMode === 'html') {
+        if (renderer) {
+            tooltipContent = new renderer({
+                appendToBody: tooltipModel.get('appendToBody', true)
+            });
+            this._newLine = renderer.newLine;
+        }
+        else if (this._renderMode === 'html') {
             tooltipContent = new TooltipContent(api.getDom(), api, {
                 appendToBody: tooltipModel.get('appendToBody', true)
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Provide a way to set the customized tooltip renderer

### Fixed issues

N/A


## Details

### Before: What was the problem?

The tooltip renderer is hardcoded in repo and no way to override. For people using web worker ( or WX小程序 maybe? ) they have to use `TooltipRichContent` which has limitations compared to the default html renderer.



### After: How is it fixed in this PR?

The PR provides a new option `renderer` for `tooltip`, and use it if set.



## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

```
tooltip: {
  renderer: Constructor
}
```

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
