### PR TITLE
tweak(line): tweak default line bolder logic.

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -163,10 +163,7 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
         },
 
         emphasis: {
-            scale: true,
-            lineStyle: {
-                width: 'bolder'
-            }
+            scale: true
         },
         // areaStyle: {
             // origin of areaStyle. Valid values:

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -736,10 +736,7 @@ class LineView extends ChartView {
 
         setStatesStylesFromModel(polyline, seriesModel, 'lineStyle');
 
-        if (polyline.style.lineWidth > 0 && seriesModel.get(['emphasis', 'lineStyle', 'width']) === 'bolder') {
-            const emphasisLineStyle = polyline.getState('emphasis').style;
-            emphasisLineStyle.lineWidth = polyline.style.lineWidth + 1;
-        }
+        this._bolderLine(polyline, seriesModel, ecModel);
 
         // Needs seriesIndex for focus
         getECData(polyline).seriesIndex = seriesModel.seriesIndex;
@@ -1167,6 +1164,28 @@ class LineView extends ChartView {
             }
             if (valueAnimation) {
                 labelInner(endLabel).setLabelText(value);
+            }
+        }
+    }
+
+    /**
+     * To determine if the line should be bolder
+     *
+     * TODO:
+     * It's better to disable bolder when data is large,
+     * but it seems no simple way to figure out.
+     */
+    _bolderLine(polyline: ECPolyline, seriesModel: LineSeriesModel, ecModel: GlobalModel) {
+        if (polyline.style.lineWidth > 0) {
+            // only make line bolder when there is more than one series and blur state
+            // or the user manually specify `lineStyle.width` as `bolder`
+            // see https://github.com/apache/echarts/pull/13501
+            const emphasisLineWidth = seriesModel.get(['emphasis', 'lineStyle', 'width']);
+            if (emphasisLineWidth === 'bolder'
+                || (emphasisLineWidth == null && polyline.getState('blur') && ecModel.getSeriesCount() > 1)
+            ) {
+                const emphasisLineStyle = polyline.getState('emphasis').style;
+                emphasisLineStyle.lineWidth = polyline.style.lineWidth + 1;
             }
         }
     }

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -1177,12 +1177,16 @@ class LineView extends ChartView {
      */
     _bolderLine(polyline: ECPolyline, seriesModel: LineSeriesModel, ecModel: GlobalModel) {
         if (polyline.style.lineWidth > 0) {
-            // only make line bolder when there is more than one series and blur state
+            // only make line bolder when there is more than one series and `emphasis.focus` is enabled
             // or the user manually specify `lineStyle.width` as `bolder`
             // see https://github.com/apache/echarts/pull/13501
             const emphasisLineWidth = seriesModel.get(['emphasis', 'lineStyle', 'width']);
+            const focus = seriesModel.get(['emphasis', 'focus']);
             if (emphasisLineWidth === 'bolder'
-                || (emphasisLineWidth == null && polyline.getState('blur') && ecModel.getSeriesCount() > 1)
+                || (emphasisLineWidth == null
+                    && (focus && focus !== 'none')
+                    // PENDING: only line series?
+                    && ecModel.getSeriesCount() > 1)
             ) {
                 const emphasisLineStyle = polyline.getState('emphasis').style;
                 emphasisLineStyle.lineWidth = polyline.style.lineWidth + 1;


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR is intended to tweak the default bolder logic of the line series.

- The line **won't** be bolder again in emphasis state by default
- Only make line bolder when there are more than one series and `emphasis.focus` is enabled
- Or the user manually specify `lineStyle.width` as `bolder`

Please refer to #13501 and #13013 for more details.

### Fixed issues

- https://github.com/apache/echarts/pull/13501#issuecomment-717771672


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

It's unnecessary for some cases to make the line bolder.
`bolder` is more suitable for multiple series with the blur scope.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

See above.

## Usage

### Are there any API changes?

- [x] The API has been changed.

<!-- LIST THE API CHANGES HERE -->

The new semantic value `bolder` for `emphasis.lineStyle.width` brought by #13013 has not been added to the document yet.

### Related test cases or examples to use the new APIs

`test/area-large.html`
`test/line-boldWhenHover.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
