### PR TITLE
Fix(brush): clamp range when brush

### DIFF
--- a/src/component/helper/BrushTargetManager.ts
+++ b/src/component/helper/BrushTargetManager.ts
@@ -36,13 +36,11 @@ import { BrushAreaParam, BrushAreaParamInternal } from '../brush/BrushModel';
 import SeriesModel from '../../model/Series';
 import { Dictionary } from '../../util/types';
 import {
-    ModelFinderObject, ParsedModelFinder, ModelFinder,
+    ModelFinderObject, ModelFinder,
     parseFinder as modelUtilParseFinder,
     ParsedModelFinderKnown
 } from '../../util/model';
 
-
-const COORD_CONVERTS = ['dataToPoint', 'pointToData'] as const;
 type COORD_CONVERTS_INDEX = 0 | 1;
 
 // FIXME
@@ -428,11 +426,11 @@ const coordConvert: Record<BrushType, ConvertCoord> = {
         xyMinMax: BrushDimensionMinMax[]
     } {
         const xminymin = to
-            ? coordSys.pointToData([rangeOrCoordRange[0][0], rangeOrCoordRange[1][0]], [], [], clamp)
-            : coordSys.dataToPoint([rangeOrCoordRange[0][0], rangeOrCoordRange[1][0]]);
+            ? coordSys.pointToData([rangeOrCoordRange[0][0], rangeOrCoordRange[1][0]], clamp)
+            : coordSys.dataToPoint([rangeOrCoordRange[0][0], rangeOrCoordRange[1][0]], clamp);
         const xmaxymax = to
-            ? coordSys.pointToData([rangeOrCoordRange[0][1], rangeOrCoordRange[1][1]], [], [], clamp)
-            : coordSys.dataToPoint([rangeOrCoordRange[0][1], rangeOrCoordRange[1][1]]);
+            ? coordSys.pointToData([rangeOrCoordRange[0][1], rangeOrCoordRange[1][1]], clamp)
+            : coordSys.dataToPoint([rangeOrCoordRange[0][1], rangeOrCoordRange[1][1]], clamp);
         const values = [
             formatMinMax([xminymin[0], xmaxymax[0]]),
             formatMinMax([xminymin[1], xmaxymax[1]])
@@ -446,7 +444,7 @@ const coordConvert: Record<BrushType, ConvertCoord> = {
     } {
         const xyMinMax = [[Infinity, -Infinity], [Infinity, -Infinity]];
         const values = map(rangeOrCoordRange, function (item) {
-            const p = to ? coordSys.pointToData(item, [], [], clamp) : coordSys.dataToPoint(item);
+            const p = to ? coordSys.pointToData(item, clamp) : coordSys.dataToPoint(item, clamp);
             xyMinMax[0][0] = Math.min(xyMinMax[0][0], p[0]);
             xyMinMax[1][0] = Math.min(xyMinMax[1][0], p[1]);
             xyMinMax[0][1] = Math.max(xyMinMax[0][1], p[0]);

--- a/src/component/helper/BrushTargetManager.ts
+++ b/src/component/helper/BrushTargetManager.ts
@@ -471,7 +471,7 @@ function axisConvert(
     const axis = coordSys.getAxis(['x', 'y'][axisNameIndex]);
     const values = formatMinMax(map([0, 1], function (i) {
         return to
-            ? axis.coordToData(axis.toLocalCoord(rangeOrCoordRange[i]))
+            ? axis.coordToData(axis.toLocalCoord(rangeOrCoordRange[i]), true)
             : axis.toGlobalCoord(axis.dataToCoord(rangeOrCoordRange[i]));
     }));
     const xyMinMax = [];

--- a/src/coord/CoordinateSystem.ts
+++ b/src/coord/CoordinateSystem.ts
@@ -126,14 +126,11 @@ export interface CoordinateSystem {
      * Some coord sys (like Parallel) might do not have `pointToData`,
      * or the meaning of this kind of features is not clear yet.
      * @param point point Point in global pixel coordinate system.
-     * @param reserved Defined by the coordinate system itself
-     * @param out
+     * @param clamp Clamp range
      * @return data
      */
     pointToData?(
         point: number[],
-        reserved?: any,
-        out?: number[],
         clamp?: boolean
     ): number | number[];
 

--- a/src/coord/CoordinateSystem.ts
+++ b/src/coord/CoordinateSystem.ts
@@ -133,7 +133,8 @@ export interface CoordinateSystem {
     pointToData?(
         point: number[],
         reserved?: any,
-        out?: number[]
+        out?: number[],
+        clamp?: boolean
     ): number | number[];
 
     // @param point Point in global pixel coordinate system.

--- a/src/coord/cartesian/Cartesian2D.ts
+++ b/src/coord/cartesian/Cartesian2D.ts
@@ -105,7 +105,7 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
             && this.getAxis('y').containData(data[1]);
     }
 
-    dataToPoint(data: ScaleDataValue[], reserved?: unknown, out?: number[]): number[] {
+    dataToPoint(data: ScaleDataValue[], clamp?: boolean, out?: number[]): number[] {
         out = out || [];
         const xVal = data[0];
         const yVal = data[1];
@@ -121,8 +121,8 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
         }
         const xAxis = this.getAxis('x');
         const yAxis = this.getAxis('y');
-        out[0] = xAxis.toGlobalCoord(xAxis.dataToCoord(xVal));
-        out[1] = yAxis.toGlobalCoord(yAxis.dataToCoord(yVal));
+        out[0] = xAxis.toGlobalCoord(xAxis.dataToCoord(xVal, clamp));
+        out[1] = yAxis.toGlobalCoord(yAxis.dataToCoord(yVal, clamp));
         return out;
     }
 
@@ -146,8 +146,8 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
         return out;
     }
 
-    pointToData(point: number[], out?: number[], reserved?: number[], clamp?: boolean): number[] {
-        out = out || [];
+    pointToData(point: number[], clamp?: boolean): number[] {
+        const out: number[] = [];
         if (this._invTransform) {
             return applyTransform(out, point, this._invTransform);
         }

--- a/src/coord/cartesian/Cartesian2D.ts
+++ b/src/coord/cartesian/Cartesian2D.ts
@@ -146,15 +146,15 @@ class Cartesian2D extends Cartesian<Axis2D> implements CoordinateSystem {
         return out;
     }
 
-    pointToData(point: number[], out?: number[]): number[] {
+    pointToData(point: number[], out?: number[], reserved?: number[], clamp?: boolean): number[] {
         out = out || [];
         if (this._invTransform) {
             return applyTransform(out, point, this._invTransform);
         }
         const xAxis = this.getAxis('x');
         const yAxis = this.getAxis('y');
-        out[0] = xAxis.coordToData(xAxis.toLocalCoord(point[0]));
-        out[1] = yAxis.coordToData(yAxis.toLocalCoord(point[1]));
+        out[0] = xAxis.coordToData(xAxis.toLocalCoord(point[0]), clamp);
+        out[1] = yAxis.coordToData(yAxis.toLocalCoord(point[1]), clamp);
         return out;
     }
 

--- a/src/layout/barGrid.ts
+++ b/src/layout/barGrid.ts
@@ -591,7 +591,7 @@ export const largeLayout: StageHandler = {
                     valuePair[valueDimIdx] = data.get(valueDim, dataIndex);
                     valuePair[1 - valueDimIdx] = data.get(baseDim, dataIndex);
 
-                    coord = cartesian.dataToPoint(valuePair, null, coord);
+                    coord = cartesian.dataToPoint(valuePair, null);
                     // Data index might not be in order, depends on `progressiveChunkMode`.
                     largeBackgroundPoints[pointsOffset] =
                         valueAxisHorizontal ? coordLayout.x + coordLayout.width : coord[0];

--- a/test/brush3.html
+++ b/test/brush3.html
@@ -42,6 +42,7 @@ under the License.
         <div id="main1"></div>
         <div id="main0"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
 
 
 
@@ -234,6 +235,41 @@ under the License.
                     'Test updateTransform: ',
                     'click "保持选择", then brush, then roam the scatter',
                     'the "cover" of the brush should be roamed together with the scatter'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [{
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                }],
+                toolbox: {
+                    feature: {
+                        dataZoom: {
+                            yAxisIndex: false,
+                            filterMode: 'weakFilter'
+                        }
+                    }
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main3', {
+                title: [
+                    'Test brush to end: ',
+                    'click "区域缩放", brush from the fourth bar to end of chart',
+                    'The number of selected bar should be 4'
                 ],
                 option: option
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

It should clamp range when brush, otherwise, range would larger than 1, because brushed area might exceed the last item.



### Fixed issues

Close #14416 


## Details

### Before: What was the problem?

![Kapture 2021-03-31 at 17 35 49](https://user-images.githubusercontent.com/20318608/113123960-9b411880-9247-11eb-8f6e-2adcb20c5a2a.gif)



### After: How is it fixed in this PR?
![Kapture 2021-03-31 at 17 37 21](https://user-images.githubusercontent.com/20318608/113124139-ca578a00-9247-11eb-9b73-1c34d63caffc.gif)




## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs
`brush3.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
