### PR TITLE
fix default colors for candlesticks

### DIFF
--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -112,14 +112,17 @@ class CandlestickSeriesModel extends SeriesModel<CandlestickSeriesOption> {
         clip: true,
 
         itemStyle: {
-            color: '#eb5454', // positive
-            color0: '#47b262', // negative
-            borderColor: '#eb5454',
-            borderColor0: '#47b262',
-            // borderColor: '#d24040',
-            // borderColor0: '#398f4f',
+            color: '#47b262', // positive
+            color0: '#eb5454', // negative
+            borderColor: '#47b262',
+            borderColor0: '#eb5454',
+            // borderColor: '#398f4f',
+            // borderColor0: '#d24040',
             borderWidth: 1
         },
+        
+        itemStyle: {
+        }
 
         emphasis: {
             scale: true,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fixes what appears to be a typo in the default colors for candlesticks that cause them to be reversed to what's normal and the comments in the code itself

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
 https://github.com/apache/echarts/issues/15100 - this pr removes the bug found in this issue making the rest of it into a feature request

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
- When the close was higher than the open, the default color was red 
- When the close was lower than the open, the default color was green
- this is reverse of every normal graph and *even opposite of the comments in the code*

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/15305612/121058051-8ae87500-c785-11eb-80cd-e4db9e63380c.png)



### After: How is it fixed in this PR?
default itemstyle is altered

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/15305612/121058221-b8cdb980-c785-11eb-8d27-66da08290f33.png)



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
