### PR TITLE
fix(calendar): provide correct TS type. close #14354

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -63,7 +63,7 @@ export type VerticalAlign = 'top' | 'middle' | 'bottom';
 
 // Types from zrender
 export type ColorString = string;
-export type ZRColor = ColorString | LinearGradientObject | RadialGradientObject | PatternObject;
+export type ZRColor = ColorString | Omit<LinearGradientObject, '__canvasGradient'> | Omit<RadialGradientObject, '__canvasGradient'> | PatternObject;
 export type ZRLineType = 'solid' | 'dotted' | 'dashed' | number | number[];
 
 export type ZRFontStyle = 'normal' | 'italic' | 'oblique';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fixed issue #14354 


### Fixed issues

<!--
- #xxxx: ...
-->
TS type error, details #14354 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
when you set the `calendar.itemStyle.color` property, `__canvasGradient` is required.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
```ts
export declare type ZRColor = ColorString | Omit<LinearGradientObject, '__canvasGradient'> | Omit<RadialGradientObject, '__canvasGradient'> | PatternObject;
```
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
