### PR TITLE
fix(timeline): trigger timelineplaychange event when play to the end

### DIFF
--- a/test/timeline-event.html
+++ b/test/timeline-event.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/esl.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+            var dates = ["2010", '2011', '2012', '2013'];
+            var option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                options: [
+                {
+                    series: [{
+                    data: [130, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }],
+                }, {
+                    series: [{
+                    data: [140, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }],
+                }, {
+                    series: [{
+                    data: [90, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }],
+                }, {
+                    series: [{
+                    data: [50, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }],
+                }
+                ],
+                timeline: {
+                    data: dates,
+                    loop: false,
+                    playInterval: 800
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'console.log should print event twice after click play button',
+                    '(once when start and once when end)'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+
+            chart.on('timelineplaychanged', function (event) {
+                console.log('timeline play changed.', event);
+            });
+
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

`timelinePlayChanged` event is fired when timeline paused, so it should be fired when play to the end when not looping.
This PR makes it fires this event.

### Fixed issues

#14588 


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
When `loop` is `false` and timeline plays to the end, no event is fired.


### After: How is it fixed in this PR?

When `loop` is `false` and timeline plays to the end, `timelinePlayChanged` event is fired.


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
