### PR TITLE
fix(endLabel): endLabel should be displayed if show is true 

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -55,6 +55,7 @@ interface ExtraStateOption {
 export interface LineStateOption {
     itemStyle?: ItemStyleOption
     label?: SeriesLabelOption
+    endLabel?: LineEndLabelOption
 }
 
 export interface LineDataItemOption extends SymbolOptionMixin,

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -413,12 +413,12 @@ function getIndexRange(points: ArrayLike<number>, xOrY: number, dim: 'x' | 'y') 
 }
 
 function anyStateShowEndLabel(
-    endLabelModel: Model<LineEndLabelOption>, seriesModel: LineSeriesModel
+    seriesModel: LineSeriesModel
 ) {
-    if (endLabelModel.get('show')) {
+    if (seriesModel.get(['endLabel', 'show'])) {
         return true;
     }
-    for (let i = 0; i < DISPLAY_STATES.length; i++) {
+    for (let i = 0; i < SPECIAL_STATES.length; i++) {
         if (seriesModel.get([SPECIAL_STATES[i], 'endLabel', 'show'])) {
             return true;
         }
@@ -446,7 +446,7 @@ function createLineClipPath(
 
         const labelAnimationRecord: EndLabelAnimationRecord = { lastFrameIndex: 0 };
 
-        const during = anyStateShowEndLabel(endLabelModel, seriesModel)
+        const during = anyStateShowEndLabel(seriesModel)
             ? (percent: number, clipRect: graphic.Rect) => {
                 lineView._endLabelOnDuring(
                     percent,
@@ -1068,7 +1068,7 @@ class LineView extends ChartView {
     ) {
         const endLabelModel = seriesModel.getModel('endLabel');
 
-        if (anyStateShowEndLabel(endLabelModel, seriesModel)) {
+        if (anyStateShowEndLabel(seriesModel)) {
             const data = seriesModel.getData();
             const polyline = this._polyline;
             let endLabel = this._endLabel;

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -48,7 +48,7 @@ import type {
 import type OrdinalScale from '../../scale/Ordinal';
 import type Axis2D from '../../coord/cartesian/Axis2D';
 import { CoordinateSystemClipArea, isCoordinateSystemType } from '../../coord/CoordinateSystem';
-import { setStatesStylesFromModel, setStatesFlag, enableHoverEmphasis } from '../../util/states';
+import { setStatesStylesFromModel, setStatesFlag, enableHoverEmphasis, DISPLAY_STATES, SPECIAL_STATES } from '../../util/states';
 import Model from '../../model/Model';
 import {setLabelStyle, getLabelStatesModels, labelInner} from '../../label/labelStyle';
 import {getDefaultLabel, getDefaultInterpolatedLabel} from '../helper/labelHelper';
@@ -415,10 +415,15 @@ function getIndexRange(points: ArrayLike<number>, xOrY: number, dim: 'x' | 'y') 
 function anyStateShowEndLabel(
     endLabelModel: Model<LineEndLabelOption>, seriesModel: LineSeriesModel
 ) {
-    return endLabelModel.get('show')
-        || seriesModel.get(['emphasis', 'endLabel', 'show'])
-        || seriesModel.get(['blur', 'endLabel', 'show'])
-        || seriesModel.get(['select', 'endLabel', 'show']);
+    if (endLabelModel.get('show')) {
+        return true;
+    }
+    for (let i = 0; i < DISPLAY_STATES.length; i++) {
+        if (seriesModel.get([SPECIAL_STATES[i], 'endLabel', 'show'])) {
+            return true;
+        }
+    }
+    return false;
 }
 
 

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -29,7 +29,7 @@ import {ECPolyline, ECPolygon} from './poly';
 import ChartView from '../../view/Chart';
 import {prepareDataCoordInfo, getStackedOnPoint} from './helper';
 import {createGridClipPath, createPolarClipPath} from '../helper/createClipPathFromCoordSys';
-import LineSeriesModel, { LineSeriesOption } from './LineSeries';
+import LineSeriesModel, { LineEndLabelOption, LineSeriesOption } from './LineSeries';
 import type GlobalModel from '../../model/Global';
 import type ExtensionAPI from '../../core/ExtensionAPI';
 // TODO
@@ -412,6 +412,15 @@ function getIndexRange(points: ArrayLike<number>, xOrY: number, dim: 'x' | 'y') 
     };
 }
 
+function anyStateShowEndLabel(
+    endLabelModel: Model<LineEndLabelOption>, seriesModel: LineSeriesModel
+) {
+    return endLabelModel.get('show')
+        || seriesModel.get(['emphasis', 'endLabel', 'show'])
+        || seriesModel.get(['blur', 'endLabel', 'show'])
+        || seriesModel.get(['select', 'endLabel', 'show']);
+}
+
 
 interface EndLabelAnimationRecord {
     lastFrameIndex: number
@@ -427,13 +436,12 @@ function createLineClipPath(
 ) {
     if (isCoordinateSystemType<Cartesian2D>(coordSys, 'cartesian2d')) {
         const endLabelModel = seriesModel.getModel('endLabel');
-        const showEndLabel = endLabelModel.get('show');
         const valueAnimation = endLabelModel.get('valueAnimation');
         const data = seriesModel.getData();
 
         const labelAnimationRecord: EndLabelAnimationRecord = { lastFrameIndex: 0 };
 
-        const during = showEndLabel
+        const during = anyStateShowEndLabel(endLabelModel, seriesModel)
             ? (percent: number, clipRect: graphic.Rect) => {
                 lineView._endLabelOnDuring(
                     percent,
@@ -1055,7 +1063,7 @@ class LineView extends ChartView {
     ) {
         const endLabelModel = seriesModel.getModel('endLabel');
 
-        if (endLabelModel.get('show')) {
+        if (anyStateShowEndLabel(endLabelModel, seriesModel)) {
             const data = seriesModel.getData();
             const polyline = this._polyline;
             let endLabel = this._endLabel;

--- a/test/line-endLabel.html
+++ b/test/line-endLabel.html
@@ -36,7 +36,7 @@ under the License.
                 height: 1000px;
                 margin-bottom: 30px;
             }
-            #main2 {
+            #main2, #main3 {
                 width: 100%;
                 height: 300px;
                 margin-bottom: 30px;
@@ -128,6 +128,8 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
+
         <script>
 
             require([
@@ -383,6 +385,48 @@ under the License.
                     }],
                     animationDuration: 10000,
                     animationDurationUpdate: 500
+                };
+                chart.setOption(option);
+
+            })
+
+        </script>
+
+        <script>
+
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main3'));
+                var option = {
+                    title: [{
+                        text: 'Emphasis on the data at "b" and endLabel should be displayed',
+                        textAlign: 'center',
+                        left: '50%',
+                        top: 0
+                    }],
+                    xAxis: [{
+                        data: ['a', 'b']
+                    }],
+                    yAxis: [{
+                    }],
+                    series: [{
+                        type: 'line',
+                        data: [1, 2],
+                        endLabel: {
+                            // show: true,
+                            formatter: '{a}: {c}'
+                        },
+                        emphasis: {
+                            endLabel: {
+                                show: true,
+                                color: 'red'
+                            }
+                        }
+                    }],
+                    animationDuration: 0
                 };
                 chart.setOption(option);
 


### PR DESCRIPTION
fix(endLabel): endLabel should be displayed if show is true in other states #14441

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

If `endLabel.show` is `false`, endLabel will not show on emphasis even when there is `emphasis.endLabel.show: true`.

### Fixed issues


- #14441: emphasis endlabel does not work



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

End label not show on emphasis

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

End label show on emphasis


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
