### PR TITLE
fix: error thrown when resize is called after setOption called with lazyUpdate: true. fix #14846, fix #11395 .

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1160,13 +1160,23 @@ class ECharts extends Eventful<ECEventDefinition> {
             return;
         }
 
-        const optionChanged = ecModel.resetOption('media');
+        let needPrepare = ecModel.resetOption('media');
 
-        const silent = opts && opts.silent;
+        let silent = opts && opts.silent;
+
+        // There is some real cases that:
+        // chart.setOption(option, { lazyUpdate: true });
+        // chart.resize();
+        if (this[OPTION_UPDATED_KEY]) {
+            silent = silent || (this[OPTION_UPDATED_KEY] as any).silent;
+            needPrepare = true;
+            this[OPTION_UPDATED_KEY] = false;
+        }
 
         this[IN_MAIN_PROCESS_KEY] = true;
 
-        optionChanged && prepare(this);
+        needPrepare && prepare(this);
+
         updateMethods.update.call(this, {
             type: 'resize',
             animation: zrUtil.extend({

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1168,7 +1168,9 @@ class ECharts extends Eventful<ECEventDefinition> {
         // chart.setOption(option, { lazyUpdate: true });
         // chart.resize();
         if (this[OPTION_UPDATED_KEY]) {
-            silent = silent || (this[OPTION_UPDATED_KEY] as any).silent;
+            if (silent == null) {
+                silent = (this[OPTION_UPDATED_KEY] as any).silent;
+            }
             needPrepare = true;
             this[OPTION_UPDATED_KEY] = false;
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

fix: resize throw error. fix #14846, fix #11395 .

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


