### PR TITLE
fix(map): ensure children have been added to group before calling `resetEventTriggerForRegion`.

### DIFF
--- a/src/component/helper/MapDraw.ts
+++ b/src/component/helper/MapDraw.ts
@@ -252,11 +252,23 @@ class MapDraw {
             // will make them share the same label and bring trouble in label
             // location calculation.
             let regionGroup = nameMap.get(regionName);
+            const hasRegionGroup = !!regionGroup;
 
-            if (!regionGroup) {
+            if (!hasRegionGroup) {
                 regionGroup = nameMap.set(regionName, new graphic.Group() as RegionsGroup);
                 regionsGroup.add(regionGroup);
+            }
 
+            const compoundPath = new graphic.CompoundPath({
+                segmentIgnoreThreshold: 1,
+                shape: {
+                    paths: []
+                }
+            });
+            regionGroup.add(compoundPath);
+
+            if (!hasRegionGroup) {
+                // ensure children have been added to group before calling resetEventTriggerForRegion
                 resetEventTriggerForRegion(
                     viewBuildCtx, regionGroup, regionName, regionModel, mapOrGeoModel, dataIdx
                 );
@@ -267,14 +279,6 @@ class MapDraw {
                     viewBuildCtx, regionGroup, regionName, regionModel, mapOrGeoModel
                 );
             }
-
-            const compoundPath = new graphic.CompoundPath({
-                segmentIgnoreThreshold: 1,
-                shape: {
-                    paths: []
-                }
-            });
-            regionGroup.add(compoundPath);
 
             zrUtil.each(region.geometries, function (geometry) {
                 if (geometry.type !== 'polygon') {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix #14699 
Fix #14701
Fix #14708 

### Fixed issues

- #14699
- #14701
- #14708

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

The tooltip can't show because of missing `seriesIndex` in the inner store of the element of zrender. 
The seriesIndex will be set by `viewBuildCtx.data.setItemGraphicEl(dataIdx, eventTrigger)` in `resetEventTriggerForRegion`.
But `regionGroup` has no children yet when calling `resetEventTriggerForRegion` for the inappropriate invoking order, which causes the `el.traverse(setItemDataAndSeriesIndex, el);` won't be invoked.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/26999792/115176182-2ef75d80-a0ff-11eb-9047-976080e96ad1.png)


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Adjust the invoking order.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img src="https://user-images.githubusercontent.com/26999792/115176159-1e46e780-a0ff-11eb-84d3-191ea8914eed.png" width="400">


## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

Please refer to `test/map-default.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
