### PR TITLE
fix(tree): error when running setOption twice with diff data

### DIFF
--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -149,7 +149,7 @@ class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
         function beforeLink(nodeData: List) {
             nodeData.wrapMethod('getItemModel', function (model, idx) {
                 const node = tree.getNodeByDataIndex(idx);
-                if (!node.children.length || !node.isExpand) {
+                if (!node?.children.length || !node.isExpand) {
                     model.parentModel = leavesModel;
                 }
                 return model;

--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -149,7 +149,7 @@ class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
         function beforeLink(nodeData: List) {
             nodeData.wrapMethod('getItemModel', function (model, idx) {
                 const node = tree.getNodeByDataIndex(idx);
-                if (!node?.children.length || !node.isExpand) {
+                if (!(node && node.children.length && node.isExpand)) {
                     model.parentModel = leavesModel;
                 }
                 return model;

--- a/test/tree-setoption-twice.html
+++ b/test/tree-setoption-twice.html
@@ -1,0 +1,80 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+</head>
+
+<body>
+    <style>
+        html,
+        body,
+        #main {
+            width: 100%;
+            padding: 0;
+            margin: 0;
+            height: 100%;
+        }
+    </style>
+    <div id="main"></div>
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var chart = echarts.init(document.getElementById('main'), null, {
+
+            });
+
+            chart.setOption({
+                series: [{
+                    type: 'tree',
+                    data: [{
+                        "name": "display",
+                        "children": [
+                            { "name": "DirtySprite", "value": 8833 },
+                            { "name": "LineSprite", "value": 1732 },
+                            { "name": "RectSprite", "value": 3623 }
+                        ]
+                    },]
+                }]
+            });
+
+            setTimeout(function () {
+                chart.setOption({
+                    series: [{
+                        type: 'tree',
+                        data: [{
+                            "name": "flex",
+                            "children": [
+                                { "name": "FlareVis", "value": 4116 }
+                            ]
+                        }]
+                    }]
+                }, true);
+            }, 500);
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fixed the bug of running setOption twice in tree chart with different data

### Fixed issues

close #14858
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
Tree chart error when running setOption twice with different data

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

Using optional chains

And add one visual test

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/tree-setoption-twice.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
