### PR TITLE
feat(tree): add tree path info to tooltip

### DIFF
--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -113,14 +113,14 @@ export interface TreeSeriesOption extends
     data?: TreeSeriesNodeItemOption[]
 }
 
-interface TreePathInfo {
+export interface TreeAncestors {
     name: string
     dataIndex: number
     value: number
 }
 
-interface TreeSeriesCallbackDataParams extends CallbackDataParams {
-    treePathInfo?: TreePathInfo[]
+export interface TreeSeriesCallbackDataParams extends CallbackDataParams {
+    treeAncestors?: TreeAncestors[]
 }
 
 class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
@@ -240,7 +240,7 @@ class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
         const params = super.getDataParams.apply(this, arguments as any) as TreeSeriesCallbackDataParams;
 
         const node = this.getData().tree.getNodeByDataIndex(dataIndex);
-        params.treePathInfo = wrapTreePathInfo(node, this);
+        params.treeAncestors = wrapTreePathInfo(node, this);
 
         return params;
     }

--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -38,6 +38,7 @@ import View from '../../coord/View';
 import { LayoutRect } from '../../util/layout';
 import Model from '../../model/Model';
 import { createTooltipMarkup } from '../../component/tooltip/tooltipMarkup';
+import { wrapTreePathInfo } from '../helper/treeHelper';
 
 interface CurveLineStyleOption extends LineStyleOption{
     curveness?: number
@@ -110,6 +111,16 @@ export interface TreeSeriesOption extends
     leaves?: TreeSeriesLeavesOption
 
     data?: TreeSeriesNodeItemOption[]
+}
+
+interface TreePathInfo {
+    name: string
+    dataIndex: number
+    value: number
+}
+
+interface TreeSeriesCallbackDataParams extends CallbackDataParams {
+    treePathInfo?: TreePathInfo[]
 }
 
 class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
@@ -222,6 +233,16 @@ class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
             value: value,
             noValue: isNaN(value as number) || value == null
         });
+    }
+
+    // Add tree path to tooltip param
+    getDataParams(dataIndex: number) {
+        const params = super.getDataParams.apply(this, arguments as any) as TreeSeriesCallbackDataParams;
+
+        const node = this.getData().tree.getNodeByDataIndex(dataIndex);
+        params.treePathInfo = wrapTreePathInfo(node, this);
+
+        return params;
     }
 
     static defaultOption: TreeSeriesOption = {

--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -37,10 +37,13 @@ under the License.
         </style>
         <div id="main"></div>
         <script>
+            var formatUtil;
+
             require([
                 'echarts',
                 './data/flare.json'
             ], function (echarts, data) {
+                formatUtil = echarts.format;
                 var chart = echarts.init(document.getElementById('main'));
 
                 window.onresize = function () {
@@ -55,7 +58,21 @@ under the License.
 
                     tooltip: {
                         trigger: 'item',
-                        triggerOn: 'mousemove'
+                        triggerOn: 'mousemove',
+                        formatter: function (info) {
+                            var value = info.value;
+                            var treePathInfo = info.treePathInfo;
+                            var treePath = [];
+
+                            for (var i = 1; i < treePathInfo.length; i++) {
+                                treePath.push(treePathInfo[i].name);
+                            }
+
+                            return [
+                                '<div>' + formatUtil.encodeHTML(treePath.join('/')) + '</div>',
+                                value ? 'value: ' + formatUtil.addCommas(value) : '',
+                            ].join('');
+                        }
                     },
 
                     series:[

--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -61,11 +61,11 @@ under the License.
                         triggerOn: 'mousemove',
                         formatter: function (info) {
                             var value = info.value;
-                            var treePathInfo = info.treePathInfo;
+                            var treeAncestors = info.treeAncestors;
                             var treePath = [];
 
-                            for (var i = 1; i < treePathInfo.length; i++) {
-                                treePath.push(treePathInfo[i].name);
+                            for (var i = 1; i < treeAncestors.length; i++) {
+                                treePath.push(treeAncestors[i].name);
                             }
 
                             return [


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Add tree path info to the tooltip as Treemap.


### Fixed issues

<!--
- #xxxx: ...
-->
Fixes #8800 

## Details

### Before: What was the problem?
![image](https://user-images.githubusercontent.com/11830681/118394411-2bf87a00-b677-11eb-9620-bcd929ea10d8.png)

The path of the tooltip cannot be customized


### After: How is it fixed in this PR?
![image](https://user-images.githubusercontent.com/11830681/118394437-4df1fc80-b677-11eb-9206-dcb1ed20dac0.png)


<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

tree-basic.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
