### PR TITLE
fix(type): exporting more necessary types for generating declarations in the extensions

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -193,7 +193,7 @@ type ConnectStatus =
     | typeof CONNECT_STATUS_UPDATING
     | typeof CONNECT_STATUS_UPDATED;
 
-interface SetOptionOpts {
+export interface SetOptionOpts {
     notMerge?: boolean;
     lazyUpdate?: boolean;
     silent?: boolean;

--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -19,6 +19,16 @@
 
 // Core API from echarts/src/echarts
 
+export * from '../core/echarts';
+export * from './api';
+
+// Export necessary types
+export {ZRColor as Color, Payload} from '../util/types';
+export {LinearGradientObject} from 'zrender/src/graphic/LinearGradient';
+export {RadialGradientObject} from 'zrender/src/graphic/RadialGradient';
+export {PatternObject} from 'zrender/src/graphic/Pattern';
+
+// ComposeOption
 import type { ComponentOption, ECBasicOption as EChartsCoreOption } from '../util/types';
 
 import type { AxisPointerOption } from '../component/axisPointer/AxisPointerModel';
@@ -26,8 +36,6 @@ import type { XAXisOption, YAXisOption } from '../coord/cartesian/AxisModel';
 import type { AngleAxisOption, RadiusAxisOption } from '../coord/polar/AxisModel';
 import type { ParallelAxisOption } from '../coord/parallel/AxisModel';
 
-export * from '../core/echarts';
-export * from './api';
 
 export {EChartsType as ECharts} from '../core/echarts';
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

For some unknown reason, [vue-echarts#next](https://github.com/ecomfe/vue-echarts/tree/ee12ad9658f3745a6738c3df995fb0b328b35299) will have `Default export of the module has or is using private name` error when generating declarations. It only happens when reexporting wrapped `ECharts#getDataURL`, `ECharts#getConnectedDataURL`, `ECharts#dispatchAction` methods to the vue component.

So in this PR, we export these necessary private types to avoid this issue:

+ `echarts.Color`
+ `echarts.Payload`
+ `echarts.LinearGradientObject`
+ `echarts.RadialGradientObject`
+ `echarts.LinearGradientObject`
+ `echarts.SetOptionOpts`

