### PR TITLE
fix(map): fix label layout may not update in map

### DIFF
--- a/src/chart/map/MapView.ts
+++ b/src/chart/map/MapView.ts
@@ -25,17 +25,9 @@ import MapSeries, { MapDataItemOption } from './MapSeries';
 import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { Payload, DisplayState, ECElement } from '../../util/types';
-import Model from '../../model/Model';
 import { setLabelStyle, getLabelStatesModels } from '../../label/labelStyle';
 import { Z2_EMPHASIS_LIFT } from '../../util/states';
 
-interface HighDownRecord {
-    recordVersion: number;
-    labelModel: Model;
-    hoverLabelModel: Model;
-    emphasisText: string;
-    normalText: string;
-};
 
 class MapView extends ChartView {
 

--- a/src/component/helper/MapDraw.ts
+++ b/src/component/helper/MapDraw.ts
@@ -586,16 +586,6 @@ class MapDraw {
 
 };
 
-function labelTextAfterUpdate(this: graphic.Text) {
-    // Make the label text apply only translate of this host el
-    // but no other transform like scale,rotation of this host el.
-    const mt = this.transform;
-    mt[0] = 1;
-    mt[1] = 0;
-    mt[2] = 0;
-    mt[3] = 1;
-}
-
 function applyOptionStyleForRegion(
     viewBuildCtx: ViewBuildContext,
     el: Displayable,
@@ -713,8 +703,6 @@ function resetLabelForRegion(
 
         const textEl = el.getTextContent();
         if (textEl) {
-            textEl.afterUpdate = labelTextAfterUpdate;
-
             mapLabelRaw(textEl).ignore = textEl.ignore;
 
             if (el.textConfig) {

--- a/src/util/symbol.ts
+++ b/src/util/symbol.ts
@@ -288,7 +288,7 @@ const SymbolClz = graphic.Path.extend({
         return res;
     },
 
-    buildPath: function (ctx, shape, inBundle) {
+    buildPath(ctx, shape, inBundle) {
         let symbolType = shape.symbolType;
         if (symbolType !== 'none') {
             let proxySymbol = symbolBuildProxies[symbolType];


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

In map series. When `labelLayout` is set. The highlighted labels are still not updated when zoom or pan the charts. Also `ignore` can't be restored when zooming in on the map.

### Fixed issues

## Details

### Before: What was the problem?

![before](https://user-images.githubusercontent.com/841551/113861362-b678ce80-97d9-11eb-998f-b90e73982524.gif)


### After: How is it fixed in this PR?

![after](https://user-images.githubusercontent.com/841551/113861399-bed10980-97d9-11eb-86dd-460531601f3f.gif)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
