### PR TITLE
Fix: endLabel color support 'auto' 'inherit'

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -43,8 +43,7 @@ import type {
     ECElement,
     DisplayState,
     LabelOption,
-    ParsedValue,
-    ZRColor
+    ParsedValue
 } from '../../util/types';
 import type OrdinalScale from '../../scale/Ordinal';
 import type Axis2D from '../../coord/cartesian/Axis2D';
@@ -56,6 +55,7 @@ import {getDefaultLabel, getDefaultInterpolatedLabel} from '../helper/labelHelpe
 
 import { getECData } from '../../util/innerStore';
 import { createFloat32Array } from '../../util/vendor';
+import { convertToColorString } from '../../util/format';
 
 type PolarArea = ReturnType<Polar['getArea']>;
 type Cartesian2DArea = ReturnType<Cartesian2D['getArea']>;
@@ -649,7 +649,7 @@ class LineView extends ChartView {
 
             // NOTE: Must update _endLabel before setClipPath.
             if (!isCoordSysPolar) {
-                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, visualColor);
+                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, convertToColorString(visualColor));
             }
 
             lineGroup.setClipPath(
@@ -671,7 +671,7 @@ class LineView extends ChartView {
 
             // NOTE: Must update _endLabel before setClipPath.
             if (!isCoordSysPolar) {
-                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, visualColor);
+                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, convertToColorString(visualColor));
             }
 
             // Update clipPath
@@ -1041,7 +1041,7 @@ class LineView extends ChartView {
     _initOrUpdateEndLabel(
         seriesModel: LineSeriesModel,
         coordSys: Cartesian2D,
-        inheritColor: ZRColor
+        inheritColor: string
     ) {
         const endLabelModel = seriesModel.getModel('endLabel');
 
@@ -1065,7 +1065,7 @@ class LineView extends ChartView {
                     polyline,
                     getLabelStatesModels(seriesModel, 'endLabel'),
                     {
-                        inheritColor: inheritColor as string,
+                        inheritColor,
                         labelFetcher: seriesModel,
                         labelDataIndex: dataIndex,
                         defaultText(dataIndex, opt, interpolatedValue) {

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -43,7 +43,8 @@ import type {
     ECElement,
     DisplayState,
     LabelOption,
-    ParsedValue
+    ParsedValue,
+    ZRColor
 } from '../../util/types';
 import type OrdinalScale from '../../scale/Ordinal';
 import type Axis2D from '../../coord/cartesian/Axis2D';
@@ -609,6 +610,8 @@ class LineView extends ChartView {
             }
         }
         this._clipShapeForSymbol = clipShapeForSymbol;
+        const visualColor = getVisualGradient(data, coordSys)
+            || data.getVisual('style')[data.getVisual('drawType')];
         // Initialization animation or coordinate system changed
         if (
             !(polyline && prevCoordSys.type === coordSys.type && step === this._step)
@@ -646,7 +649,7 @@ class LineView extends ChartView {
 
             // NOTE: Must update _endLabel before setClipPath.
             if (!isCoordSysPolar) {
-                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D);
+                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, visualColor);
             }
 
             lineGroup.setClipPath(
@@ -668,7 +671,7 @@ class LineView extends ChartView {
 
             // NOTE: Must update _endLabel before setClipPath.
             if (!isCoordSysPolar) {
-                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D);
+                this._initOrUpdateEndLabel(seriesModel, coordSys as Cartesian2D, visualColor);
             }
 
             // Update clipPath
@@ -718,8 +721,6 @@ class LineView extends ChartView {
             }
         }
 
-        const visualColor = getVisualGradient(data, coordSys)
-            || data.getVisual('style')[data.getVisual('drawType')];
         const focus = seriesModel.get(['emphasis', 'focus']);
         const blurScope = seriesModel.get(['emphasis', 'blurScope']);
 
@@ -1039,7 +1040,8 @@ class LineView extends ChartView {
 
     _initOrUpdateEndLabel(
         seriesModel: LineSeriesModel,
-        coordSys: Cartesian2D
+        coordSys: Cartesian2D,
+        inheritColor: ZRColor
     ) {
         const endLabelModel = seriesModel.getModel('endLabel');
 
@@ -1063,6 +1065,7 @@ class LineView extends ChartView {
                     polyline,
                     getLabelStatesModels(seriesModel, 'endLabel'),
                     {
+                        inheritColor: inheritColor as string,
                         labelFetcher: seriesModel,
                         labelDataIndex: dataIndex,
                         defaultText(dataIndex, opt, interpolatedValue) {

--- a/test/line-endLabel.html
+++ b/test/line-endLabel.html
@@ -290,7 +290,8 @@ under the License.
                                             show: true,
                                             formatter: _endLabelFormatter,
                                             fontSize: 20,
-                                            distance: 10
+                                            distance: 10,
+                                            color: 'inherit'
                                         },
                                         emphasis: {
                                             endLabel: {
@@ -376,7 +377,8 @@ under the License.
                             fontSize: 14,
                             distance: 50,
                             offset: [0, 20],
-                            rotate: 5
+                            rotate: 5,
+                            color: 'auto'
                         },
                         emphasis: {
                             endLabel: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

Close #13685


## Details

### Before: What was the problem?
<img width="135" alt="Screen Shot 2021-01-10 at 16 25 47" src="https://user-images.githubusercontent.com/20318608/104117996-88adf600-5360-11eb-9c38-fbf640dbfd06.png">




### After: How is it fixed in this PR?

<img width="181" alt="Screen Shot 2021-01-10 at 16 25 33" src="https://user-images.githubusercontent.com/20318608/104117999-8f3c6d80-5360-11eb-8c2d-3f1e65f23d86.png">



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

test/line-endLabel.html


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
