### PR TITLE
Enhance visual regression test

### DIFF
--- a/test/force2.html
+++ b/test/force2.html
@@ -45,7 +45,7 @@ under the License.
 
                 var gexf = dataTool.gexf;
 
-                var chart = echarts.init(document.getElementById('main');
+                var chart = echarts.init(document.getElementById('main'));
 
                 $.get('./data/les-miserables.gexf', function (xml) {
                     var graph = gexf.parse(xml);

--- a/test/parallel-aqi.html
+++ b/test/parallel-aqi.html
@@ -115,20 +115,7 @@ under the License.
                         padding: 10,
                         backgroundColor: '#222',
                         borderColor: '#777',
-                        borderWidth: 1,
-                        formatter: function (obj) {
-                            var value = obj[0].value;
-                            return '<div style="border-bottom: 1px solid rgba(255,255,255,.3); font-size: 18px;padding-bottom: 7px;margin-bottom: 7px">'
-                                + obj[0].seriesName + ' ' + value[0] + '日期：'
-                                + value[7]
-                                + '</div>'
-                                + schema[1].text + '：' + value[1] + '<br>'
-                                + schema[2].text + '：' + value[2] + '<br>'
-                                + schema[3].text + '：' + value[3] + '<br>'
-                                + schema[4].text + '：' + value[4] + '<br>'
-                                + schema[5].text + '：' + value[5] + '<br>'
-                                + schema[6].text + '：' + value[6] + '<br>';
-                        }
+                        borderWidth: 1
                     },
                     visualMap: {
                         show: true,

--- a/test/parallel-nutrients.html
+++ b/test/parallel-nutrients.html
@@ -157,17 +157,7 @@ under the License.
                             padding: 10,
                             backgroundColor: '#222',
                             borderColor: '#777',
-                            borderWidth: 1,
-                            formatter: function (obj) {
-                                var value = obj[0].value;
-                                return '<div style="border-bottom: 1px solid rgba(255,255,255,.3); font-size: 18px;padding-bottom: 7px;margin-bottom: 7px">'
-                                    + schema[1].name + '：' + value[1] + '<br>'
-                                    + schema[2].name + '：' + value[2] + '<br>'
-                                    + schema[3].name + '：' + value[3] + '<br>'
-                                    + schema[4].name + '：' + value[4] + '<br>'
-                                    + schema[5].name + '：' + value[5] + '<br>'
-                                    + schema[6].name + '：' + value[6] + '<br>';
-                            }
+                            borderWidth: 1
                         },
                         title: [
                             {

--- a/test/runTest/cli.js
+++ b/test/runTest/cli.js
@@ -327,6 +327,10 @@ async function runTests(pendingTests) {
     let runtimeCode = await buildRuntimeCode();
     runtimeCode = `window.__TEST_PLAYBACK_SPEED__ = ${program.speed || 1};\n${runtimeCode}`;
 
+    process.on('exit', () => {
+        browser.close();
+    });
+
     try {
         for (let testOpt of pendingTests) {
             console.log(`Running test: ${testOpt.name}, renderer: ${program.renderer}`);

--- a/test/runTest/cli.js
+++ b/test/runTest/cli.js
@@ -38,7 +38,8 @@ program
     .option('--expected <expected>', 'Expected version')
     .option('--actual <actual>', 'Actual version')
     .option('--renderer <renderer>', 'svg/canvas renderer')
-    .option('--no-save', 'Don\'t save result');
+    .option('--no-save', 'Don\'t save result')
+    .option('--dir <dir>', 'Out dir');
 
 program.parse(process.argv);
 
@@ -46,13 +47,14 @@ program.speed = +program.speed || 1;
 program.actual = program.actual || 'local';
 program.expected = program.expected || '4.2.1';
 program.renderer = (program.renderer || 'canvas').toLowerCase();
+program.dir = program.dir || (__dirname + '/tmp');
 
 if (!program.tests) {
     throw new Error('Tests are required');
 }
 
 function getScreenshotDir() {
-    return 'tmp/__screenshot__';
+    return `${program.dir}/__screenshot__`;
 }
 
 function sortScreenshots(list) {
@@ -98,9 +100,6 @@ async function convertToWebP(filePath, lossless) {
 
 async function takeScreenshot(page, fullPage, fileUrl, desc, isExpected, minor) {
     let screenshotName = testNameFromFile(fileUrl);
-    if (program.renderer === 'svg') {
-        screenshotName += '-_svg_render_';
-    }
     if (desc) {
         screenshotName += '-' + slugify(desc, { replacement: '-', lower: true });
     }
@@ -108,8 +107,8 @@ async function takeScreenshot(page, fullPage, fileUrl, desc, isExpected, minor) 
         screenshotName += '-' + minor;
     }
     let screenshotPrefix = isExpected ? 'expected' : 'actual';
-    fse.ensureDirSync(path.join(__dirname, getScreenshotDir()));
-    let screenshotPath = path.join(__dirname, `${getScreenshotDir()}/${screenshotName}-${screenshotPrefix}.png`);
+    fse.ensureDirSync(getScreenshotDir());
+    let screenshotPath = path.join(getScreenshotDir(), `${screenshotName}-${screenshotPrefix}.png`);
     await page.screenshot({
         path: screenshotPath,
         fullPage
@@ -277,7 +276,7 @@ async function runTest(browser, testOpt, runtimeCode, expectedVersion, actualVer
                     actual.rawScreenshotPath
                 );
 
-                const diffPath = `${path.resolve(__dirname, getScreenshotDir())}/${shot.screenshotName}-diff.png`;
+                const diffPath = `${getScreenshotDir()}/${shot.screenshotName}-diff.png`;
                 await writePNG(diffPNG, diffPath);
                 const diffWebpPath = await convertToWebP(diffPath);
 

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -37,6 +37,11 @@
     height: 55px;
 }
 
+.header>* {
+    display: inline-block;
+    vertical-align: middle;
+}
+
 .header h1 {
     color: #222;
     line-height: 50px;
@@ -79,7 +84,7 @@
     z-index: 1;
     position: sticky;
     width: 100%;
-    padding: 5px 20px;
+    padding: 5px 40px;
     top: 0px;
 
     background: #896bda;
@@ -99,6 +104,8 @@
 
 .run-config-item {
     margin: 0 5px;
+    color: #fff;
+    font-size: 12px;
 }
 .run-config-item>* {
     display: inline-block;

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -267,6 +267,11 @@ iframe {
     overflow: overlay;
 }
 
+#tests-runs-dialog .el-dialog {
+    width: 90%;
+    max-width: 1400px;
+}
+
 
 ::-webkit-scrollbar {
     height: 8px;

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -192,6 +192,13 @@
     -webkit-text-stroke: 1px #F56C6C;
 }
 
+.no-result {
+    text-align: center;
+    font-size: 30px;
+    padding: 100px 0;
+    color: #ccc;
+}
+
 .test-result {
     padding: 20px;
     margin-top: 20px;

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -269,7 +269,7 @@ iframe {
 
 #tests-runs-dialog .el-dialog {
     width: 90%;
-    max-width: 1400px;
+    max-width: 1200px;
 }
 
 

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -79,20 +79,17 @@
     z-index: 1;
     width: 100%;
     padding: 5px 20px;
+
+    background: #896bda;
+    box-shadow: 0 0 20px rgb(0 0 0 / 20%);
+    border-bottom: none;
 }
 
 .test-run-controls>* {
     display: inline-block;
     vertical-align: middle;
 }
-.test-run-controls .el-checkbox {
-    margin-right: 2px;
-}
-.nav-toolbar .el-icon-setting {
-    font-size: 20px;
-    margin-left: 5px;
-    cursor: pointer;
-}
+
 .nav-toolbar .el-button {
     padding-left: 8px;
     padding-right: 8px;
@@ -105,7 +102,15 @@
     display: inline-block;
     vertical-align: middle;
     font-size: 12px;
-    color: #afafaf;
+    color: #fff;
+}
+
+.run-config-item .el-input__inner,
+.run-config-item .el-button-group {
+    border: none;
+}
+.run-config-item .el-button {
+    border-color: #fff;
 }
 
 .run-config-item .label {
@@ -119,13 +124,22 @@
     background: #fff;
     margin: 0;
     padding: 0;
-    margin-top: 48px;
+
+    position: absolute;
+    top: 48px;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    overflow-y: scroll;
 }
 .test-list li {
     list-style: none;
     padding-left: 10px;
     cursor: pointer;
     color: #222;
+}
+.test-list li .el-checkbox {
+    margin-right: 5px;
 }
 .test-list li a.menu-link {
     display: inline-block;
@@ -184,6 +198,9 @@
     margin: 0;
 }
 
+.test-result .title {
+    margin-left: 20px;
+}
 .test-result .title>* {
     display: inline-block;
     vertical-align: middle;
@@ -222,13 +239,12 @@
 .test-screenshots h4 {
     font-size: 30px;
     font-weight: 200;
-    margin-left: -20px;
     color: #162436;
 }
 
 .test-errors, .test-logs {
     margin-top: 20px;
-    padding: 0 50px;
+    padding: 0 20px;
 }
 
 .test-logs .log-item {

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -232,6 +232,13 @@
     text-decoration: underline;
 }
 
+.single-test-ops {
+    padding: 20px 20px 0 10px;
+}
+.single-test-ops .el-button {
+    margin-left: 10px;
+}
+
 .test-screenshots {
     margin-top: 20px;
     padding: 0 20px;

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -30,17 +30,17 @@
 }
 
 .header {
-    background-color: #293c55;
-    box-shadow: 0 0  20px rgba(0, 0, 0, 0.2);
+    background-color: #fff;
+    box-shadow: 0 0  20px rgba(0, 0, 0, 0.05);
     position: relative;
-    z-index: 10;
+    z-index: 20;
+    height: 55px;
 }
 
 .header h1 {
-    color: #fff;
+    color: #222;
     line-height: 50px;
     margin: 0;
-    font-weight: 200;
     font-size: 20px;
 }
 
@@ -54,27 +54,41 @@
     margin-right: 20px;
 }
 
-.nav-toolbar {
+.el-aside {
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+    position: relative;
+    z-index: 10;
+}
+
+.el-main {
+    background: #f3f4fa;
+    padding: 0;
+}
+
+.nav-toolbar, .test-run-controls {
     padding: 10px 10px;
-    background: #162436;
-    box-shadow: inset 0 0 5px black;
+    background: #fff;
     position: fixed;
-    top: 50px;
     width: 330px;
     z-index: 2;
+    /* box-shadow: 0 0 20px rgba(0, 0, 0, 0.1); */
+    border-bottom: 1px solid #eee;
 }
-.nav-toolbar .controls {
-    margin-top: 10px;
+
+.test-run-controls {
+    z-index: 1;
+    width: 100%;
+    padding: 5px 20px;
 }
-.nav-toolbar .controls>* {
+
+.test-run-controls>* {
     display: inline-block;
     vertical-align: middle;
 }
-.nav-toolbar .controls .el-checkbox {
+.test-run-controls .el-checkbox {
     margin-right: 2px;
 }
 .nav-toolbar .el-icon-setting {
-    color: #f3f3f3;
     font-size: 20px;
     margin-left: 5px;
     cursor: pointer;
@@ -85,34 +99,40 @@
 }
 
 .run-config-item {
-    margin: 5px 0;
+    margin: 0 5px;
 }
 .run-config-item>* {
     display: inline-block;
     vertical-align: middle;
-    margin-right: 10px;
+    font-size: 12px;
+    color: #afafaf;
+}
+
+.run-config-item .label {
+    margin-right: 2px;
+    margin-left: 5px;
 }
 
 
 .test-list {
     overflow-x: hidden;
-    background: #293c55;
+    background: #fff;
     margin: 0;
     padding: 0;
-    margin-top: 80px;
+    margin-top: 48px;
 }
 .test-list li {
     list-style: none;
     padding-left: 10px;
     cursor: pointer;
-    color: #f3f3f3;
+    color: #222;
 }
 .test-list li a.menu-link {
     display: inline-block;
     text-decoration: none;
     font-size: 14px;
     line-height: 40px;
-    color: #f3f3f3;
+    color: #222;
     margin-left: 3px;
     cursor: pointer;
 }
@@ -122,10 +142,13 @@
 }
 
 .test-list li.active {
-    background: #e43c59;
+    background: #5470C6;
+}
+.test-list li.active a {
+    color: #fff;
 }
 .test-list li:hover {
-    background: #162436;
+    border-right: 4px solid #5470C6
 }
 .test-list li>* {
     vertical-align: middle;
@@ -134,6 +157,20 @@
 
 .test-list .el-progress__text {
     font-size: 12px!important;
+}
+
+.el-progress.is-success .el-progress__text {
+    color: #67C23A;
+    -webkit-text-stroke: 1px #67C23A;
+}
+.el-progress.is-exception .el-progress__text {
+    color: #F56C6C;
+    -webkit-text-stroke: 1px #F56C6C;
+}
+
+.test-result {
+    padding: 20px;
+    margin-top: 80px;
 }
 
 .test-result .el-progress__text {

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -107,6 +107,13 @@
     color: #fff;
 }
 
+.run-config-item .el-progress-circle__track {
+    stroke: rgba(255, 255, 255, 0.3)!important;
+}
+.run-config-item .el-progress-circle__path {
+    stroke: rgba(255, 255, 255, 1)!important;
+}
+
 .run-config-item .el-input__inner,
 .run-config-item .el-button-group {
     border: none;

--- a/test/runTest/client/client.css
+++ b/test/runTest/client/client.css
@@ -77,8 +77,10 @@
 
 .test-run-controls {
     z-index: 1;
+    position: sticky;
     width: 100%;
     padding: 5px 20px;
+    top: 0px;
 
     background: #896bda;
     box-shadow: 0 0 20px rgb(0 0 0 / 20%);
@@ -116,6 +118,7 @@
 .run-config-item .label {
     margin-right: 2px;
     margin-left: 5px;
+    text-transform: uppercase;
 }
 
 
@@ -184,7 +187,7 @@
 
 .test-result {
     padding: 20px;
-    margin-top: 80px;
+    margin-top: 20px;
 }
 
 .test-result .el-progress__text {
@@ -227,6 +230,8 @@
 .test-screenshots .preview {
     cursor: pointer;
     color: #409eff;
+    float: right;
+    font-size: 20px;
 }
 .test-screenshots .preview:hover {
     text-decoration: underline;

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -109,6 +109,10 @@ const app = new Vue({
         previewIframeSrc: '',
         previewTitle: '',
 
+        // List of all runs.
+        showRunsDialog: false,
+        testsRuns: [],
+
         runConfig: Object.assign({
             sortBy: 'name',
 
@@ -336,6 +340,34 @@ const app = new Vue({
                     }
                 }
             });
+        },
+
+        showAllTestsRuns() {
+            this.showRunsDialog = true;
+            socket.emit('getAllTestsRuns');
+        },
+
+        switchTestsRun(runResult) {
+
+        },
+        genTestsRunReport(runResult) {
+
+        },
+
+        delTestsRun(runResult) {
+            app.$confirm('Are you sure to delete this run?', 'Warn', {
+                confirmButtonText: 'Yes',
+                cancelButtonText: 'No',
+                center: true
+            }).then(value => {
+                const idx = this.testsRuns.indexOf(runResult);
+                if (idx >= 0) {
+                    this.testsRuns.splice(idx, 1);
+                }
+                socket.emit('delTestsRun', {
+                    id: runResult.id
+                });
+            }).catch(() => {});
         }
     }
 });
@@ -413,6 +445,10 @@ socket.on('abort', res => {
         duration: 4000
     });
     app.running = false;
+});
+
+socket.on('getAllTestsRuns_return', res => {
+    app.testsRuns = res.runs;
 });
 
 function updateUrl(notRefresh) {

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -78,6 +78,8 @@ function processTestsData(tests, oldTestsData) {
             test.summary = 'warning';
         }
 
+        // To simplify the condition in sort
+        test.actualErrors = test.actualErrors || [];
         // Keep select status not change.
         if (oldTestsData && oldTestsData[idx]) {
             test.selected = oldTestsData[idx].selected;
@@ -187,20 +189,15 @@ const app = new Vue({
             let sortFunc = this.runConfig.sortBy === 'name'
                 ? (a, b) => a.name.localeCompare(b.name)
                 : (a, b) => {
-                    if (a.percentage === b.percentage) {
-                        if (a.actualErrors && b.actualErrors) {
-                            if (a.actualErrors.length === b.actualErrors.length) {
-                                return a.name.localeCompare(b.name);
-                            }
-                            else {
-                                return b.actualErrors.length - a.actualErrors.length;
-                            }
-                        }
-                        else {
+                    if (a.actualErrors.length === b.actualErrors.length) {
+                        if (a.percentage === b.percentage) {
                             return a.name.localeCompare(b.name);
                         }
+                        else {
+                            return a.percentage - b.percentage;
+                        }
                     }
-                    return a.percentage - b.percentage;
+                    return b.actualErrors.length - a.actualErrors.length;
                 };
 
             if (!this.searchString) {

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -423,7 +423,19 @@ function updateUrl(notRefresh) {
         history.pushState({}, '', location.pathname + '?' + searchUrl);
     }
     else {
-        window.location.search = '?' + searchUrl;
+        if (app.running) {
+            app.$confirm('Change versions will stop the running tests. <br />Do you still want to continue?', 'Warn', {
+                confirmButtonText: 'Yes',
+                cancelButtonText: 'No',
+                dangerouslyUseHTMLString: true,
+                center: true
+            }).then(value => {
+                window.location.search = '?' + searchUrl;
+            }).catch(() => {});
+        }
+        else {
+            window.location.search = '?' + searchUrl;
+        }
     }
 }
 

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -128,8 +128,7 @@ const app = new Vue({
         runConfig: Object.assign({
             sortBy: 'name',
 
-            noHeadless: false,
-            replaySpeed: 5,
+            // replaySpeed: 5,
 
             isActualNightly: false,
             isExpectedNightly: false,
@@ -312,8 +311,8 @@ const app = new Vue({
                 this.tests[i].selected = selected;
             }
         },
-        runSingleTest(testName) {
-            runTests([testName]);
+        runSingleTest(testName, noHeadless) {
+            runTests([testName], noHeadless);
         },
         run(runTarget) {
             let tests;
@@ -329,7 +328,7 @@ const app = new Vue({
             else {
                 tests = this.fullTests;
             }
-            runTests(tests.map(test => test.name));
+            runTests(tests.map(test => test.name), false);
         },
         stopTests() {
             this.running = false;
@@ -389,11 +388,15 @@ const app = new Vue({
                     id: runResult.id
                 });
             }).catch(() => {});
+        },
+
+        open(url, target) {
+            window.open(url, target);
         }
     }
 });
 
-function runTests(tests) {
+function runTests(tests, noHeadless) {
     if (!tests.length) {
         app.$notify({
             title: 'No test selected.',
@@ -415,9 +418,9 @@ function runTests(tests) {
         actualVersion: app.runConfig.actualVersion,
         threads: app.runConfig.threads,
         renderer: app.runConfig.renderer,
-        noHeadless: app.runConfig.noHeadless,
+        noHeadless,
         replaySpeed: app.runConfig.noHeadless
-            ? app.runConfig.replaySpeed
+            ? 1
             : 5 // Force run at 5x speed
     });
 }

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -144,6 +144,16 @@ const app = new Vue({
     },
 
     computed: {
+        finishedPercentage() {
+            let finishedCount = 0;
+            this.fullTests.forEach(test => {
+                if (test.status === 'finished') {
+                    finishedCount++;
+                }
+            });
+            return +(finishedCount / this.fullTests.length * 100).toFixed(0) || 0;
+        },
+
         tests() {
             let sortFunc = this.runConfig.sortBy === 'name'
                 ? (a, b) => a.name.localeCompare(b.name)

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -348,7 +348,12 @@ const app = new Vue({
         },
 
         switchTestsRun(runResult) {
-
+            this.runConfig.expectedVersion = runResult.expectedVersion;
+            this.runConfig.actualVersion = runResult.actualVersion;
+            // TODO
+            this.runConfig.isExpectedNightly = runResult.expectedVersion.includes('-dev.');
+            this.runConfig.isActualNightly = runResult.actualVersion.includes('-dev.');
+            this.runConfig.renderer = runResult.renderer;
         },
         genTestsRunReport(runResult) {
 

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -172,7 +172,8 @@ const app = new Vue({
         },
 
         selectedTests() {
-            return this.fullTests.filter(test => {
+            // Only run visible tests.
+            return this.tests.filter(test => {
                 return test.selected;
             });
         },

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -39,71 +39,17 @@ under the License.
         <el-container style="min-height: 0"> <!-- https://juejin.im/post/5c642f2ff265da2de660ecfc -->
             <el-aside width="350px">
                 <div class="nav-toolbar">
-                    <el-input v-model="searchString" size="mini" placeholder="Filter Tests"></el-input>
-                    <div class="controls">
-                        <el-checkbox :indeterminate="isSelectAllIndeterminate" v-model="allSelected" @change="handleSelectAllChange"></el-checkbox>
-                        <el-button title="Sort By Failue Percentage" @click="toggleSort" size="mini" type="primary" icon="el-icon-sort">Sort</el-button>
-
-                        <el-dropdown v-if="!running" split-button type="primary" size="mini" title="Run"
-                            @click="run('selected')"
-                            @command="run"
-                        >
-                            <i class="el-icon-caret-right"></i> Run selected ({{selectedTests.length}})
-                            <el-dropdown-menu slot="dropdown" >
-                                <el-dropdown-item command="unfinished">Run unfinished ({{unfinishedTests.length}})</el-dropdown-item>
-                                <el-dropdown-item command="failed">Run failed ({{failedTests.length}})</el-dropdown-item>
-                                <el-dropdown-item command="all">Run all ({{fullTests.length}})</el-dropdown-item>
-                            </el-dropdown-menu>
-                        </el-dropdown>
-
-                        <el-button-group v-else>
-                            <el-button type="primary" size="mini" :loading="true">Stop</el-button>
-                            <el-button title="Run Selected" @click="stopTests" size="mini" type="primary" icon="el-icon-close" style="padding-left: 3px;padding-right:3px;"></el-button>
-                        </el-button-group>
-
-
-                        <el-popover title="Configuration" class="run-configuration">
-                            <div class="run-config-item">
-                                <el-checkbox v-model="runConfig.noHeadless">Replay</el-checkbox>
-                                <el-slider
-                                    style="width: 130px;"
-                                    v-model="runConfig.replaySpeed"
-                                    :step="1" :min="1" :max="10"
-                                    show-stops
-                                    :format-tooltip="function(val) { return val + 'x'; }"
-                                    :disabled="!runConfig.noHeadless"
-                                ></el-slider>
-                            </div>
-                            <div class="run-config-item">
-                                <span>Threads</span>
-                                <el-slider style="width: 140px;" v-model="runConfig.threads" :step="1" :min="1" :max="8" show-stops></el-slider>
-                            </div>
-                            <div class="run-config-item">
-                                <span>Version</span>
-                                <span style="font-size: 12px; color:#afafaf">Expected</span>
-                                <el-select size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
-                                    style="width: 80px;"
-                                >
-                                    <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
-                                </el-select>
-                                <span style="font-size: 12px; color: #afafaf">Actual</span>
-                                <el-select size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
-                                    style="width: 80px;"
-                                >
-                                    <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
-                                </el-select>
-                            </div>
-                            <div class="run-config-item">
-                                <span>Renderer</span>
-                                <el-select size="mini" v-model="runConfig.renderer" placeholder="Select Renderer">
-                                    <el-option key="canvas" label="canvas" value="canvas"></el-option>
-                                    <el-option key="svg" label="svg" value="svg"></el-option>
-                                </el-select>
-                            </div>
-                            <i slot="reference" class="el-icon-setting"></i>
-                        </el-popover>
-
-                    </div>
+                    <el-row class="filters" :gutter="10" :align="'middle'">
+                        <el-col :span="2">
+                            <el-checkbox :indeterminate="isSelectAllIndeterminate" v-model="allSelected" @change="handleSelectAllChange"></el-checkbox>
+                        </el-col>
+                        <el-col :span="17">
+                            <el-input v-model="searchString" size="mini" placeholder="Filter Tests"></el-input>
+                        </el-col>
+                        <el-col :span="2">
+                            <el-button title="Sort By Failue Percentage" @click="toggleSort" size="mini" type="primary" icon="el-icon-sort">Sort</el-button>
+                        </el-col>
+                    </el-row>
                 </div>
                 <ul class="test-list">
                     <li v-for="(test, index) in tests"
@@ -129,11 +75,19 @@ under the License.
                             ></el-progress>
                         </el-tooltip>
                         <el-tooltip
-                            v-if="test.status==='finished' && test.actualErrors && test.actualErrors.length > 0"
+                            v-else-if="test.status==='finished' && test.actualErrors && test.actualErrors.length > 0"
                         >
                             <div slot="content">{{test.actualErrors.length}} Errors</div>
                             <i class="el-icon-message-solid"
                                 style="color: #F56C6C"
+                            ></i>
+                        </el-tooltip>
+                        <el-tooltip
+                            content="Not yet run"
+                            v-else
+                        >
+                            <i class="el-icon-question"
+                                style="color: #ccc;font-size: 20px;"
                             ></i>
                         </el-tooltip>
                         <a :href="'#' + test.name" class="menu-link">
@@ -145,6 +99,64 @@ under the License.
                 </ul>
             </el-aside>
             <el-main>
+                <div class="test-run-controls">
+                    <el-dropdown v-if="!running" split-button type="primary" size="mini" title="Run"
+                        @click="run('selected')"
+                        @command="run"
+                    >
+                        <i class="el-icon-caret-right"></i> Run selected ({{selectedTests.length}})
+                        <el-dropdown-menu slot="dropdown" >
+                            <el-dropdown-item command="unfinished">Run unfinished ({{unfinishedTests.length}})</el-dropdown-item>
+                            <el-dropdown-item command="failed">Run failed ({{failedTests.length}})</el-dropdown-item>
+                            <el-dropdown-item command="all">Run all ({{fullTests.length}})</el-dropdown-item>
+                        </el-dropdown-menu>
+                    </el-dropdown>
+
+                    <el-button-group v-else>
+                        <el-button type="primary" size="mini" :loading="true">Stop</el-button>
+                        <el-button title="Run Selected" @click="stopTests" size="mini" type="primary" icon="el-icon-close" style="padding-left: 3px;padding-right:3px;"></el-button>
+                    </el-button-group>
+
+
+                    <!-- <div class="run-config-item">
+                        <el-checkbox v-model="runConfig.noHeadless">Replay</el-checkbox>
+                        <el-slider
+                            style="width: 80px;"
+                            v-model="runConfig.replaySpeed"
+                            :step="1" :min="1" :max="10"
+                            show-stops
+                            :format-tooltip="function(val) { return val + 'x'; }"
+                            :disabled="!runConfig.noHeadless"
+                        ></el-slider>
+                    </div> -->
+                    <div class="run-config-item">
+                        <span class="label">Expected</span>
+                        <el-select size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
+                            style="width: 80px;"
+                        >
+                            <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
+                        </el-select>
+                        <span class="label">Actual</span>
+                        <el-select size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
+                            style="width: 80px;"
+                        >
+                            <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
+                        </el-select>
+                    </div>
+                    <div class="run-config-item">
+                        <span class="label">Renderer</span>
+                        <el-select size="mini" style="width: 100px;" v-model="runConfig.renderer" placeholder="Select Renderer">
+                            <el-option key="canvas" label="canvas" value="canvas"></el-option>
+                            <el-option key="svg" label="svg" value="svg"></el-option>
+                        </el-select>
+                    </div>
+                    <div class="run-config-item">
+                        <span class="label">Threads</span>
+                        <el-slider style="width: 100px;" v-model="runConfig.threads" :step="1" :min="1" :max="8" show-stops></el-slider>
+                    </div>
+                </div>
+
+
                 <div v-if="currentTest" class="test-result">
                     <div class="title">
                         <el-progress

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -63,26 +63,26 @@ under the License.
                         </span>
                         <i class="el-icon-loading" v-if="test.status === 'pending' && running"></i>
 
-                        <el-tooltip
-                            v-if="test.status === 'finished'"
-                        >
-                            <div slot="content">{{test.percentage}}% Passed</div>
-                            <el-progress
-                                type="circle"
-                                :width="20"
-                                :stroke-width="2"
-                                :percentage="test.percentage"
-                                :status="test.summary"
-                            ></el-progress>
-                        </el-tooltip>
-                        <el-tooltip
-                            v-else-if="test.status==='finished' && test.actualErrors && test.actualErrors.length > 0"
-                        >
-                            <div slot="content">{{test.actualErrors.length}} Errors</div>
-                            <i class="el-icon-message-solid"
-                                style="color: #F56C6C"
-                            ></i>
-                        </el-tooltip>
+                        <template v-if="test.status === 'finished'">
+                            <el-tooltip
+                                v-if="test.actualErrors && test.actualErrors.length > 0"
+                            >
+                                <div slot="content">{{test.actualErrors.length}} Errors</div>
+                                <i class="el-icon-message-solid"
+                                    style="color: #F56C6C"
+                                ></i>
+                            </el-tooltip>
+                            <el-tooltip v-else>
+                                <div slot="content">{{test.percentage}}% Passed</div>
+                                <el-progress
+                                    type="circle"
+                                    :width="20"
+                                    :stroke-width="2"
+                                    :percentage="test.percentage"
+                                    :status="test.summary"
+                                ></el-progress>
+                            </el-tooltip>
+                        </template>
                         <el-tooltip
                             content="Not yet run"
                             v-else-if="!(test.status === 'pending' && running)"
@@ -101,6 +101,15 @@ under the License.
             </el-aside>
             <el-main>
                 <div class="test-run-controls">
+                    <div class="run-config-item">
+                        <el-tooltip content="Show All Tests Runs">
+                            <div style="cursor: pointer;"  @click="showAllTestsRuns">
+                                <i style="font-size:20px;vertical-align:middle;display:inline-block;" class="el-icon-files"></i>
+                                <span style="vertical-align:middle;display:inline-block;">ALL RUNS</span>
+                            </div>
+                        </el-tooltip>
+                    </div>
+
                     <div class="run-config-item">
                         <el-dropdown v-if="!running" split-button size="mini" title="Run"
                             @click="run('selected')"
@@ -127,16 +136,6 @@ under the License.
                                 :stroke-width="4"
                                 :show-text="false"
                             ></el-progress>
-                        </el-tooltip>
-                    </div>
-
-                    <div class="run-config-item">
-                        <el-tooltip content="Show All Tests Runs">
-                            <i
-                                style="font-size: 20px; cursor: pointer;"
-                                class="el-icon-files"
-                                @click="showAllTestsRuns"
-                            ></i>
                         </el-tooltip>
                     </div>
 

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -123,7 +123,7 @@ under the License.
                             <el-progress
                                 type="circle"
                                 :percentage="finishedPercentage"
-                                :width="25"
+                                :width="20"
                                 :stroke-width="4"
                                 :show-text="false"
                             ></el-progress>
@@ -156,10 +156,10 @@ under the License.
                         <span class="label">
                             Expected
                             <el-tooltip content="Use Nightly Build">
-                                <el-checkbox v-model="runConfig.isExpectedNightly" size="mini"></el-checkbox>
+                                <el-checkbox :disabled="running" v-model="runConfig.isExpectedNightly" size="mini"></el-checkbox>
                             </el-tooltip>
                         </span>
-                        <el-select size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
+                        <el-select :disabled="running" size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
                             :style="`width: ${runConfig.isExpectedNightly ? 160 : 80}px;`"
                         >
                             <el-option v-for="version in expectedVersionsList" :key="version" :label="version" :value="version"></el-option>
@@ -168,10 +168,10 @@ under the License.
                         <span class="label">
                             Actual
                             <el-tooltip content="Use Nightly Build">
-                                <el-checkbox v-model="runConfig.isActualNightly" size="mini"></el-checkbox>
+                                <el-checkbox :disabled="running" v-model="runConfig.isActualNightly" size="mini"></el-checkbox>
                             </el-tooltip>
                         </span>
-                        <el-select size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
+                        <el-select :disabled="running" size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
                             :style="`width: ${runConfig.isActualNightly ? 160 : 80}px;`"
                         >
                             <el-option v-for="version in actualVersionsList" :key="version" :label="version" :value="version"></el-option>
@@ -179,14 +179,18 @@ under the License.
                     </div>
                     <div class="run-config-item">
                         <span class="label">Renderer</span>
-                        <el-select size="mini" style="width: 100px;" v-model="runConfig.renderer" placeholder="Select Renderer">
+                        <el-select :disabled="running" size="mini" style="width: 100px;" v-model="runConfig.renderer" placeholder="Select Renderer">
                             <el-option key="canvas" label="canvas" value="canvas"></el-option>
                             <el-option key="svg" label="svg" value="svg"></el-option>
                         </el-select>
                     </div>
                     <div class="run-config-item">
                         <span class="label">Threads</span>
-                        <el-slider style="width: 100px;" v-model="runConfig.threads" :step="1" :min="1" :max="8" show-stops></el-slider>
+
+                        <el-select :disabled="running" size="mini" v-model="runConfig.threads" style="width: 58px">
+                            <el-option v-for="t in [1, 2, 4, 8]" :key="t" :label="t" :value="t"></el-option>
+                        </el-select>
+                        <!-- <el-slider style="width: 100px;" v-model="runConfig.threads" :step="1" :min="1" :max="8" show-stops></el-slider> -->
                     </div>
                 </div>
 

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -118,6 +118,16 @@ under the License.
                             <el-button size="mini" :loading="true">Stop</el-button>
                             <el-button title="Run" @click="stopTests" size="mini" icon="el-icon-close" style="padding-left: 3px;padding-right:3px;"></el-button>
                         </el-button-group>
+
+                        <el-tooltip :content="'Finished ' + finishedPercentage + '%'">
+                            <el-progress
+                                type="circle"
+                                :percentage="finishedPercentage"
+                                :width="25"
+                                :stroke-width="4"
+                                :show-text="false"
+                            ></el-progress>
+                        </el-tooltip>
                     </div>
 
                     <div class="run-config-item">

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -84,7 +84,7 @@ under the License.
                         </el-tooltip>
                         <el-tooltip
                             content="Not yet run"
-                            v-else
+                            v-else-if="!(test.status === 'pending' && running)"
                         >
                             <i class="el-icon-question"
                                 style="color: #ccc;font-size: 20px;"

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -100,22 +100,24 @@ under the License.
             </el-aside>
             <el-main>
                 <div class="test-run-controls">
-                    <el-dropdown v-if="!running" split-button type="primary" size="mini" title="Run"
-                        @click="run('selected')"
-                        @command="run"
-                    >
-                        <i class="el-icon-caret-right"></i> Run selected ({{selectedTests.length}})
-                        <el-dropdown-menu slot="dropdown" >
-                            <el-dropdown-item command="unfinished">Run unfinished ({{unfinishedTests.length}})</el-dropdown-item>
-                            <el-dropdown-item command="failed">Run failed ({{failedTests.length}})</el-dropdown-item>
-                            <el-dropdown-item command="all">Run all ({{fullTests.length}})</el-dropdown-item>
-                        </el-dropdown-menu>
-                    </el-dropdown>
+                    <div class="run-config-item">
+                        <el-dropdown v-if="!running" split-button size="mini" title="Run"
+                            @click="run('selected')"
+                            @command="run"
+                        >
+                            <i class="el-icon-caret-right"></i> Run ({{selectedTests.length}})
+                            <el-dropdown-menu slot="dropdown" >
+                                <el-dropdown-item command="unfinished">Run unfinished ({{unfinishedTests.length}})</el-dropdown-item>
+                                <el-dropdown-item command="failed">Run failed ({{failedTests.length}})</el-dropdown-item>
+                                <el-dropdown-item command="all">Run all ({{fullTests.length}})</el-dropdown-item>
+                            </el-dropdown-menu>
+                        </el-dropdown>
 
-                    <el-button-group v-else>
-                        <el-button type="primary" size="mini" :loading="true">Stop</el-button>
-                        <el-button title="Run Selected" @click="stopTests" size="mini" type="primary" icon="el-icon-close" style="padding-left: 3px;padding-right:3px;"></el-button>
-                    </el-button-group>
+                        <el-button-group v-else>
+                            <el-button size="mini" :loading="true">Stop</el-button>
+                            <el-button title="Run" @click="stopTests" size="mini" icon="el-icon-close" style="padding-left: 3px;padding-right:3px;"></el-button>
+                        </el-button-group>
+                    </div>
 
 
                     <!-- <div class="run-config-item">
@@ -169,12 +171,14 @@ under the License.
                             style="margin-top: 5px;"
                         ></el-progress>
                         <h3>{{currentTest.name}}</h3>
-                        <el-button-group style="margin-left: 10px">
-                            <el-button title="Run Selected" @click="runSingleTest(currentTest.name)" :loading="running" circle type="primary" icon="el-icon-caret-right"></el-button>
-                            <el-button v-if="running" title="Run Selected" @click="stopTests" circle type="primary" icon="el-icon-close"></el-button>
+                        <el-button-group style="margin-left: 10px" v-if="running">
+                            <el-button :loading="running" circle type="primary"></el-button>
+                            <el-button title="Run Selected" @click="stopTests" circle type="primary" icon="el-icon-close"></el-button>
                         </el-button-group>
-                        <a target="_blank" :href="currentTestUrl"><i class="el-icon-link"></i>Open Demo</a>
-                        <a target="_blank" :href="currentTestRecordUrl"><i class="el-icon-video-camera"></i>Record Interaction</a>
+                        <el-button v-else style="margin-left: 10px"  title="Run Selected" @click="runSingleTest(currentTest.name)" circle type="primary" icon="el-icon-caret-right"></el-button>
+                        </el-button>
+                        <a target="_blank" :href="currentTestUrl"><i class="el-icon-link"></i>&nbsp;Open Demo</a>
+                        <a target="_blank" :href="currentTestRecordUrl"><i class="el-icon-video-camera"></i>&nbsp;Record Interaction</a>
                     </div>
 
                     <div class="test-screenshots" v-for="(result, idx) in currentTest.results">

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -290,7 +290,7 @@ under the License.
                         <el-table-column property="expectedVersion" label="Expected" width="160"></el-table-column>
                         <el-table-column property="actualVersion" label="Actual" width="160"></el-table-column>
                         <el-table-column property="renderer" label="Renderer" width="100"></el-table-column>
-                        <el-table-column property="lastRunTime" label="Last Run"></el-table-column>
+                        <el-table-column property="lastRunTime" label="Last Run" width="160"></el-table-column>
                         <el-table-column property="diskSize" label="Disk Size" width="100"></el-table-column>
                         <el-table-column property="total" label="Total Tests" width="100"></el-table-column>
                         <el-table-column property="finished" label="Finished" width="100"></el-table-column>

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -37,6 +37,7 @@ under the License.
             </div>
         </el-header>
         <el-container style="min-height: 0"> <!-- https://juejin.im/post/5c642f2ff265da2de660ecfc -->
+            <!-------- Tests List ----------->
             <el-aside width="350px">
                 <div class="nav-toolbar">
                     <el-row class="filters" :gutter="10" :align="'middle'">
@@ -119,6 +120,16 @@ under the License.
                         </el-button-group>
                     </div>
 
+                    <div class="run-config-item">
+                        <el-tooltip content="Show All Tests Runs">
+                            <i
+                                style="font-size: 20px; cursor: pointer;"
+                                class="el-icon-files"
+                                @click="showAllTestsRuns"
+                            ></i>
+                        </el-tooltip>
+                    </div>
+
 
                     <!-- <div class="run-config-item">
                         <el-checkbox v-model="runConfig.noHeadless">Replay</el-checkbox>
@@ -169,7 +180,7 @@ under the License.
                     </div>
                 </div>
 
-
+                <!-------- Single Test Reusult ----------->
                 <div v-if="currentTest" class="test-result">
                     <div class="title">
                         <el-progress
@@ -267,6 +278,33 @@ under the License.
                         <a target="_blank" :href="'../../' + previewTitle"><i class="el-icon-link"></i>Open in New Window</a>
                     </div>
                     <iframe :src="previewIframeSrc" width="800" height="600"></iframe>
+                </el-dialog>
+
+                <!-------- All Tests Runs ----------->
+                <el-dialog
+                    id="tests-runs-dialog"
+                    :visible.sync="showRunsDialog"
+                    title="All Tests Runs"
+                >
+                    <el-table :data="testsRuns">
+                        <el-table-column property="expectedVersion" label="Expected"></el-table-column>
+                        <el-table-column property="actualVersion" label="Actual"></el-table-column>
+                        <el-table-column property="renderer" label="Renderer" width="100"></el-table-column>
+                        <el-table-column property="lastRunTime" label="lastRunTime"></el-table-column>
+                        <el-table-column property="total" label="Total Tests" width="100"></el-table-column>
+                        <el-table-column property="finished" label="Finished" width="100"></el-table-column>
+                        <el-table-column property="passed" label="Passed" width="100"></el-table-column>
+                        <el-table-column
+                            fixed="right"
+                            label=""
+                            width="160">
+                            <template slot-scope="scope">
+                                <el-button type="text" @click="switchTestsRun(scope.row)" size="small">View</el-button>
+                                <el-button type="text" @click="genTestsRunReport(scope.row)" size="small">Report</el-button>
+                                <el-button type="text" @click="delTestsRun(scope.row)" size="small">Delete</el-button>
+                            </template>
+                        </el-table-column>
+                    </el-table>
                 </el-dialog>
             </el-main>
         </el-container>

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -217,44 +217,49 @@ under the License.
                         <a target="_blank" :href="currentTestRecordUrl"><i class="el-icon-video-camera"></i>&nbsp;Record Interaction</a>
                     </div>
 
-                    <div class="test-screenshots" v-for="(result, idx) in currentTest.results">
-                        <!-- Not display title if it's same with previous -->
-                        <h4 v-if="result.desc !== (currentTest.results[idx - 1] && currentTest.results[idx - 1].desc)">
-                            <i class="el-icon-s-operation"></i>{{result.desc || result.name}}
-                        </h4>
-                        <el-row :gutter="40" class="screenshots">
-                            <el-col :span="8">
-                                <el-card shadow="hover">
-                                    <div slot="header" class="clearfix">
-                                        <span>Expected - {{currentTest.expectedVersion || ''}}</span>
-                                        <i title="Preview" class="el-icon-view preview" @click="preview(currentTest, 'expected')"></i>
-                                    </div>
-                                    <el-image fit="cover" :src="result.expected" :preview-src-list="[result.expected]"></el-image>
-                                </el-card>
-                            </el-col>
+                    <div v-if="currentTest.results.length > 0">
+                        <div class="test-screenshots"  v-for="(result, idx) in currentTest.results">
+                            <!-- Not display title if it's same with previous -->
+                            <h4 v-if="result.desc !== (currentTest.results[idx - 1] && currentTest.results[idx - 1].desc)">
+                                <i class="el-icon-s-operation"></i>{{result.desc || result.name}}
+                            </h4>
+                            <el-row :gutter="40" class="screenshots">
+                                <el-col :span="8">
+                                    <el-card shadow="hover">
+                                        <div slot="header" class="clearfix">
+                                            <span>Expected - {{currentTest.expectedVersion || ''}}</span>
+                                            <i title="Preview" class="el-icon-view preview" @click="preview(currentTest, 'expected')"></i>
+                                        </div>
+                                        <el-image fit="cover" :src="result.expected" :preview-src-list="[result.expected]"></el-image>
+                                    </el-card>
+                                </el-col>
 
-                            <el-col :span="8">
-                                <el-card shadow="hover">
-                                    <div slot="header" class="clearfix">
-                                        <span>Actual - {{currentTest.actualVersion || ''}}</span>
-                                        <i title="Preview" class="el-icon-view preview" @click="preview(currentTest, 'actual')"></i>
-                                    </div>
-                                    <el-image fit="cover" :src="result.actual" :preview-src-list="[result.actual]"></el-image>
-                                </el-card>
-                            </el-col>
+                                <el-col :span="8">
+                                    <el-card shadow="hover">
+                                        <div slot="header" class="clearfix">
+                                            <span>Actual - {{currentTest.actualVersion || ''}}</span>
+                                            <i title="Preview" class="el-icon-view preview" @click="preview(currentTest, 'actual')"></i>
+                                        </div>
+                                        <el-image fit="cover" :src="result.actual" :preview-src-list="[result.actual]"></el-image>
+                                    </el-card>
+                                </el-col>
 
-                            <el-col :span="8">
-                                <el-card shadow="hover">
-                                    <div slot="header" class="clearfix">
-                                        <span>Diff - {{result.diffRatio.toFixed(4)}}</span>
-                                    </div>
-                                    <el-image fit="cover" :src="result.diff" :preview-src-list="[result.diff]"></el-image>
-                                </el-card>
-                            </el-col>
-                        </el-row>
+                                <el-col :span="8">
+                                    <el-card shadow="hover">
+                                        <div slot="header" class="clearfix">
+                                            <span>Diff - {{result.diffRatio.toFixed(4)}}</span>
+                                        </div>
+                                        <el-image fit="cover" :src="result.diff" :preview-src-list="[result.diff]"></el-image>
+                                    </el-card>
+                                </el-col>
+                            </el-row>
+                        </div>
+                    </div>
+                    <div v-else class="no-result">
+                        No Result
                     </div>
 
-                    <div class="test-errors">
+                    <div class="test-errors" v-if="currentTest.expectedErrors.length > 0 || currentTest.actualErrors.length > 0">
                         <el-row :gutter="40">
                             <el-col :span="12">
                                 <el-alert title="Expected Errors" type="error" show-icon></el-alert>
@@ -267,7 +272,7 @@ under the License.
                         </el-row>
                     </div>
 
-                    <div class="test-logs">
+                    <div class="test-logs" v-if="currentTest.expectedLogs.length > 0 || currentTest.actualLogs.length > 0">
                         <el-row :gutter="40">
                             <el-col :span="12">
                                 <el-alert title="Expected Logs" type="info" show-icon> </el-alert>

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -287,16 +287,17 @@ under the License.
                     title="All Tests Runs"
                 >
                     <el-table :data="testsRuns">
-                        <el-table-column property="expectedVersion" label="Expected"></el-table-column>
-                        <el-table-column property="actualVersion" label="Actual"></el-table-column>
+                        <el-table-column property="expectedVersion" label="Expected" width="160"></el-table-column>
+                        <el-table-column property="actualVersion" label="Actual" width="160"></el-table-column>
                         <el-table-column property="renderer" label="Renderer" width="100"></el-table-column>
-                        <el-table-column property="lastRunTime" label="lastRunTime"></el-table-column>
+                        <el-table-column property="lastRunTime" label="Last Run"></el-table-column>
+                        <el-table-column property="diskSize" label="Disk Size" width="100"></el-table-column>
                         <el-table-column property="total" label="Total Tests" width="100"></el-table-column>
                         <el-table-column property="finished" label="Finished" width="100"></el-table-column>
                         <el-table-column property="passed" label="Passed" width="100"></el-table-column>
                         <el-table-column
                             fixed="right"
-                            label=""
+                            label="Operations"
                             width="160">
                             <template slot-scope="scope">
                                 <el-button type="text" @click="switchTestsRun(scope.row)" size="small">View</el-button>

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -140,18 +140,6 @@ under the License.
                         </el-tooltip>
                     </div>
 
-
-                    <!-- <div class="run-config-item">
-                        <el-checkbox v-model="runConfig.noHeadless">Replay</el-checkbox>
-                        <el-slider
-                            style="width: 80px;"
-                            v-model="runConfig.replaySpeed"
-                            :step="1" :min="1" :max="10"
-                            show-stops
-                            :format-tooltip="function(val) { return val + 'x'; }"
-                            :disabled="!runConfig.noHeadless"
-                        ></el-slider>
-                    </div> -->
                     <div class="run-config-item">
                         <span class="label">
                             Expected
@@ -207,14 +195,14 @@ under the License.
                             style="margin-top: 5px;"
                         ></el-progress>
                         <h3>{{currentTest.name}}</h3>
-                        <el-button-group style="margin-left: 10px" v-if="running">
-                            <el-button :loading="running" circle type="primary"></el-button>
-                            <el-button title="Run Selected" @click="stopTests" circle type="primary" icon="el-icon-close"></el-button>
+                    </div>
+                    <div class="single-test-ops">
+                        <el-button-group>
+                            <el-button :loading="running" size="mini" @click="runSingleTest(currentTest.name)" type="primary" icon="el-icon-caret-right">Run Single</el-button>
+                            <el-button :loading="running" size="mini" @click="runSingleTest(currentTest.name, true)">Replay</el-button>
                         </el-button-group>
-                        <el-button v-else style="margin-left: 10px"  title="Run Selected" @click="runSingleTest(currentTest.name)" circle type="primary" icon="el-icon-caret-right"></el-button>
-                        </el-button>
-                        <a target="_blank" :href="currentTestUrl"><i class="el-icon-link"></i>&nbsp;Open Demo</a>
-                        <a target="_blank" :href="currentTestRecordUrl"><i class="el-icon-video-camera"></i>&nbsp;Record Interaction</a>
+                        <el-button size="mini" @click="open(currentTestUrl, '_blank')" icon="el-icon-link">Open Demo</el-button>
+                        <el-button size="mini" @click="open(currentTestRecordUrl, '_blank')" icon="el-icon-video-camera">Record Interaction</el-button>
                     </div>
 
                     <div v-if="currentTest.results.length > 0">

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -55,7 +55,7 @@ under the License.
                     <li v-for="(test, index) in tests"
                         :title="test.name"
                         :class="{active: currentTest && currentTest.name === test.name}"
-                        @click.self="goto(test.name)"
+                        @click="changeTest($event.target, test.name)"
                     >
                         <span @mouseup="handleSelect(index)" @mouseup.shift="handleShiftSelect(index)">
                             <el-checkbox v-model="test.selected"></el-checkbox>
@@ -105,7 +105,7 @@ under the License.
                             @click="run('selected')"
                             @command="run"
                         >
-                            <i class="el-icon-caret-right"></i> Run ({{selectedTests.length}})
+                            <i class="el-icon-caret-right"></i> RUN ({{selectedTests.length}})
                             <el-dropdown-menu slot="dropdown" >
                                 <el-dropdown-item command="unfinished">Run unfinished ({{unfinishedTests.length}})</el-dropdown-item>
                                 <el-dropdown-item command="failed">Run failed ({{failedTests.length}})</el-dropdown-item>
@@ -132,17 +132,28 @@ under the License.
                         ></el-slider>
                     </div> -->
                     <div class="run-config-item">
-                        <span class="label">Expected</span>
+                        <span class="label">
+                            Expected
+                            <el-tooltip content="Use Nightly Build">
+                                <el-checkbox v-model="runConfig.isExpectedNightly" size="mini"></el-checkbox>
+                            </el-tooltip>
+                        </span>
                         <el-select size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
-                            style="width: 80px;"
+                            :style="`width: ${runConfig.isExpectedNightly ? 160 : 80}px;`"
                         >
-                            <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
+                            <el-option v-for="version in expectedVersionsList" :key="version" :label="version" :value="version"></el-option>
                         </el-select>
-                        <span class="label">Actual</span>
+                        <!-- <i class="el-icon-link"></i> -->
+                        <span class="label">
+                            Actual
+                            <el-tooltip content="Use Nightly Build">
+                                <el-checkbox v-model="runConfig.isActualNightly" size="mini"></el-checkbox>
+                            </el-tooltip>
+                        </span>
                         <el-select size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
-                            style="width: 80px;"
+                            :style="`width: ${runConfig.isActualNightly ? 160 : 80}px;`"
                         >
-                            <el-option v-for="version in versions" :key="version" :label="version" :value="version"></el-option>
+                            <el-option v-for="version in actualVersionsList" :key="version" :label="version" :value="version"></el-option>
                         </el-select>
                     </div>
                     <div class="run-config-item">

--- a/test/runTest/server.js
+++ b/test/runTest/server.js
@@ -33,12 +33,14 @@ const {
     getResultBaseDir,
     getRunHash,
     getAllTestsRuns,
-    delTestsRun
+    delTestsRun,
+    RESULTS_ROOT_DIR
 } = require('./store');
 const {prepareEChartsLib, getActionsFullPath} = require('./util');
 const fse = require('fs-extra');
 const fs = require('fs');
 const open = require('open');
+const genReport = require('./genReport');
 
 function serve() {
     const server = http.createServer((request, response) => {
@@ -253,6 +255,16 @@ async function start() {
         socket.on('getAllTestsRuns', async () => {
             socket.emit('getAllTestsRuns_return', {
                 runs: await getAllTestsRuns()
+            });
+        });
+
+        socket.on('genTestsRunReport', async (params) => {
+            const absPath = await genReport(
+                path.join(RESULTS_ROOT_DIR, getRunHash(params))
+            );
+            const relativeUrl = path.join('../', path.relative(__dirname, absPath));
+            socket.emit('genTestsRunReport_return', {
+                reportUrl: relativeUrl
             });
         });
 

--- a/test/runTest/server.js
+++ b/test/runTest/server.js
@@ -25,7 +25,7 @@ const {fork} = require('child_process');
 const semver = require('semver');
 const {port, origin} = require('./config');
 const {getTestsList, updateTestsList, saveTestsList, mergeTestsResults, updateActionsMeta} = require('./store');
-const {prepareEChartsLib, getActionsFullPath, fetchVersions} = require('./util');
+const {prepareEChartsLib, getActionsFullPath} = require('./util');
 const fse = require('fs-extra');
 const fs = require('fs');
 const open = require('open');
@@ -193,10 +193,7 @@ async function start() {
         return;
     }
 
-    let [versions] = await Promise.all([
-        fetchVersions(),
-        updateTestsList(true)
-    ]);
+    updateTestsList(true);
 
     // let runtimeCode = await buildRuntimeCode();
     // fse.outputFileSync(path.join(__dirname, 'tmp/testRuntime.js'), runtimeCode, 'utf-8');
@@ -273,8 +270,6 @@ async function start() {
         });
 
         socket.on('stop', abortTests);
-
-        socket.emit('versions', versions);
     });
 
     io.of('/recorder').on('connect', async socket => {

--- a/test/runTest/server.js
+++ b/test/runTest/server.js
@@ -133,6 +133,8 @@ function startTests(testsNameList, socket, {
                 testOpt.status = 'pending';
                 testOpt.results = [];
             });
+            // Save status immediately
+            saveTestsList();
 
             if (running) {
                 socket.emit('update', {

--- a/test/runTest/server.js
+++ b/test/runTest/server.js
@@ -34,7 +34,8 @@ const {
     getRunHash,
     getAllTestsRuns,
     delTestsRun,
-    RESULTS_ROOT_DIR
+    RESULTS_ROOT_DIR,
+    checkStoreVersion
 } = require('./store');
 const {prepareEChartsLib, getActionsFullPath} = require('./util');
 const fse = require('fs-extra');
@@ -287,6 +288,10 @@ async function start() {
 
             // TODO Should broadcast to all sockets.
             try {
+                if (!checkStoreVersion(data)) {
+                    throw new Error('Unmatched store version and run version.');
+                }
+
                 await startTests(
                     data.tests,
                     io.of('/client'),

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -234,6 +234,14 @@ async function getFolderSize(dir) {
 module.exports.getAllTestsRuns = async function () {
     const dirs = await globby('*', { cwd: RESULTS_ROOT_DIR, onlyDirectories: true });
     const results = [];
+
+    function f(number) {
+        return number < 10 ? '0' + number : number;
+    }
+    function formatDate(lastRunTime) {
+        const date = new Date(lastRunTime);
+        return `${date.getFullYear()}-${f(date.getMonth() + 1)}-${f(date.getDate())} ${f(date.getHours())}:${f(date.getMinutes())}:${f(date.getSeconds())}`;
+    }
     for (let dir of dirs) {
         const params = parseRunHash(dir);
         const resultJson = JSON.parse(fs.readFileSync(path.join(
@@ -265,7 +273,7 @@ module.exports.getAllTestsRuns = async function () {
             }
         });
 
-        params.lastRunTime = lastRunTime > 0 ? new Date(lastRunTime).toISOString() : 'N/A';
+        params.lastRunTime = lastRunTime > 0 ? formatDate(lastRunTime) : 'N/A';
         params.total = total;
         params.passed = passedCount;
         params.finished = finishedCount;

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -106,6 +106,17 @@ function getResultBaseDir() {
 module.exports.getResultBaseDir = getResultBaseDir;
 module.exports.getRunHash = getRunHash;
 
+/**
+ * Check run version is same with store version.
+ */
+module.exports.checkStoreVersion = function (runParams) {
+    const storeParams = parseRunHash(_runHash);
+    console.log('Store ', _runHash);
+    return storeParams.expectedVersion === runParams.expectedVersion
+        && storeParams.actualVersion === runParams.actualVersion
+        && storeParams.renderer === runParams.renderer;
+}
+
 function getResultFilePath() {
     return path.join(getResultBaseDir(), RESULT_FILE_NAME);
 }

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -159,7 +159,7 @@ module.exports.updateTestsList = async function (
     catch(e) {
     }
     // Find if there is new html file
-    const files = await globby('**.html', { cwd: path.resolve(__dirname, '../') });
+    const files = await globby('*.html', { cwd: path.resolve(__dirname, '../') });
     files.forEach(fileUrl => {
         if (blacklist.includes(fileUrl)) {
             return;

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -23,7 +23,6 @@ const fs = require('fs');
 const globby = require('globby');
 const {testNameFromFile} = require('./util');
 const {blacklist, SVGBlacklist} = require('./blacklist');
-const { promisify } = require('util');
 
 let _tests = [];
 let _testsMap = {};
@@ -31,6 +30,9 @@ let _runHash = '';
 
 const RESULT_FILE_NAME = '__result__.json';
 const RESULTS_ROOT_DIR = path.join(__dirname, 'tmp', 'result');
+
+module.exports.RESULT_FILE_NAME = RESULT_FILE_NAME;
+module.exports.RESULTS_ROOT_DIR = RESULTS_ROOT_DIR;
 
 const TEST_HASH_SPLITTER = '__';
 
@@ -104,9 +106,11 @@ function getResultBaseDir() {
 module.exports.getResultBaseDir = getResultBaseDir;
 module.exports.getRunHash = getRunHash;
 
-function getCacheFilePath() {
+function getResultFilePath() {
     return path.join(getResultBaseDir(), RESULT_FILE_NAME);
 }
+
+module.exports.getResultFilePath = getResultFilePath;
 
 module.exports.getTestsList = function () {
     return _tests;
@@ -128,7 +132,7 @@ module.exports.updateTestsList = async function (
     fse.ensureDirSync(getResultBaseDir());
 
     try {
-        let cachedStr = fs.readFileSync(getCacheFilePath(), 'utf-8');
+        let cachedStr = fs.readFileSync(getResultFilePath(), 'utf-8');
         const tests = JSON.parse(cachedStr);
         tests.forEach(test => {
             // In somehow tests are stopped and leave the status pending.
@@ -184,7 +188,7 @@ module.exports.updateTestsList = async function (
 };
 
 module.exports.saveTestsList = function () {
-    fse.outputFileSync(getCacheFilePath(), JSON.stringify(_tests, null, 2), 'utf-8');
+    fse.outputFileSync(getResultFilePath(), JSON.stringify(_tests, null, 2), 'utf-8');
 };
 
 module.exports.mergeTestsResults = function (testsResults) {

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -137,6 +137,10 @@ module.exports.updateTestsList = async function (
     _tests.forEach(testOpt => {
         testOpt.actions = actionsMetaData[testOpt.name] || 0;
     });
+
+    // Save once.
+    module.exports.saveTestsList();
+
     return _tests;
 };
 

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -288,6 +288,12 @@ module.exports.getAllTestsRuns = async function () {
             }
         });
 
+        if (finishedCount === 0) {
+            // Cleanup empty runs
+            await module.exports.delTestsRun(dir);
+            continue;
+        }
+
         params.lastRunTime = lastRunTime > 0 ? formatDate(lastRunTime) : 'N/A';
         params.total = total;
         params.passed = passedCount;

--- a/test/runTest/util.js
+++ b/test/runTest/util.js
@@ -67,9 +67,11 @@ module.exports.prepareEChartsLib = function (version) {
         let testLibPath = `${versionFolder}/${module.exports.getEChartsTestFileName()}`;
         if (!fs.existsSync(testLibPath)) {
             const file = fs.createWriteStream(`${versionFolder}/echarts.js`);
+            const isNightly = version.includes('-dev');
+            const packageName = isNightly ? 'echarts-nightly' : 'echarts'
 
-            console.log(`Downloading echarts@${version} from `, `https://cdn.jsdelivr.net/npm/echarts@${version}/dist/echarts.js`);
-            https.get(`https://cdn.jsdelivr.net/npm/echarts@${version}/dist/echarts.js`, response => {
+            console.log(`Downloading ${packageName}@${version} from `, `https://cdn.jsdelivr.net/npm/${packageName}@${version}/dist/echarts.js`);
+            https.get(`https://cdn.jsdelivr.net/npm/${packageName}@${version}/dist/echarts.js`, response => {
                 response.pipe(file);
 
                 file.on('finish', () => {

--- a/test/runTest/util.js
+++ b/test/runTest/util.js
@@ -87,9 +87,13 @@ module.exports.prepareEChartsLib = function (version) {
     });
 };
 
-module.exports.fetchVersions = function () {
+module.exports.fetchVersions = function (isNighlty) {
     return new Promise((resolve, reject) => {
-        https.get(`https://registry.npmjs.org/echarts`, res => {
+        https.get(
+            isNighlty
+                ? `https://registry.npmjs.org/echarts-nightly`
+                : `https://registry.npmjs.org/echarts`
+        , res => {
             if (res.statusCode !== 200) {
                 res.destroy();
                 reject('Failed fetch versions from https://registry.npmjs.org/echarts');
@@ -100,7 +104,7 @@ module.exports.fetchVersions = function () {
             res.on('end', function () {
                 try {
                     var data = Buffer.concat(buffers);
-                    resolve(Object.keys(JSON.parse(data).versions));
+                    resolve(Object.keys(JSON.parse(data).versions).reverse());
                 }
                 catch (e) {
                     reject(e.toString());


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



## What does this PR do?

This PR enhances visual regression test.

### Details

Major changes:

#### 1. Brand new UI

![image](https://user-images.githubusercontent.com/841551/117091669-a0d1d700-ad8e-11eb-9274-1f618cb0cbb5.png)

#### 2. Management of multiple versions of run

Because we reduced the size of screenshot storage significantly in https://github.com/apache/echarts/pull/14745 . We can now save multiple versions of test run on our disk now. 

![image](https://user-images.githubusercontent.com/841551/117096122-b816c180-ad9a-11eb-9921-7b903d15f68c.png)

We can manage all test runs in the `ALL RUNS` dialog. 

#### 3. Targeting nightly build

In https://github.com/apache/echarts/pull/14754 we add nightly build for echarts. It publishes the master branch every day.
So we can now choose to compare to the nightly build. Which can minimize the difference between the dev branch and the master branch if we wan't test if the dev branch breaks something.

![image](https://user-images.githubusercontent.com/841551/117096373-6cb0e300-ad9b-11eb-8ef5-5eb688e28ed1.png)

Just check the nightly build checkbox and choose nightly versions.

#### 4. Report generation

If we wan't to share our test result with others. We can generate the report by simply clicking the `Report`link.

![image](https://user-images.githubusercontent.com/841551/117096641-50617600-ad9c-11eb-91af-880cfb9e0d03.png)

Generated report HTML can be saved to local and sent to others. All images are embeded

