### PR TITLE
feat(line):  support brushSelector for lineSeries. close #6718

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -39,6 +39,7 @@ import {
 import List from '../../data/List';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import type Polar from '../../coord/polar/Polar';
+import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 
 type LineDataValue = OptionDataValue | OptionDataValue[];
 
@@ -204,6 +205,11 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
         progressive: 0,
         hoverLayerThreshold: Infinity
     };
+
+    brushSelector(dataIndex: number, data: List, selectors: BrushCommonSelectorsForSeries): boolean {
+        const pts = data.getLayout('points')
+        return selectors.point([pts[dataIndex * 2], pts[dataIndex * 2 + 1]]);
+    }
 }
 
 export default LineSeriesModel;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Add brushSelector for lineSeries, so that dataIndex can be selected when line series are brushed.


### Fixed issues

<!--
- #xxxx: ...
-->
#6718
#10739

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
No dataIndex was selected when line series are burshed.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
DataIndex can be selected when line series are brushed


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
