### PR TITLE
fix(visualMap): use itemSymbol as default symbol type and fix #5719

### DIFF
--- a/src/component/visualMap/PiecewiseModel.ts
+++ b/src/component/visualMap/PiecewiseModel.ts
@@ -247,6 +247,13 @@ class PiecewiseModel extends VisualMapModel<PiecewiseVisualMapOption> {
     /**
      * @public
      */
+    getItemSymbol(): string {
+        return this.get('itemSymbol');
+    }
+
+    /**
+     * @public
+     */
     getSelectedMapKey(piece: InnerVisualPiece) {
         return this._mode === 'categories'
             ? piece.value + '' : piece.index + '';

--- a/src/component/visualMap/VisualMapModel.ts
+++ b/src/component/visualMap/VisualMapModel.ts
@@ -39,7 +39,6 @@ import Model from '../../model/Model';
 import GlobalModel from '../../model/Global';
 import SeriesModel from '../../model/Series';
 import List from '../../data/List';
-import {PiecewiseVisualMapOption} from './PiecewiseModel';
 
 const mapVisual = VisualMapping.mapVisual;
 const eachVisual = VisualMapping.eachVisual;
@@ -235,6 +234,13 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
         this.targetVisuals = visualSolution.createVisualMappings(
             this.option.target, stateList, supplementVisualOption
         );
+    }
+
+    /**
+     * @public
+     */
+    getItemSymbol(): string {
+        return null;
     }
 
     /**
@@ -484,9 +490,7 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
             const symbolSizeExists = (controller.inRange || {}).symbolSize
                 || (controller.outOfRange || {}).symbolSize;
             const inactiveColor = this.get('inactiveColor');
-            const itemSymbol = this.type === 'visualMap.piecewise'
-                ? (this as VisualMapModel<PiecewiseVisualMapOption>).get('itemSymbol')
-                : null;
+            const itemSymbol = this.getItemSymbol();
             const defaultSymbol = itemSymbol || 'roundRect';
 
             each(this.stateList, function (state: VisualState) {

--- a/src/component/visualMap/VisualMapModel.ts
+++ b/src/component/visualMap/VisualMapModel.ts
@@ -514,9 +514,9 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
                         || (isCategory ? itemSize[0] : [itemSize[0], itemSize[0]]);
                 }
 
-                // Filter square and none.
+                // Filter none
                 visuals.symbol = mapVisual(visuals.symbol, function (symbol) {
-                    return (symbol === 'none' || symbol === 'square') ? defaultSymbol : symbol;
+                    return symbol === 'none' ? defaultSymbol : symbol;
                 });
 
                 // Normalize symbolSize

--- a/src/component/visualMap/VisualMapModel.ts
+++ b/src/component/visualMap/VisualMapModel.ts
@@ -39,6 +39,7 @@ import Model from '../../model/Model';
 import GlobalModel from '../../model/Global';
 import SeriesModel from '../../model/Series';
 import List from '../../data/List';
+import {PiecewiseVisualMapOption} from './PiecewiseModel';
 
 const mapVisual = VisualMapping.mapVisual;
 const eachVisual = VisualMapping.eachVisual;
@@ -483,6 +484,10 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
             const symbolSizeExists = (controller.inRange || {}).symbolSize
                 || (controller.outOfRange || {}).symbolSize;
             const inactiveColor = this.get('inactiveColor');
+            const itemSymbol = this.type === 'visualMap.piecewise'
+                ? (this as VisualMapModel<PiecewiseVisualMapOption>).get('itemSymbol')
+                : null;
+            const defaultSymbol = itemSymbol || 'roundRect';
 
             each(this.stateList, function (state: VisualState) {
 
@@ -501,7 +506,7 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
                 if (visuals.symbol == null) {
                     visuals.symbol = symbolExists
                         && zrUtil.clone(symbolExists)
-                        || (isCategory ? 'roundRect' : ['roundRect']);
+                        || (isCategory ? defaultSymbol : [defaultSymbol]);
                 }
                 if (visuals.symbolSize == null) {
                     visuals.symbolSize = symbolSizeExists
@@ -511,7 +516,7 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
 
                 // Filter square and none.
                 visuals.symbol = mapVisual(visuals.symbol, function (symbol) {
-                    return (symbol === 'none' || symbol === 'square') ? 'roundRect' : symbol;
+                    return (symbol === 'none' || symbol === 'square') ? defaultSymbol : symbol;
                 });
 
                 // Normalize symbolSize

--- a/src/component/visualMap/VisualMapView.ts
+++ b/src/component/visualMap/VisualMapView.ts
@@ -27,7 +27,6 @@ import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import VisualMapModel from './VisualMapModel';
 import { VisualOptionUnit, ColorString } from '../../util/types';
-import PiecewiseModel from './PiecewiseModel';
 
 type VisualState = VisualMapModel['stateList'][number];
 
@@ -118,7 +117,7 @@ class VisualMapView extends ComponentView {
 
         // Default values.
         if (visualCluster === 'symbol') {
-            visualObj.symbol = (visualMapModel as PiecewiseModel).get('itemSymbol');
+            visualObj.symbol = visualMapModel.getItemSymbol();
         }
         if (visualCluster === 'color') {
             const defaultColor = visualMapModel.get('contentColor');

--- a/src/component/visualMap/VisualMapView.ts
+++ b/src/component/visualMap/VisualMapView.ts
@@ -116,9 +116,6 @@ class VisualMapView extends ComponentView {
         const visualObj: {[key in typeof visualCluster]?: VisualOptionUnit[key]} = {};
 
         // Default values.
-        if (visualCluster === 'symbol') {
-            visualObj.symbol = visualMapModel.getItemSymbol();
-        }
         if (visualCluster === 'color') {
             const defaultColor = visualMapModel.get('contentColor');
             visualObj.color = defaultColor as ColorString;

--- a/test/visualMap-scatter-colorAndSymbol.html
+++ b/test/visualMap-scatter-colorAndSymbol.html
@@ -86,7 +86,8 @@ under the License.
                             dimension: 3,
                             seriesIndex: 0,
                             max: 10,
-                            color: ['red', 'pink', 'black']
+                            color: ['red', 'pink', 'black'],
+                            itemSymbol: 'circle'
                         },
                         {
                             right: 0,
@@ -98,7 +99,8 @@ under the License.
                             backgroundColor: '#eee',
                             inRange: {
                                 symbol: ['rect', 'line', 'path://M 100 100 L 300 100 L 200 300 z']
-                            }
+                            },
+                            itemSymbol: 'diamond'
                         },
                         {
                             left: 'center',
@@ -116,9 +118,10 @@ under the License.
                                 {
                                     gte: 0,
                                     color: 'green',
-                                    symbol: 'rect'
+                                    // symbol: 'rect'
                                 }
-                            ]
+                            ],
+                            itemSymbol: 'circle'
                         }
                     ],
                     series: [


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

`visualMap[piecewise].itemSymbol` took no effect.

### Fixed issues

- #5719: itemSymbol in the visualMap (piecewise) can't be set


## Details

### Before: What was the problem?

`visualMap[piecewise].itemSymbol` took no effect.

### After: How is it fixed in this PR?

`visualMap[piecewise].itemSymbol` should be used as default symbol type when `symbol` is not defined in visualMap pieces.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

- `test/visualMap-scatter-colorAndSymbol.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
