### PR TITLE
fix(bar): fix bar layout with borderWidth but no borderColor

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -61,8 +61,6 @@ import {LayoutRect} from '../../util/layout';
 import {EventCallback} from 'zrender/src/core/Eventful';
 import { warn } from '../../util/log';
 
-const BAR_BORDER_WIDTH_QUERY = ['itemStyle', 'borderWidth'] as const;
-const BAR_BORDER_RADIUS_QUERY = ['itemStyle', 'borderRadius'] as const;
 const _eventPos = [0, 0];
 
 const mathMax = Math.max;
@@ -314,7 +312,7 @@ class BarView extends ChartView {
                     }
                     const bgLayout = getLayout[coord.type](data, newIndex);
                     const shape = createBackgroundShape(isHorizontalOrRadial, bgLayout, coord);
-                    updateProps(bgEl, { shape: shape }, animationModel, newIndex);
+                    updateProps(bgEl, { shape }, animationModel, newIndex);
                 }
 
                 let el = oldData.getItemGraphicEl(oldIndex) as BarPossiblePath;
@@ -905,7 +903,7 @@ function updateStyle(
     const style = data.getItemVisual(dataIndex, 'style');
 
     if (!isPolar) {
-        (el as Rect).setShape('r', itemModel.get(BAR_BORDER_RADIUS_QUERY) || 0);
+        (el as Rect).setShape('r', itemModel.get(['itemStyle', 'borderRadius']) || 0);
     }
 
     el.useStyle(style);
@@ -961,7 +959,12 @@ function getLineWidth(
     itemModel: Model<BarDataItemOption>,
     rawLayout: RectLayout
 ) {
-    const lineWidth = itemModel.get(BAR_BORDER_WIDTH_QUERY) || 0;
+    // Has no border.
+    const borderColor = itemModel.get(['itemStyle', 'borderColor']);
+    if (!borderColor || borderColor === 'none') {
+        return 0;
+    }
+    const lineWidth = itemModel.get(['itemStyle', 'borderWidth']) || 0;
     // width or height may be NaN for empty data
     const width = isNaN(rawLayout.width) ? Number.MAX_VALUE : Math.abs(rawLayout.width);
     const height = isNaN(rawLayout.height) ? Number.MAX_VALUE : Math.abs(rawLayout.height);

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -153,10 +153,8 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
             position: 'top'
         },
 
-        itemStyle: {
-            color: 'auto',
-            borderWidth: 2
-        },
+        // itemStyle: {
+        // },
 
         endLabel: {
             show: false,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Bar chart will eliminate `borderWidth` when calculating rectangle coordinates. But it didn't check if there is `borderColor`. In this PR this will be checked. Also default `borderWidth: 2` is removed in line series.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

![image](https://user-images.githubusercontent.com/841551/114157493-45125a80-9956-11eb-81ad-74643629d816.png)

There is a gap between bar and axis line because borderWidth is considered.

### After: How is it fixed in this PR?

![image](https://user-images.githubusercontent.com/841551/114157502-4774b480-9956-11eb-887c-651f1ff4074f.png)



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
