### PR TITLE
perf(pie):when the pie chart slice is selected, the label is centered and remains unchanged

### DIFF
--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -432,8 +432,13 @@ export default function pieLabelLayout(
             }
             const selectState = label.states.select;
             if (selectState) {
-                selectState.x += label.x;
-                selectState.y += label.y;
+                if (layout.textAlign === 'center') {
+                    selectState.x = label.x;
+                    selectState.y = label.y;
+                } else {
+                    selectState.x += label.x;
+                    selectState.y += label.y;
+                }
             }
         }
         if (labelLine) {


### PR DESCRIPTION
… and remains unchanged

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

when the pie chart slice is selected, the label is centered and remains unchanged



### Fixed issues

This may be a  improves performance raised from [#14375](https://github.com/apache/echarts/issues/14565) .

## Details

### Before: What was the problem?

![avatar](https://media.giphy.com/media/inGVhWzCCL4eWj0hKu/giphy.gif)



### After: How is it fixed in this PR?

check whether the label is in the center and keep the selected position.
![avatar](https://media.giphy.com/media/J1Eq7x43Bsy0Zch3Pj/giphy.gif)


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
