### PR TITLE
fix: add back the default tooltip textStyle settings. 

### DIFF
--- a/src/component/tooltip/TooltipModel.ts
+++ b/src/component/tooltip/TooltipModel.ts
@@ -169,6 +169,8 @@ class TooltipModel extends ComponentModel<TooltipOption> {
             // otherwise it will always override those styles on option.axisPointer.
         },
         textStyle: {
+            color: '#666',
+            fontSize: 14
         }
     };
 }


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fix: add back the default tooltip textStyle settings. Without those settings, the tooltip text will follow the website settings if user specified `tooltip.formatter`, which is not expected.

