### PR TITLE
chore: enhance github workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,14 +21,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: npm install
         run: |
-          npm install
-          npm install git+https://github.com/ecomfe/zrender.git
-      - name: build zrender
-        run: |
-          cd node_modules/zrender
-          npm install
-          npm run prepublish
-          cd ../..
+          npm ci
       - name: check type
         run: |
           npm run checktype

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,6 +28,9 @@ jobs:
       - name: build release
         run: |
           npm run release
+      - name: test generated DTS
+        run: |
+          npm run test:dts
 
   # test:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,6 +19,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: npm install
         run: |
           npm ci

--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -206,7 +206,9 @@ async function runTsCompile(localTs, compilerOptions, srcPathList) {
             console.log(chalk.red(localTs.flattenDiagnosticMessageText(diagnostic.messageText, '\n')));
         }
     });
-    assert(!emitResult.emitSkipped, 'ts compile failed.');
+    if (allDiagnostics.length > 0) {
+        throw new Error('TypeScript Compile Failed')
+    }
 }
 module.exports.runTsCompile = runTsCompile;
 
@@ -268,26 +270,6 @@ async function transformDistributionFiles(rooltFolder, replacement) {
         // }
         fs.writeFileSync(fileName, code, 'utf-8');
     }
-}
-
-/**
- * Remove __esModule mark.
- *
- * In the 4.x version. The exported CJS don't have __esModule mark.
- * Developers can use `import echarts from 'echarts/lib/echarts' instead of
- * `import * as echarts from 'echarts/lib/echarts'` to import all the exported methods.
- * It's not recommand but developers may still have the chance to do it.
- * But in the tsc export with __esModule mark. This will get an undefined export.
- * To avoid breaking this kind of code. We remove __esModule mark manually here.
- */
-function removeESmoduleMark() {
-    const filePath = nodePath.resolve(ecDir, 'lib/echarts.js');
-    const code = fs.readFileSync(filePath, 'utf-8')
-        .replace('\nexports.__esModule = true;\n', '');
-    if (code.indexOf('__esModule') >= 0) {
-        throw new Error('Seems still has __esModule mark');
-    }
-    fs.writeFileSync(filePath, code, 'utf-8');
 }
 
 function singleTransformZRRootFolder(code, replacement) {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@types/jest": "^26.0.14",
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
-    "canvas": "^2.6.0",
     "chalk": "^3.0.0",
     "commander": "2.11.0",
     "dtslint": "^4.0.5",

--- a/src/chart/helper/EffectSymbol.ts
+++ b/src/chart/helper/EffectSymbol.ts
@@ -250,6 +250,5 @@ class EffectSymbol extends Group {
     };
 
 }
-zrUtil.inherits(EffectSymbol, Group);
 
 export default EffectSymbol;

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -191,19 +191,19 @@ class PiePiece extends graphic.Sector {
         const labelPosition = seriesModel.get(['label', 'position']);
         if (labelPosition !== 'outside' && labelPosition !== 'outer') {
             sector.removeTextGuideLine();
-            return;
-        } else {
-          let polyline = this.getTextGuideLine();
-          if (!polyline) {
-            polyline = new graphic.Polyline();
-            this.setTextGuideLine(polyline);
-          }
+        }
+        else {
+            let polyline = this.getTextGuideLine();
+            if (!polyline) {
+                polyline = new graphic.Polyline();
+                this.setTextGuideLine(polyline);
+            }
 
-          // Default use item visual color
-          setLabelLineStyle(this, getLabelLineStatesModels(itemModel), {
-            stroke: visualColor,
-            opacity: retrieve3(labelLineModel.get(['lineStyle', 'opacity']), visualOpacity, 1)
-          });
+            // Default use item visual color
+            setLabelLineStyle(this, getLabelLineStatesModels(itemModel), {
+                stroke: visualColor,
+                opacity: retrieve3(labelLineModel.get(['lineStyle', 'opacity']), visualOpacity, 1)
+            });
         }
     }
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1356,8 +1356,6 @@ export type ComponentItemTooltipLabelFormatterParams = {
     // properies key array like ['name']
     $vars: string[]
 } & {
-    [key in `${ComponentMainType}Index`]: number
-} & {
     // Other properties
     [key in string]: unknown
 };

--- a/test/ut/core/setup.ts
+++ b/test/ut/core/setup.ts
@@ -17,12 +17,4 @@
 * under the License.
 */
 
-// import { JSDOM } from 'jsdom';
-import { Image } from 'canvas';
-
-// const { window } = new JSDOM();
-
-// (global as any).window = window;
-// (global as any).navigator = window.navigator;
-// (global as any).document = window.document;
-(global as any).Image = Image;
+export {};

--- a/test/ut/index.d.ts
+++ b/test/ut/index.d.ts
@@ -20,6 +20,9 @@
 
 export {};
 declare global {
+
+  const __DEV__: boolean;
+
   namespace jest {
     interface Matchers<R> {
         toBeFinite(): R

--- a/test/ut/jest.config.js
+++ b/test/ut/jest.config.js
@@ -32,6 +32,10 @@ module.exports = {
     globals: {
         '__DEV__': true
     },
+    // Not exclude node_modules because zrender also needs to be transformed.
+    transformIgnorePatterns: [
+        "node_modules/(?!zrender/)"
+    ],
     testMatch: [
         '**/spec/api/*.test.ts',
         '**/spec/component/**/*.test.ts',

--- a/test/ut/tsconfig.json
+++ b/test/ut/tsconfig.json
@@ -1,22 +1,14 @@
 {
     "compilerOptions": {
-        "target": "ES3",
+        "target": "ES6",
 
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictBindCallApply": true,
-        "removeComments": true,
-        "sourceMap": true,
 
-        // https://github.com/ezolenko/rollup-plugin-typescript2/issues/12#issuecomment-536173372
-        "moduleResolution": "node",
-
-        "importHelpers": true,
-
-        "pretty": true
+        "esModuleInterop": true
     },
     "include": [
-        "../../src/global.d.ts",
         "**/*.ts"
     ],
     "exclude": [


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

1. Fix jest failes on `node_modules/zrender`
2. Remove `canvas` from devDependency, which is always failed on install.
3. Not install zrender from GitHub in the workflow. Always test on the version in the dependency.
4. Add DTS check for earlier versions of TypeScript. 
5. Remove template string in the exported type. Avoid type error in the earlier versions of TypeScript. #14716 
6. Cache node_modules in the workflow to speedup the runner.