### PR TITLE
fix(pie): pie chart avoidLabelOverlap hides label. close #13938

### DIFF
--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -32,9 +32,9 @@ import { shiftLayoutOnY } from '../../label/labelLayoutHelper';
 const RADIAN = Math.PI / 180;
 
 interface LabelLayout {
-    label: ZRText,
-    labelLine: Polyline,
-    position: PieSeriesOption['label']['position'],
+    label: ZRText
+    labelLine: Polyline
+    position: PieSeriesOption['label']['position']
     len: number
     len2: number
     minTurnAngle: number
@@ -42,10 +42,10 @@ interface LabelLayout {
     surfaceNormal: Point
     linePoints: VectorArray[]
     textAlign: HorizontalAlign
-    labelDistance: number,
-    labelAlignTo: PieSeriesOption['label']['alignTo'],
-    edgeDistance: number,
-    bleedMargin: PieSeriesOption['label']['bleedMargin'],
+    labelDistance: number
+    labelAlignTo: PieSeriesOption['label']['alignTo']
+    edgeDistance: number
+    bleedMargin: PieSeriesOption['label']['bleedMargin']
     rect: BoundingRect
 }
 
@@ -104,7 +104,7 @@ function adjustSingleSide(
                 // horizontal r is always same with original r because x is not changed.
                 const rA = r + item.len;
                 // Canculate rB based on the topest / bottemest label.
-                const rB = dx < rA
+                const rB = Math.abs(dx) < rA
                     ? Math.sqrt(dy * dy / (1 - dx * dx / rA / rA))
                     : rA;
                 semi.rB = rB;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

fix chart avoidLabelOverlap hides label even when there are lot's of free space.

### Fixed issues

<!--
- #xxxx: ...
-->
- #13938: Pie chart avoidLabelOverlap hides label even when there are lot's of free space

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

dx has the direction(1/-1) presentation, if dx < 0; then dx < rA always be true; 
But if (-dx) > rA, there would be square root of negative number. 

`Math.sqrt(dy * dy / (1 - dx * dx / rA / rA))`

rB will get NaN.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![13938-before1](https://user-images.githubusercontent.com/30228906/105683108-3955f100-5f2e-11eb-90e8-34642305be07.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
When comparing, dx => Math.abs(dx)
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![13938-after1](https://user-images.githubusercontent.com/30228906/105683124-3e1aa500-5f2e-11eb-9f18-6268360ad906.png)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
