### PR TITLE
Fix(handleIcon): icon without 'path://' will block

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -547,7 +547,11 @@ class SliderZoomView extends DataZoomView {
         // Left and right handle to resize
         each([0, 1] as const, function (handleIndex) {
             let iconStr = dataZoomModel.get('handleIcon');
-            if (!symbolBuildProxies[iconStr] && iconStr.indexOf('path://') < 0) {
+            if (
+                !symbolBuildProxies[iconStr]
+                && iconStr.indexOf('path://') < 0
+                && iconStr.indexOf('image://') < 0
+            ) {
                 // Compatitable with the old icon parsers. Which can use a path string without path://
                 iconStr = 'path://' + iconStr;
                 if (__DEV__) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`path://` prefix is in wrong position



### Fixed issues

Close #14014


## Details

### Before: What was the problem?

`handleIcon` was base64 might block render



### After: How is it fixed in this PR?

Chart render successfully.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
