### PR TITLE
Changed LineEndLabelOption.valueAnimation to be optional.

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -65,7 +65,7 @@ export interface LineDataItemOption extends SymbolOptionMixin,
 }
 
 export interface LineEndLabelOption extends SeriesLabelOption {
-    valueAnimation: boolean
+    valueAnimation?: boolean
 }
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Changes `series: {endLabel: {valueAnimation: bool}}` to be optional, so `valueAnimation` does not have to be specified every time `endLabel` is specified.

### Fixed issues

Cannot specify `endLabel: {}` without TS error:

>TS2741: Property 'valueAnimation' is missing in type '{}' but required in type 'LineEndLabelOption'.

