### PR TITLE
fix(Calendar): fix day label drifting. close #11508

### DIFF
--- a/src/component/calendar/CalendarView.ts
+++ b/src/component/calendar/CalendarView.ts
@@ -518,7 +518,7 @@ class CalendarView extends ComponentView {
         ).time;
 
         const cellSize = [coordSys.getCellWidth(), coordSys.getCellHeight()];
-        margin = numberUtil.parsePercent(margin, cellSize[1]);
+        margin = numberUtil.parsePercent(margin, Math.min(cellSize[1], cellSize[0]));
 
         if (pos === 'start') {
             start = coordSys.getNextNDay(

--- a/src/component/calendar/CalendarView.ts
+++ b/src/component/calendar/CalendarView.ts
@@ -518,7 +518,7 @@ class CalendarView extends ComponentView {
         ).time;
 
         const cellSize = [coordSys.getCellWidth(), coordSys.getCellHeight()];
-        margin = numberUtil.parsePercent(margin, cellSize[orient === 'horizontal' ? 0 : 1]);
+        margin = numberUtil.parsePercent(margin, cellSize[1]);
 
         if (pos === 'start') {
             start = coordSys.getNextNDay(


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fix day label drifting



### Fixed issues


- #11508: Day label is drifting on the left when calendar range is getting smaller



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
If orient is horizontal and range changes, the cell will automatically adjust its width.
But the weekly text margin always to be 50% width of cellSize.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![issue](https://user-images.githubusercontent.com/30228906/103290962-b1abbe00-4a25-11eb-9a64-e9d5feb10858.PNG)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
I tried to fix it by making daylabel margin always be the cell's height .
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![fixed](https://user-images.githubusercontent.com/30228906/103291125-0a7b5680-4a26-11eb-959b-a74472162145.PNG)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
