### PR TITLE
add string type to height for percent

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1046,7 +1046,7 @@ export interface TextCommonOption extends ShadowOptionMixin {
     padding?: number | number[]
 
     width?: number | string// Percent
-    height?: number
+    height?: number | string// Percent
     textBorderColor?: string
     textBorderWidth?: number
     textBorderType?: ZRLineType


### PR DESCRIPTION
https://github.com/apache/echarts/issues/14914

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

add type of string to height in TextCommonOption 

### Fixed issues

https://github.com/apache/echarts/issues/14914


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
height type is only number and cant accept percent 
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

I add string to fix this bug
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
