### PR TITLE
fix(pie): hide labelLine emphasis when inside

### DIFF
--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -193,7 +193,7 @@ class PiePiece extends graphic.Sector {
 
         const labelPosition = seriesModel.get(['label', 'position']);
         if (labelPosition !== 'outside' && labelPosition !== 'outer') {
-            sector.getTextGuideLine()?.hide();
+            sector.removeTextGuideLine();
             return;
         }
         // Default use item visual color

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -43,10 +43,7 @@ class PiePiece extends graphic.Sector {
 
         this.z2 = 2;
 
-        const polyline = new graphic.Polyline();
         const text = new graphic.Text();
-
-        this.setTextGuideLine(polyline);
 
         this.setTextContent(text);
 
@@ -195,12 +192,19 @@ class PiePiece extends graphic.Sector {
         if (labelPosition !== 'outside' && labelPosition !== 'outer') {
             sector.removeTextGuideLine();
             return;
-        }
-        // Default use item visual color
-        setLabelLineStyle(this, getLabelLineStatesModels(itemModel), {
+        } else {
+          let polyline = this.getTextGuideLine();
+          if (!polyline) {
+            polyline = new graphic.Polyline();
+            this.setTextGuideLine(polyline);
+          }
+
+          // Default use item visual color
+          setLabelLineStyle(this, getLabelLineStatesModels(itemModel), {
             stroke: visualColor,
             opacity: retrieve3(labelLineModel.get(['lineStyle', 'opacity']), visualOpacity, 1)
-        });
+          });
+        }
     }
 }
 

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -751,7 +751,12 @@ under the License.
                     option.series[1].label.position = 'inside';
                     chart.setOption(option);
                 }, 2000);
-            
+                setTimeout(() => {
+                    option.series[0].label.position = 'inside';
+                    option.series[1].label.position = 'outside';
+                    chart.setOption(option);
+                }, 4000);
+
                 var chart = testHelper.create(echarts, 'main8', {
                     title: 'labelLine should be hidden when position is not \'outside\'',
                     height: 300,

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -756,6 +756,11 @@ under the License.
                     option.series[1].label.position = 'outside';
                     chart.setOption(option);
                 }, 4000);
+                setTimeout(() => {
+                    option.series[0].label.position = 'outside';
+                    option.series[1].label.position = 'inside';
+                    chart.setOption(option);
+                }, 6000);
 
                 var chart = testHelper.create(echarts, 'main8', {
                     title: 'labelLine should be hidden when position is not \'outside\'',


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Currently the label line will stay visible on emphasis when changing from outside to inside. This PR fixes this problem and adds a test to show that emphasis works even after changing back and forth.


## Details

### Before: What was the problem?

![pie-before](https://user-images.githubusercontent.com/33317356/115137975-f3429200-a031-11eb-995f-38992b046006.gif)

### After: How is it fixed in this PR?

![pie-after](https://user-images.githubusercontent.com/33317356/115138137-099d1d80-a033-11eb-9325-cb1745515870.gif)

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
