### PR TITLE
Export union members of option types separately

### DIFF
--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -41,14 +41,14 @@ import type {TitleOption as TitleComponentOption} from '../component/title/insta
 import type {TimelineOption as TimelineComponentOption} from '../component/timeline/TimelineModel';
 import type {SliderTimelineOption as TimelineSliderComponentOption} from '../component/timeline/SliderTimelineModel';
 
-import type {LegendOption} from '../component/legend/LegendModel';
-import type {ScrollableLegendOption} from '../component/legend/ScrollableLegendModel';
+import type {LegendOption as PlainLegendComponentOption} from '../component/legend/LegendModel';
+import type {ScrollableLegendOption as ScrollableLegendComponentOption} from '../component/legend/ScrollableLegendModel';
 
-import type {SliderDataZoomOption} from '../component/dataZoom/SliderZoomModel';
-import type {InsideDataZoomOption} from '../component/dataZoom/InsideZoomModel';
+import type {SliderDataZoomOption as SliderDataZoomComponentOption} from '../component/dataZoom/SliderZoomModel';
+import type {InsideDataZoomOption as InsideDataZoomComponentOption} from '../component/dataZoom/InsideZoomModel';
 
-import type {ContinousVisualMapOption} from '../component/visualMap/ContinuousModel';
-import type {PiecewiseVisualMapOption} from '../component/visualMap/PiecewiseModel';
+import type {ContinousVisualMapOption as ContinousVisualMapComponentOption} from '../component/visualMap/ContinuousModel';
+import type {PiecewiseVisualMapOption as PiecewiseVisualMapComponentOption} from '../component/visualMap/PiecewiseModel';
 
 import type {MarkLineOption as MarkLineComponentOption} from '../component/marker/MarkLineModel';
 import type {MarkPointOption as MarkPointComponentOption} from '../component/marker/MarkPointModel';
@@ -108,9 +108,12 @@ interface ToolboxComponentOption extends ToolboxOption {
     }
 }
 
-export type DataZoomComponentOption = SliderDataZoomOption | InsideDataZoomOption;
-export type VisualMapComponentOption = ContinousVisualMapOption | PiecewiseVisualMapOption;
-export type LegendComponentOption = LegendOption | ScrollableLegendOption;
+export { SliderDataZoomComponentOption, InsideDataZoomComponentOption };
+export type DataZoomComponentOption = SliderDataZoomComponentOption | InsideDataZoomComponentOption;
+export { ContinousVisualMapComponentOption, PiecewiseVisualMapComponentOption };
+export type VisualMapComponentOption = ContinousVisualMapComponentOption | PiecewiseVisualMapComponentOption;
+export { PlainLegendComponentOption, ScrollableLegendComponentOption };
+export type LegendComponentOption = PlainLegendComponentOption | ScrollableLegendComponentOption;
 export {
     GridComponentOption,
     PolarComponentOption,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Export component option's typescript union members separately to enable more explicit typed factory functions for config parts.

## Details

### Before: What was the problem?

Since 5.0.1 the `PiecewiseVisualMapOption` interface is no longer available, only the union `VisualMapComponentOption`.  
That's why some of our utilities to build config parts cannot be typed correctly anymore.

```ts
// until version 5.0.0

import { PiecewiseVisualMapOption } from 'echarts/lib/component/visualMap/PiecewiseModel';

export function createCustomVisualMap(options: CustomOptions): PiecewiseVisualMapOption {
    const pieces: PiecewiseVisualMapOption['pieces'] = [];

    // build pieces...

    return {
        ...customConfig,
        pieces,
    };
}
```

```ts
// since version 5.0.1

import { VisualMapComponentOption } from 'echarts';

export function createCustomVisualMap(options: CustomOptions): VisualMapComponentOption {
    const pieces: VisualMapComponentOption['pieces'] = []; // <-- ERROR: pieces does not exist, because other union members does not have this property

    // build pieces...

    return {
        ...customConfig,
        pieces,
    };
}
```

### After: How is it fixed in this PR?

With this new export it is possible again to access the `PiecewiseVisualMapOption` interface as `PiecewiseVisualMapComponentOption` (and therefore the pieces).

## Usage

### Are there any API changes?

It was already available in version 5.0.0 and disappeared in 5.0.1.
