### PR TITLE
fix(markLine): fix axis type in markLine data and close #14300

### DIFF
--- a/src/component/marker/MarkLineModel.ts
+++ b/src/component/marker/MarkLineModel.ts
@@ -43,8 +43,8 @@ interface MarkLineDataItemOptionBase extends MarkLineStateOption, StatesOptionMi
 export interface MarkLine1DDataItemOption extends MarkLineDataItemOptionBase {
 
     // On cartesian coordinate system
-    xAxis?: number
-    yAxis?: number
+    xAxis?: number | string
+    yAxis?: number | string
 
     // Use statistic method
     type?: MarkerStatisticType


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

`string` is a valid type for `markLine.data` because time axis values can be string. This PR adds `string` to its type.

### Fixed issues

- #14300: MarkLine1DDataItemOption incorrectly defines xAxis as number

## Details

### Before: What was the problem?

Only `number` is supported for MarkLine1DDataItemOption.xAxis.


### After: How is it fixed in this PR?

Set the type to be `number | string`.



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
