### PR TITLE
refactor(radar):when obtaining the value of symbolType,"|| circle" is unreachable code

### DIFF
--- a/src/chart/radar/RadarView.ts
+++ b/src/chart/radar/RadarView.ts
@@ -56,7 +56,7 @@ class RadarView extends ChartView {
         const oldData = this._data;
 
         function createSymbol(data: List<RadarSeriesModel>, idx: number) {
-            const symbolType = data.getItemVisual(idx, 'symbol') as string || 'circle';
+            const symbolType = data.getItemVisual(idx, 'symbol') as string;
             if (symbolType === 'none') {
                 return;
             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

"|| circle" is unreachable code, './src/model/Series.ts' has initialized the defaultSymbol
```ts
static protoInitialize = (function () {
        const proto = SeriesModel.prototype;
        proto.type = 'series.__base__';
        proto.seriesIndex = 0;
        proto.useColorPaletteOnData = false;
        proto.ignoreStyleOnData = false;
        proto.hasSymbolVisual = false;
        proto.defaultSymbol = 'circle';
        // Make sure the values can be accessed!
        proto.visualStyleAccessPath = 'itemStyle';
        proto.visualDrawType = 'fill';
})();
```


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
```ts
function createSymbol(data: List<RadarSeriesModel>, idx: number) {
            const symbolType = data.getItemVisual(idx, 'symbol') as string || 'circle';
            ...
}
```



### After: How is it fixed in this PR?

```ts
function createSymbol(data: List<RadarSeriesModel>, idx: number) {
            const symbolType = data.getItemVisual(idx, 'symbol') as string;
            ...
}
```



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
