### PR TITLE
fix(tooltip): use kebab-case in transition property.

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -100,7 +100,7 @@ function assembleTransition(duration: number, onlyFade?: boolean): string {
     if (!onlyFade) {
         transitionOption = ` ${duration}s ${transitionCurve}`;
         transitionText += env.transformSupported
-            ? `,${TRANSFORM_VENDOR}${transitionOption}`
+            ? `,${CSS_TRANSFORM_VENDOR}${transitionOption}`
             : `,left${transitionOption},top${transitionOption}`;
     }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Use kebab-case in `transition` property.

`transition: webkitTransform ease 0.3s;` is not valid, use `transition: -webkit-transform ease 0.3s;` instead.


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
