### PR TITLE
feat(tooltip):provide rich option to tooltip. close #12232 and #14136

### DIFF
--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -26,7 +26,7 @@ import Model from '../../model/Model';
 import ZRText, { TextStyleProps } from 'zrender/src/graphic/Text';
 import { TooltipMarkupStyleCreator, getPaddingFromTooltipModel } from './tooltipMarkup';
 import { throwError } from '../../util/log';
-
+import {createTextStyle} from '../../label/labelStyle';
 class TooltipRichContent {
 
     private _zr: ZRenderType;
@@ -85,29 +85,17 @@ class TooltipRichContent {
         }
 
         const textStyleModel = tooltipModel.getModel('textStyle');
-
-        this.el = new ZRText({
-            style: {
-                rich: markupStyleCreator.richTextStyles,
+        const mergeTextStyle = createTextStyle(textStyleModel, {
                 text: content as string,
-                lineHeight: 22,
                 backgroundColor: tooltipModel.get('backgroundColor'),
-                borderRadius: tooltipModel.get('borderRadius'),
-                borderWidth: 1,
+                borderWidth: tooltipModel.get('borderWidth'),
                 borderColor: borderColor as string,
-                shadowColor: tooltipModel.get('shadowColor'),
-                shadowBlur: tooltipModel.get('shadowBlur'),
-                shadowOffsetX: tooltipModel.get('shadowOffsetX'),
-                shadowOffsetY: tooltipModel.get('shadowOffsetY'),
-                textShadowColor: textStyleModel.get('textShadowColor'),
-                textShadowBlur: textStyleModel.get('textShadowBlur') || 0,
-                textShadowOffsetX: textStyleModel.get('textShadowOffsetX') || 0,
-                textShadowOffsetY: textStyleModel.get('textShadowOffsetY') || 0,
                 fill: tooltipModel.get(['textStyle', 'color']),
-                padding: getPaddingFromTooltipModel(tooltipModel, 'richText'),
-                verticalAlign: 'top',
-                align: 'left'
-            },
+                padding: getPaddingFromTooltipModel(tooltipModel, 'richText')
+            }, {disableBox: true});
+        mergeTextStyle.rich = {...mergeTextStyle.rich, ...markupStyleCreator.richTextStyles};
+        this.el = new ZRText({
+            style: mergeTextStyle,
             z: tooltipModel.get('z')
         });
         this._zr.add(this.el);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
like the option of  title.textStyle.rich , i add rich option to tooltip


### Fixed issues


- #12232: need rich option to set richText for tooltip
- #14136: tooltip with html not working on the H5 site created by uniapp


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
 textStyle  lineHeight/borderWidth...  is not available to tooltip
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

```
option = {
    xAxis: {
        type: 'category',
        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
    },
    yAxis: {
        type: 'value'
    },
    series: [{
        data: [150, 230, 224, 218, 135, 147, 260],
        type: 'line',
        
    }],
    tooltip:{
            show:true,
            textStyle:{
                borderWidth:20,
                lineHeight: 56,
            }
        }
};
```


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
By imitating the textStyle setting of title, I use the 'createTextStyle' function to generate ZRText style
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
```
option = {
    xAxis: {
        type: 'category',
        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
    },
    yAxis: {
        type: 'value'
    },
    series: [{
        data: [150, 230, 224, 218, 135, 147, 260],
        type: 'line',
        
    }],
    tooltip:{
            trigger: "axis",
                formatter: function (params) {
                    return `{abg|${params[0].value}},123`;
                },
                textStyle: {
                    lineHeight: 100,
                    color: "#ff0000",
                    rich: {
                        abg: {
                            color: "#ff00ff",
                            fontStyle: "italic",
                            fontWeight: "bold",
                            fontFamily: "Microsoft YaHei",
                            fontSize: 20,
                            lineHeight: 56,
                            width: 100,
                            height: 90,
                            textBorderColor: "red",
                        },
                    },
                },
        }
};
```


