### PR TITLE
Fix(markline): markline label should have higher z

### DIFF
--- a/src/chart/helper/Line.ts
+++ b/src/chart/helper/Line.ts
@@ -261,7 +261,9 @@ class Line extends graphic.Group {
                 ? lineData.getName(idx)
                 : isFinite(rawVal)
                 ? round(rawVal)
-                : rawVal) + ''
+                : rawVal) + '',
+            // @ts-ignore
+            z: seriesModel.getData(lineData.dataType).getItemModel(idx).get('z') + 1
         });
         const label = this.getTextContent() as InnerLineLabel;
 

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -98,7 +98,8 @@ interface SetLabelStyleOpt<TLabelDataIndex> extends TextCommonParams {
     /**
      * Inject a setter of text for the text animation case.
      */
-    enableTextSetter?: boolean
+    enableTextSetter?: boolean;
+    z?: number;
 }
 type LabelModel = Model<LabelOption & {
     formatter?: string | ((params: any) => string);
@@ -275,6 +276,7 @@ function setLabelStyle<TLabelDataIndex>(
         textContent.ignore = !showNormal;
         // Always create new style.
         textContent.useStyle(normalStyle);
+        textContent.z = opt.z ?? textContent.z;
         textContent.dirty();
 
         if (opt.enableTextSetter) {
@@ -287,6 +289,7 @@ function setLabelStyle<TLabelDataIndex>(
     else if (textContent) {
         // Not display rich text.
         textContent.ignore = true;
+        textContent.z = opt.z ?? textContent.z;
     }
     targetEl.dirty();
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`Label` should have higher `z index` compare to `line`



### Fixed issues

Close #14190

## Details

### Before: What was the problem?

<img width="472" alt="Screen Shot 2021-02-03 at 23 00 01" src="https://user-images.githubusercontent.com/20318608/106765267-94e15680-6673-11eb-986e-5369e4918778.png">


### After: How is it fixed in this PR?

<img width="467" alt="Screen Shot 2021-02-03 at 22 59 45" src="https://user-images.githubusercontent.com/20318608/106765298-9b6fce00-6673-11eb-8537-9cf0aff08f1d.png">


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

/test/markline.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
