### PR TITLE
fix(markLine): symbolOffset incorrectly marked as mandatory

### DIFF
--- a/src/component/marker/MarkLineModel.ts
+++ b/src/component/marker/MarkLineModel.ts
@@ -61,7 +61,7 @@ export interface MarkLine1DDataItemOption extends MarkLineDataItemOptionBase {
     symbol?: string[] | string
     symbolSize?: number[] | number
     symbolRotate?: number[] | number
-    symbolOffset: number | string | (number | string)[]
+    symbolOffset?: number | string | (number | string)[]
 }
 
 // 2D markLine on any direction


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others
### What does this PR do?

When upgrading the ECharts dependency in Superset from 5.0.2 to 5.1.0, I noticed that `symbolOffset` in `MarkLine1DDataItemOption` is marked as mandatory, while it's optional in `MarkLine2DDataItemOption`. I believe this parameter can be made optional.

### Fixed issues

- Incorrect type checking

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
