### PR TITLE
fix(label): ensure the label of the temporary symbol is in front of line and area polygon.

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -833,17 +833,20 @@ class LineView extends ChartView {
                 if (this._clipShapeForSymbol && !this._clipShapeForSymbol.contain(x, y)) {
                     return;
                 }
+                const zlevel = seriesModel.get('zlevel');
+                const z = seriesModel.get('z');
                 symbol = new SymbolClz(data, dataIndex);
                 symbol.x = x;
                 symbol.y = y;
-                symbol.setZ(
-                    seriesModel.get('zlevel'),
-                    seriesModel.get('z')
-                );
+                symbol.setZ(zlevel, z);
 
-                // ensure label text of the temporal symbol is on the top of line and area polygon
+                // ensure label text of the temporary symbol is in front of line and area polygon
                 const symbolLabel = symbol.getSymbolPath().getTextContent();
-                symbolLabel && (symbolLabel.z2 = this._polyline.z2 + 1);
+                if (symbolLabel) {
+                    symbolLabel.zlevel = zlevel;
+                    symbolLabel.z = z;
+                    symbolLabel.z2 = this._polyline.z2 + 1;
+                }
 
                 (symbol as SymbolExtended).__temp = true;
                 data.setItemGraphicEl(dataIndex, symbol);


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix the bug that the label of the temporary symbol is not in front of the line series and area polygon.

### Fixed issues

- #14541
- #14735

<!-- closes #14541 -->
<!-- closes #14735-->

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img src="https://user-images.githubusercontent.com/26999792/112712803-96f5c200-8f0c-11eb-91f2-e2a9304e45ab.png" alt="Demo 1" width="300">

<img src="https://user-images.githubusercontent.com/26999792/112712856-fbb11c80-8f0c-11eb-96ff-dcc0727f6e33.png" alt="Demo 2" width="300">



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img src="https://user-images.githubusercontent.com/26999792/118768148-3f8f2500-b8b1-11eb-9815-9041503f4bf3.png" alt="" width="300">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
