### PR TITLE
fix(pie): deprecate series[pie].label.margin #14067

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -62,6 +62,10 @@ interface PieLabelOption extends Omit<SeriesLabelOption, 'rotate' | 'position'> 
     rotate?: number
     alignTo?: 'none' | 'labelLine' | 'edge'
     edgeDistance?: string | number
+    /**
+     * @deprecated Use `edgeDistance` instead
+     */
+    margin?: string | number
     bleedMargin?: number
     distanceToLabelLine?: number
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictBindCallApply": true,
-        "removeComments": true,
+        "removeComments": false,
         "sourceMap": true,
 
         // https://github.com/ezolenko/rollup-plugin-typescript2/issues/12#issuecomment-536173372


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix deprecated typing.


### Fixed issues

- #14067 Pie label margin doesn't exist on typing



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
