### PR TITLE
fix(markArea): markArea background color disappeared. close #13647

### DIFF
--- a/src/component/marker/MarkAreaView.ts
+++ b/src/component/marker/MarkAreaView.ts
@@ -248,22 +248,19 @@ class MarkAreaView extends MarkerView {
             const points = map(dimPermutations, function (dim) {
                 return getSingleMarkerEndPoint(areaData, idx, dim, seriesModel, api);
             });
+            const xAxis = coordSys.getAxis('x').scale.getExtent();
+            const yAxis = coordSys.getAxis('y').scale.getExtent();
+            const xPoint = [coordSys.getAxis('x').scale.parse(areaData.get('x0', idx)),
+                                coordSys.getAxis('x').scale.parse(areaData.get('x1', idx))];
+            const yPoint = [coordSys.getAxis('y').scale.parse(areaData.get('y0', idx)),
+                                coordSys.getAxis('y').scale.parse(areaData.get('y1', idx))];
+            xPoint.sort();
+            yPoint.sort();
+            const overlapped = !(xAxis[0] > xPoint[1] || xAxis[1] < xPoint[0]
+                                || yAxis[0] > yPoint[1] || yAxis[1] < yPoint[0]);
             // If none of the area is inside coordSys, allClipped is set to be true
             // in layout so that label will not be displayed. See #12591
-            let allClipped = true;
-            each(dimPermutations, function (dim) {
-                if (!allClipped) {
-                    return;
-                }
-                const xValue = areaData.get(dim[0], idx);
-                const yValue = areaData.get(dim[1], idx);
-                // If is infinity, the axis should be considered not clipped
-                if ((isInifinity(xValue) || coordSys.getAxis('x').containData(xValue))
-                    && (isInifinity(yValue) || coordSys.getAxis('y').containData(yValue))
-                ) {
-                    allClipped = false;
-                }
-            });
+            const allClipped = !overlapped;
             areaData.setItemLayout(idx, {
                 points: points,
                 allClipped: allClipped

--- a/src/component/marker/MarkAreaView.ts
+++ b/src/component/marker/MarkAreaView.ts
@@ -26,7 +26,7 @@ import * as graphic from '../../util/graphic';
 import { enableHoverEmphasis, setStatesStylesFromModel } from '../../util/states';
 import * as markerHelper from './markerHelper';
 import MarkerView from './MarkerView';
-import { retrieve, mergeAll, map, defaults, curry, filter, HashMap, each } from 'zrender/src/core/util';
+import { retrieve, mergeAll, map, defaults, curry, filter, HashMap } from 'zrender/src/core/util';
 import { ScaleDataValue, ParsedValue, ZRColor } from '../../util/types';
 import { CoordinateSystem, isCoordinateSystemType } from '../../coord/CoordinateSystem';
 import MarkAreaModel, { MarkArea2DDataItemOption } from './MarkAreaModel';
@@ -248,16 +248,16 @@ class MarkAreaView extends MarkerView {
             const points = map(dimPermutations, function (dim) {
                 return getSingleMarkerEndPoint(areaData, idx, dim, seriesModel, api);
             });
-            const xScale = coordSys.getAxis('x').scale;
-            const yScale = coordSys.getAxis('y').scale;
-            const xAxis = xScale.getExtent();
-            const yAxis = yScale.getExtent();
-            const xPoint = [xScale.parse(areaData.get('x0', idx)), xScale.parse(areaData.get('x1', idx))];
-            const yPoint = [yScale.parse(areaData.get('y0', idx)), yScale.parse(areaData.get('y1', idx))];
-            xPoint.sort();
-            yPoint.sort();
-            const overlapped = !(xAxis[0] > xPoint[1] || xAxis[1] < xPoint[0]
-                                || yAxis[0] > yPoint[1] || yAxis[1] < yPoint[0]);
+            const xAxisScale = coordSys.getAxis('x').scale;
+            const yAxisScale = coordSys.getAxis('y').scale;
+            const xAxisExtent = xAxisScale.getExtent();
+            const yAxisExtent = yAxisScale.getExtent();
+            const xPointExtent = [xAxisScale.parse(areaData.get('x0', idx)), xAxisScale.parse(areaData.get('x1', idx))];
+            const yPointExtent = [yAxisScale.parse(areaData.get('y0', idx)), yAxisScale.parse(areaData.get('y1', idx))];
+            numberUtil.asc(xPointExtent);
+            numberUtil.asc(yPointExtent);
+            const overlapped = !(xAxisExtent[0] > xPointExtent[1] || xAxisExtent[1] < xPointExtent[0]
+                                || yAxisExtent[0] > yPointExtent[1] || yAxisExtent[1] < yPointExtent[0]);
             // If none of the area is inside coordSys, allClipped is set to be true
             // in layout so that label will not be displayed. See #12591
             const allClipped = !overlapped;

--- a/src/component/marker/MarkAreaView.ts
+++ b/src/component/marker/MarkAreaView.ts
@@ -248,12 +248,12 @@ class MarkAreaView extends MarkerView {
             const points = map(dimPermutations, function (dim) {
                 return getSingleMarkerEndPoint(areaData, idx, dim, seriesModel, api);
             });
-            const xAxis = coordSys.getAxis('x').scale.getExtent();
-            const yAxis = coordSys.getAxis('y').scale.getExtent();
-            const xPoint = [coordSys.getAxis('x').scale.parse(areaData.get('x0', idx)),
-                                coordSys.getAxis('x').scale.parse(areaData.get('x1', idx))];
-            const yPoint = [coordSys.getAxis('y').scale.parse(areaData.get('y0', idx)),
-                                coordSys.getAxis('y').scale.parse(areaData.get('y1', idx))];
+            const xScale = coordSys.getAxis('x').scale;
+            const yScale = coordSys.getAxis('y').scale;
+            const xAxis = xScale.getExtent();
+            const yAxis = yScale.getExtent();
+            const xPoint = [xScale.parse(areaData.get('x0', idx)), xScale.parse(areaData.get('x1', idx))];
+            const yPoint = [yScale.parse(areaData.get('y0', idx)), yScale.parse(areaData.get('y1', idx))];
             xPoint.sort();
             yPoint.sort();
             const overlapped = !(xAxis[0] > xPoint[1] || xAxis[1] < xPoint[0]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fix markArea background color disappearing when markArea inclued selected area 


### Fixed issues

<!--
- #xxxx: ...
-->
- #13647: When you select a area in the same color markArea, you will find the markArea background color disappear.

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
when selected area was included in markArea, then point would not meet condition that set allClipped to false. 
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![13647-before](https://user-images.githubusercontent.com/30228906/109098532-8101af80-775c-11eb-87ef-37b770c279e0.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
add condition that check if rectangle of markArea intersects the rectangle of display area.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![13647-after](https://user-images.githubusercontent.com/30228906/109098973-3e8ca280-775d-11eb-8d85-01f18ab2fde5.png)



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
