### PR TITLE
group series and the user can specify format

### DIFF
--- a/test/dataView-axisCategory.html
+++ b/test/dataView-axisCategory.html
@@ -1,0 +1,108 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="//cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>
+        <link rel="stylesheet" href="//cdn.datatables.net/1.10.11/css/jquery.dataTables.min.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body>
+        <style>
+            html, body, #main {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+            #main {
+                background: #fff;
+            }
+        </style>
+        <div id="main"></div>
+        <script>
+
+            require(['echarts'], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main'));
+
+                var data = [];
+
+                for (var i = 0; i < 10; i++) {
+                    data.push([new Date(2021, 04, i), (Math.random() * 5), (Math.random() * 5)]);
+                }
+
+                console.log(data)
+
+                chart.setOption({
+                    toolbox: {
+                        // y: 'bottom',
+                        feature: {
+                            dataView: {
+                                categoryAxisFormatter: function(value) {
+                                    return new Date(value).toISOString();
+                                }
+                            },
+                            saveAsImage: {
+                                pixelRatio: 2
+                            }
+                        }
+                    },
+                    dataset: {
+                        source: data
+                    },
+                    xAxis: [
+                        {type: 'time', name: 'Time'}
+                    ],
+                    yAxis: [
+                        {type: 'value', name: 'Value 1'},
+                        {type: 'value', name: 'Value 2'}    
+                    ],
+                    series: [
+                        {
+                            type: 'bar',
+                            name: 'Value 1',
+                            yAxisIndex: 0,
+                            encode: {
+                                x: 'ts',
+                                y: 'value'
+                            }
+                        },
+                                                {
+                            type: 'bar',
+                            name: 'Value 2',
+                            yAxisIndex: 1,
+                            encode: {
+                                x: 'ts',
+                                y: 'value'
+                            }
+                        }
+
+                    ]
+                });
+
+                window.onresize = chart.resize;
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others


### What does this PR do?
You can specify the formatting and the series is grouped together i the DataView

## Details

### Before: What was the problem?
The dateformat is in Unix time. The data is also split between series.
![Screenshot from 2021-05-10 12-45-21](https://user-images.githubusercontent.com/788131/117657391-c9e0d600-b199-11eb-99b0-fefedc8797e3.png)



### After: How is it fixed in this PR?
You can specify the formatting and the series is grouped together.
![Screenshot from 2021-05-10 12-58-47](https://user-images.githubusercontent.com/788131/117657407-ccdbc680-b199-11eb-9518-d0f36f5df650.png)

In this screenshot the formatter is looking like this. 
```javascript
categoryAxisFormatter: function(value) {
  return new Date(value).toISOString();
}

```

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).

Added new option (`categoryAxisFormatter`) to `toolbox.feature.dataView`

### Related test cases or examples to use the new APIs

`test/dataView-axisCategory.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
