### PR TITLE
Add LegendComponentOption.icon property type

### DIFF
--- a/src/component/legend/LegendModel.ts
+++ b/src/component/legend/LegendModel.ts
@@ -98,6 +98,11 @@ export interface LegendOption extends ComponentOption, BoxLayoutOptionMixin, Bor
      */
     padding?: number | number[]
     /**
+     * Icon of the legend items.
+     * @default 'roundRect'
+     */
+    icon?: string
+    /**
      * Gap between each legend item.
      * @default 10
      */


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

adds the icon property to LegendComponentOption


### Fixed issues

https://github.com/apache/echarts/issues/14262


## Details

### Before: What was the problem?

couldn't add a strongly typed legend option object because the icon property didn't exist


### After: How is it fixed in this PR?

add the type for it


## Usage

### Are there any API changes?

- [ ] The API has been changed.

Updates the TS types to be in line with the echarts docs https://echarts.apache.org/en/option.html#legend.icon 



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
