### PR TITLE
fix(lines): discard extraneous data-points during lines animation

### DIFF
--- a/src/chart/line/lineAnimationDiff.ts
+++ b/src/chart/line/lineAnimationDiff.ts
@@ -132,30 +132,7 @@ export default function lineAnimationDiff(
                 rawIndices.push(newData.getRawIndex(newIdx));
                 break;
             case '-':
-                const oldIdx = diffItem.idx;
-                const rawIndex = oldData.getRawIndex(oldIdx);
-                const oldDataDimsForPoint = oldDataNewCoordInfo.dataDimsForPoint;
-                oldIdx2 = oldIdx * 2;
-                // Data is replaced. In the case of dynamic data queue
-                // FIXME FIXME FIXME
-                if (rawIndex !== oldIdx) {
-                    const newPt = newCoordSys.dataToPoint([
-                        oldData.get(oldDataDimsForPoint[0], oldIdx),
-                        oldData.get(oldDataDimsForPoint[1], oldIdx)
-                    ]);
-                    const newStackedOnPt = getStackedOnPoint(oldDataNewCoordInfo, newCoordSys, oldData, oldIdx);
-
-                    currPoints.push(oldPoints[oldIdx2], oldPoints[oldIdx2 + 1]);
-                    nextPoints.push(newPt[0], newPt[1]);
-
-                    currStackedPoints.push(oldStackedOnPoints[oldIdx2], oldStackedOnPoints[oldIdx2 + 1]);
-                    nextStackedPoints.push(newStackedOnPt[0], newStackedOnPt[1]);
-
-                    rawIndices.push(rawIndex);
-                }
-                else {
-                    pointAdded = false;
-                }
+                pointAdded = false;
         }
 
         // Original indices

--- a/test/lines-extraneous.html
+++ b/test/lines-extraneous.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/esl.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+        .test-title {
+            background: #146402;
+            color: #fff;
+        }
+    </style>
+
+
+    <div id="main0"></div>
+
+    <script>
+
+        /**
+         * Related issues:
+         * - https://github.com/apache/incubator-echarts/issues/10228
+         * - https://github.com/apache/incubator-echarts/issues/11633
+         * - https://github.com/apache/incubator-echarts/issues/12164
+         * - https://github.com/apache/incubator-echarts/issues/12433
+         */
+
+        var chart;
+        var myChart;
+
+        const datasetSource1 = [['2019-04-14', 17], ['2019-04-16', 13], ['2019-04-17', 5]];
+        const datasetSource2 = [['2019-04-13', 0], ['2019-04-18', 23]];
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            const option1 = {
+                dataset: [
+                    {
+                        source: datasetSource1,
+                        sourceHeader: false
+                    }
+                ],
+                dataZoom: [
+                    { show: true }
+                ],
+                xAxis: {
+                    type: 'time',
+                    min: '2019-04-15',
+                    max: '2019-04-18',
+                },
+                yAxis: [
+                    {
+                        scale: true,
+                        type: 'value'
+                    }
+                ],
+                series: [
+                    {
+                        type: 'line',
+                        showSymbol: false,
+                        animation: false,
+                    }
+                ]
+            };
+
+            const option2 = {
+                dataset: [
+                    {
+                        source: datasetSource2,
+                        sourceHeader: false
+                    }
+                ],
+                dataZoom: [
+                    {
+                        show: true,
+                        start: 0,
+                        end: 100,
+                    }
+                ],
+                xAxis: {
+                    type: 'time',
+                    min: '2019-04-12',
+                    max: '2019-04-19',
+                },
+                yAxis: [
+                    {
+                        scale: true,
+                        type: 'value'
+                    }
+                ],
+                series: [
+                    {
+                        type: 'line',
+                        showSymbol: false,
+                    }
+                ]
+            };
+
+            chart = myChart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Lines series should not show extraneous points when updating options',
+                    'Only **one**  segment (e.g.: **two** data points) should be displayed after pressing the button'
+                ],
+                option: option1,
+                button: {
+                    text: 'Click to trigger extraneous lines bug',
+                    onClick: () => {
+                        myChart.setOption(option2, true);
+                    }
+                }
+            });
+        });
+
+    </script>
+
+</body>
+
+</html>

--- a/test/runTest/actions/lines-extraneous.json
+++ b/test/runTest/actions/lines-extraneous.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"mousedown","time":596,"x":28,"y":93},{"type":"mouseup","time":698,"x":28,"y":93},{"time":699,"delay":2000,"type":"screenshot-auto"}],"scrollY":0,"scrollX":0,"timestamp":1568042380534}]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Discards data-points that were erroneously added to the chart during the lines animation.

### Fixed issues

- #10228
- #11633
- #12164
- #12433

There are multiple issues currently open about this problem and they might all be related.

## Details

Add a test to easily reproduce the bug where points are erroneously added to the chart during the lines animation and make a *naive* attempt at fixing it.

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

This bug happens during line-animations and it makes the chart display some invalid data-points after the animation is complete. 

These erroneous data-points seem to be transient and they seem to go away after some interactions with the chart (e.g.: by manually changing the data-zoom).

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
This is a screenshot of the bug from the added test case (there are only **two** points in the series so there should only be **one** segment):

![erroneous_line](https://user-images.githubusercontent.com/433598/99429503-67083380-2908-11eb-9499-04c97fee9b05.png)

Reproduction link: https://jsfiddle.net/8kv71j0w/7/ (also see added test case in `test/lines-extraneous.html`).

### After: How is it fixed in this PR?

Due to some items in the *old* series having been filtered out (e.g.: by the data-zoom component), the `rawIndex` of the **removed** items is different than the `index`. Therefore, [this condition](https://github.com/apache/incubator-echarts/blob/694ea4328fb1e131449a0c24ba54fa8139ce41c3/src/chart/line/lineAnimationDiff.ts#L141) evaluates to `true` which results in [this particular code path](https://github.com/apache/incubator-echarts/blob/694ea4328fb1e131449a0c24ba54fa8139ce41c3/src/chart/line/lineAnimationDiff.ts#L141-L155) being executed. This in turn has the effect of keeping these **removed** points in the line during (and after) the animation.

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

The naive fix as part of this pull-request was to remove that code-block all together.

***Warning***: I don't have enough context to understand the full-implications of this change and it's very likely that this is **not a good fix** for this problem.

The main reason for opening this pull-request was to start a discussion and get some feedback from the developers about **what would a proper fix look like**.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

That being said, this proposed change does seem to produce the expected result in the attached test case:

![no_erroneous_line](https://user-images.githubusercontent.com/433598/99433194-80f84500-290d-11eb-8a01-bb8b37ef0380.png)

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

See test case in: `test/lines-extraneous.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information

See the linked issues for more details about other instances where this bug happens.