### PR TITLE
fix(radar): make radar label can break by word when user set width. close #14449

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -408,10 +408,11 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
 
         const textFont = textStyleModel.getFont();
 
+        const nameWidth = textStyleModel.get('width') as number;
         const truncateOpt = axisModel.get('nameTruncate', true) || {};
         const ellipsis = truncateOpt.ellipsis;
         const maxWidth = retrieve(
-            opt.nameTruncateMaxWidth, truncateOpt.maxWidth, axisNameAvailableWidth
+            opt.nameTruncateMaxWidth, truncateOpt.maxWidth, axisNameAvailableWidth, nameWidth
         );
 
         const textEl = new graphic.Text({
@@ -422,7 +423,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
             style: createTextStyle(textStyleModel, {
                 text: name,
                 font: textFont,
-                overflow: 'truncate',
+                overflow: textStyleModel.get('overflow') || 'truncate',
                 width: maxWidth,
                 ellipsis,
                 fill: textStyleModel.getTextColor()

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1056,6 +1056,8 @@ export interface TextCommonOption extends ShadowOptionMixin {
     textShadowColor?: string
     textShadowOffsetX?: number
     textShadowOffsetY?: number
+    
+    overflow?: TextStyleProps['overflow']
 
     tag?: string
 }

--- a/test/radar.html
+++ b/test/radar.html
@@ -58,7 +58,9 @@ under the License.
                         radius: [50, '70%'],
                         name: {
                             formatter:'【{value}】',
-                            color:'#72ACD1'
+                            color:'#72ACD1',
+                            width: 50,
+                            overflow: 'break'
                         },
                         triggerEvent: true,
                         // shape: 'circle',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

make radar label can break by word when user set width

### Fixed issues

<!--
- #xxxx: ...
-->
- #14449 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
i want to break radar label depended it's width, but i can't
```
radar: {
    name: {
        width: 50,
        overflow: 'break'
    }
}
```


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
i changed fiexd style in the AxsisBuilder.ts


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/radar.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
