### PR TITLE
fix(tooltip): fix time axis formatter #14470

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -82,7 +82,7 @@ export function makeValueReadable(
     valueType: DimensionType,
     useUTC: boolean
 ): string {
-    const USER_READABLE_DEFUALT_TIME_PATTERN = 'yyyy-MM-dd hh:mm:ss';
+    const USER_READABLE_DEFUALT_TIME_PATTERN = '{yyyy}-{MM}-{dd} {hh}:{mm}:{ss}';
 
     function stringToUserReadable(str: string): string {
         return (str && zrUtil.trim(str)) ? str : '-';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix default time axis formatter so that the time template can be used in tooltip.

### Fixed issues

<!--
- #14470: Tooltip is wrong in custom-gantt-flight example
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
Wrong tooltip content
![image](https://user-images.githubusercontent.com/779050/111112159-a3882b00-859a-11eb-8bfb-32b9a796f189.png)



### After: How is it fixed in this PR?

Correct tooltip content
![image](https://user-images.githubusercontent.com/779050/111112095-8b181080-859a-11eb-8d19-056134234227.png)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
