### PR TITLE
Fix(pie): labelLine is not hidden in some case

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -65,7 +65,7 @@ interface PieLabelOption extends Omit<SeriesLabelOption, 'rotate' | 'position'> 
     bleedMargin?: number
     distanceToLabelLine?: number
 
-    position?: SeriesLabelOption['position'] | 'outer' | 'inner' | 'center'
+    position?: SeriesLabelOption['position'] | 'outer' | 'inner' | 'center' | 'outside'
 }
 
 interface PieLabelLineOption extends LabelLineOption {

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -185,7 +185,8 @@ class PiePiece extends graphic.Sector {
             z2: 10
         });
 
-        if (seriesModel.get('label').position !== 'outside') {
+        const labelPosition = seriesModel.get(['label', 'position']);
+        if (labelPosition !== 'outside' && labelPosition !== 'outer') {
             sector.getTextGuideLine()?.hide();
             return;
         }

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -136,7 +136,7 @@ class PiePiece extends graphic.Sector {
         const labelLine = sector.getTextGuideLine();
         const labelText = sector.getTextContent();
 
-        extend(labelLine.ensureState('select'), {
+        labelLine && extend(labelLine.ensureState('select'), {
             x: dx,
             y: dy
         });
@@ -185,6 +185,10 @@ class PiePiece extends graphic.Sector {
             z2: 10
         });
 
+        if (seriesModel.get('label').position !== 'outside') {
+            sector.getTextGuideLine()?.hide();
+            return;
+        }
         // Default use item visual color
         setLabelLineStyle(this, getLabelLineStatesModels(itemModel), {
             stroke: visualColor,

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -48,6 +48,7 @@ under the License.
         <div id="main5"></div>
         <div id="main6"></div>
         <div id="main7"></div>
+        <div id="main8"></div>
 
 
         <script>
@@ -696,6 +697,68 @@ under the License.
                 });
             });
 
+        </script>
+
+        <script>
+            require([
+                'echarts'/*, 'map/js/china' */
+            ], function (echarts) {
+                const option = {
+                    series: [
+                        {
+                            name: '访问来源',
+                            type: 'pie',
+                            radius: '50%',
+                            center: ['25%', '50%'],
+                            data: [
+                                { value: 1, name: '搜索引擎' },
+                            ],
+                            emphasis: {
+                                itemStyle: {
+                                    shadowBlur: 10,
+                                    shadowOffsetX: 0,
+                                    shadowColor: 'rgba(0, 0, 0, 0.5)'
+                                }
+                            },
+                            label: {
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: '访问来源1',
+                            type: 'pie',
+                            radius: '50%',
+                            center: ['75%', '50%'],
+                            data: [
+                                { value: 1, name: '搜索引擎' },
+                            ],
+                            emphasis: {
+                                itemStyle: {
+                                    shadowBlur: 10,
+                                    shadowOffsetX: 0,
+                                    shadowColor: 'rgba(0, 0, 0, 0.5)'
+                                }
+                            },
+                            label: {
+                                position: 'outside'
+                            }
+                        },
+                    ]
+                };
+
+                setTimeout(() => {
+                    option.series[0].label.position = 'outside';
+                    option.series[1].label.position = 'inside';
+                    chart.setOption(option);
+                }, 2000);
+            
+                var chart = testHelper.create(echarts, 'main8', {
+                    title: 'labelLine should be hidden when position is not \'outside\'',
+                    height: 300,
+                    option: option
+                });
+
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Add `showLabelLine` param for `setLabelLineStyle` to control `labelLine` should be drawn or removed.



### Fixed issues

Close #13871


## Details

### Before: What was the problem?

After second  `setOption`. `labelLine` didn't hide when `position` is `inside`.


### After: How is it fixed in this PR?

`labelLine` was hidden after second `setOption`



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

The last test case in `pie-label.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
