### PR TITLE
test: fix old esl code in test

### DIFF
--- a/test/toolbox-custom.html
+++ b/test/toolbox-custom.html
@@ -23,11 +23,10 @@ under the License.
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="lib/esl.js"></script>
+        <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
         <script src="lib/facePrint.js"></script>
         <script src="lib/testHelper.js"></script>
-        <!-- <script src="ut/lib/canteen.js"></script> -->
         <link rel="stylesheet" href="lib/reset.css" />
     </head>
     <body>


### PR DESCRIPTION
loader has been changed from `esl.js` to `simpleRequire.js` in https://github.com/apache/echarts/pull/14894