### PR TITLE
Fix(sankey): sankey label has higher z2

### DIFF
--- a/src/chart/sankey/SankeyView.ts
+++ b/src/chart/sankey/SankeyView.ts
@@ -250,7 +250,8 @@ class SankeyView extends ChartView {
                     width: layout.dx,
                     height: layout.dy
                 },
-                style: itemModel.getModel('itemStyle').getItemStyle()
+                style: itemModel.getModel('itemStyle').getItemStyle(),
+                z2: 10
             });
 
             setLabelStyle(

--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -42,13 +42,19 @@ import type {TimelineOption as TimelineComponentOption} from '../component/timel
 import type {SliderTimelineOption as TimelineSliderComponentOption} from '../component/timeline/SliderTimelineModel';
 
 import type {LegendOption as PlainLegendComponentOption} from '../component/legend/LegendModel';
-import type {ScrollableLegendOption as ScrollableLegendComponentOption} from '../component/legend/ScrollableLegendModel';
+import type {
+    ScrollableLegendOption as ScrollableLegendComponentOption
+} from '../component/legend/ScrollableLegendModel';
 
 import type {SliderDataZoomOption as SliderDataZoomComponentOption} from '../component/dataZoom/SliderZoomModel';
 import type {InsideDataZoomOption as InsideDataZoomComponentOption} from '../component/dataZoom/InsideZoomModel';
 
-import type {ContinousVisualMapOption as ContinousVisualMapComponentOption} from '../component/visualMap/ContinuousModel';
-import type {PiecewiseVisualMapOption as PiecewiseVisualMapComponentOption} from '../component/visualMap/PiecewiseModel';
+import type {
+    ContinousVisualMapOption as ContinousVisualMapComponentOption
+} from '../component/visualMap/ContinuousModel';
+import type {
+    PiecewiseVisualMapOption as PiecewiseVisualMapComponentOption
+} from '../component/visualMap/PiecewiseModel';
 
 import type {MarkLineOption as MarkLineComponentOption} from '../component/marker/MarkLineModel';
 import type {MarkPointOption as MarkPointComponentOption} from '../component/marker/MarkPointModel';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Set `sankey label`  z2 property.



### Fixed issues

Close #14287 


## Details

### Before: What was the problem?
<img width="110" alt="Screen Shot 2021-03-07 at 22 56 11" src="https://user-images.githubusercontent.com/20318608/110244135-57385c00-7f98-11eb-91e3-81cb30ab680e.png">




### After: How is it fixed in this PR?

<img width="192" alt="Screen Shot 2021-03-07 at 22 55 57" src="https://user-images.githubusercontent.com/20318608/110244142-5dc6d380-7f98-11eb-86dd-271e8556a7b5.png">




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

`sankey-vertical.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
