### PR TITLE
fix(dataZoom): type fix for startValue and endValue. close #14412

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -139,8 +139,8 @@ class AxisProxy {
     calculateDataWindow(opt?: {
         start?: number
         end?: number
-        startValue?: number
-        endValue?: number
+        startValue?: number | string | Date
+        endValue?: number | string | Date
     }) {
         const dataExtent = this._dataExtent;
         const axisModel = this.getAxisModel();

--- a/src/component/dataZoom/DataZoomModel.ts
+++ b/src/component/dataZoom/DataZoomModel.ts
@@ -101,11 +101,11 @@ export interface DataZoomOption extends ComponentOption {
     /**
      * Start value. If startValue specified, start is ignored
      */
-    startValue?: number
+    startValue?: number | string | Date
     /**
      * End value. If endValue specified, end is ignored.
      */
-    endValue?: number
+    endValue?: number | string | Date
     /**
      * Min span percent, 0 - 100
      * The range of dataZoom can not be smaller than that.
@@ -506,9 +506,12 @@ class DataZoomModel<Opts extends DataZoomOption = DataZoomOption> extends Compon
 
     setCalculatedRange(opt: RangeOption): void {
         const option = this.option;
-        each(['start', 'startValue', 'end', 'endValue'] as const, function (name) {
+        each(['start', 'end'] as const, function (name) {
             option[name] = opt[name];
         });
+        each(['startValue', 'endValue'] as const, function (name) {
+          option[name] = opt[name];
+      });
     }
 
     getPercentRange(): number[] {
@@ -588,7 +591,13 @@ class DataZoomModel<Opts extends DataZoomOption = DataZoomOption> extends Compon
 function retrieveRawOption<T extends DataZoomOption>(option: T) {
     const ret = {} as T;
     each(
-        ['start', 'end', 'startValue', 'endValue', 'throttle'] as const,
+        ['start', 'end', 'throttle'] as const,
+        function (name) {
+            option.hasOwnProperty(name) && (ret[name] = option[name]);
+        }
+    );
+    each(
+        ['startValue', 'endValue'] as const,
         function (name) {
             option.hasOwnProperty(name) && (ret[name] = option[name]);
         }

--- a/src/component/dataZoom/DataZoomModel.ts
+++ b/src/component/dataZoom/DataZoomModel.ts
@@ -506,12 +506,9 @@ class DataZoomModel<Opts extends DataZoomOption = DataZoomOption> extends Compon
 
     setCalculatedRange(opt: RangeOption): void {
         const option = this.option;
-        each(['start', 'end'] as const, function (name) {
-            option[name] = opt[name];
+        each(['start', 'startValue', 'end', 'endValue'] as const, function (name) {
+            (option as any)[name] = opt[name];
         });
-        each(['startValue', 'endValue'] as const, function (name) {
-          option[name] = opt[name];
-      });
     }
 
     getPercentRange(): number[] {
@@ -591,15 +588,9 @@ class DataZoomModel<Opts extends DataZoomOption = DataZoomOption> extends Compon
 function retrieveRawOption<T extends DataZoomOption>(option: T) {
     const ret = {} as T;
     each(
-        ['start', 'end', 'throttle'] as const,
+        ['start', 'end', 'startValue', 'endValue', 'throttle'] as const,
         function (name) {
-            option.hasOwnProperty(name) && (ret[name] = option[name]);
-        }
-    );
-    each(
-        ['startValue', 'endValue'] as const,
-        function (name) {
-            option.hasOwnProperty(name) && (ret[name] = option[name]);
+            option.hasOwnProperty(name) && ((ret as any)[name] = option[name]);
         }
     );
     return ret;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fixes Type error while using dataZoom.startValue, dataZoom.endValue
<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
- #14412: 


## Details

### Before: What was the problem?

dataZoom.startValue, dataZoom.endValue supports number | string | Date but in types allowing only number. This is leading to error - Type 'string' is not assignable to type 'number'



### After: How is it fixed in this PR?

Now dataZoom.startValue, dataZoom.endValue supports number | string | Date



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
