### PR TITLE
fix(legend): remove unexpected syntax to ensure better compatibility.

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -573,7 +573,7 @@ function getLegendStyle(
                      * in visual style
                      */
                     itemStyle.stroke = itemVisualStyle[
-                        symbolType.startsWith('empty') ? 'fill' : 'stroke'
+                        symbolType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke'
                     ];
                     break;
 


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Remove unexpected syntax `String.startsWith` from `LegendView` to ensure better compatibility.

This syntax is not supported in IE, so use `lastIndexOf(search, 0) === 0` instead. 

### Fixed issues

N.A.


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
The chart cannot be rendered in IE and threw a syntax error about `startsWith`.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
Use `lastIndexOf(search, 0) === 0` instead. 

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
