### PR TITLE
fix(custom): fix series label on custom series not working properly. close #14092

### DIFF
--- a/src/util/styleCompat.ts
+++ b/src/util/styleCompat.ts
@@ -191,7 +191,7 @@ export function convertToEC4StyleForCustomSerise(
     }
     else {
         if (textFillNotSet) {
-            out.textFill = txCfg.outsideFill || hostFill;
+            out.textFill = itemStl.fill || txCfg.outsideFill || '#000';
         }
         !out.textStroke && txCfg.outsideStroke && (out.textStroke = txCfg.outsideStroke);
     }


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fix the color of series label  on custom series not following the color of  bars


### Fixed issues

<!--
- #xxxx: ...
-->
- #14092: Series Label on Custom Series not working properly

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
The color of series label  on custom series followed the last/hovered bar.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![14092-before](https://user-images.githubusercontent.com/30228906/107370427-ec713d80-6b1d-11eb-9686-5d4e68c7ace5.png)



### After: How is it fixed in this PR?
I read the comment below and code on v4.9.0 branch. But I'm not sure whether the fix meets requirement of comment below:
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Element.ts
```
 outsideFill is a color string or left empty.
If a textContent is "inside", its final fill will be picked by this priority:
textContent.style.fill > textConfig.outsideFill > #000
```

txCfg.outsideFill always get 'auto' as default value , the color of series label should follow the  color of  bars.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![14092-after](https://user-images.githubusercontent.com/30228906/107371296-1840f300-6b1f-11eb-9f5d-babcff0780a5.png)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
