### PR TITLE
fix: pie chart's label padding top & padding bottom attribute not work

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -252,10 +252,11 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
             // Works only position is 'outer' and alignTo is not 'edge'.
             bleedMargin: 10,
             // Distance between text and label line.
-            distanceToLabelLine: 5
+            distanceToLabelLine: 5,
             // formatter: 标签文本格式器，同Tooltip.formatter，不支持异步回调
             // 默认使用全局文本样式，详见TEXTSTYLE
             // distance: 当position为inner时有效，为label位置到圆心的距离与圆半径(环状图为内外半径和)的比例系数
+            verticalAlign: 'middle'
         },
         // Enabled when label.normal.position is 'outer'
         labelLine: {

--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -367,10 +367,6 @@ export default function pieLabelLayout(
         label.y = textY;
         label.rotation = labelRotate;
 
-        label.setStyle({
-            verticalAlign: 'middle'
-        });
-
         // Not sectorShape the inside label
         if (!isLabelInside) {
             const textRect = label.getBoundingRect().clone();

--- a/test/pie-label-padding.html
+++ b/test/pie-label-padding.html
@@ -1,0 +1,104 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body>
+        <style>
+            h1 {
+                line-height: 60px;
+                height: 60px;
+                background: #146402;
+                text-align: center;
+                font-weight: bold;
+                color: #eee;
+                font-size: 14px;
+            }
+            .chart {
+                height: 600px;
+            }
+        </style>
+
+        <div id="main" class="chart"></div>
+        <script>
+            require(["echarts"], function (echarts) {
+                var chart = echarts.init(document.getElementById("main"));
+
+                chart.setOption({
+                    aria: {
+                        enabled: true,
+                    },
+                    title: {
+                        text: `The label padding attribute should be respected`,
+                        x: "center",
+                    },
+                    tooltip: {
+                        trigger: "item",
+                        formatter: "{a} <br/>{b} : {c} ({d}%)",
+                    },
+                    legend: {
+                        orient: "vertical",
+                        left: "left",
+                        data: [
+                            "直接访问",
+                            "邮件营销",
+                            "联盟广告",
+                        ],
+                    },
+                    series: [
+                        {
+                            name: "访问来源",
+                            type: "pie",
+                            radius: "55%",
+                            center: ["50%", "60%"],
+                            selectedMode: "single",
+                            label: {
+                              verticalAlign: 'top',
+                              padding: [50, 50, 0, 50]
+                            },
+                            data: [
+                                { value: 335, name: "直接访问" },
+                                { value: 310, name: "邮件营销" },
+                                { value: 234, name: "联盟广告" },
+                            ],
+                            emphasis: {
+                                itemStyle: {
+                                    shadowBlur: 10,
+                                    shadowOffsetX: 0,
+                                    shadowColor: "rgba(0, 0, 0, 0.5)",
+                                },
+                            },
+                        },
+                    ],
+                });
+
+                chart.on("pieselectchanged", function (e) {
+                    console.log(e);
+                });
+
+                window.onresize = chart.resize;
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues


- #14879 



## Details

Seems like a [previous commit](https://github.com/apache/echarts/commit/c5dc732c797ebdc2ca1c86c7005a8e4f693d0539#diff-1e5adccab43aa7a33469251b12bb3ae79a3e71da5f5a6f0be0b248f69c7a1d58) introduce this issue #14879, the user-configured `verticalAlign` attribute is overridden;
I moved the default `verticalAlign: 'middle'` to PieSeries‘s default config to solve this issue;


### Before: What was the problem?

config:
```javascript
      label: {
        verticalAlign: 'top',
        padding: [50, 50, 0, 50]
      },
```

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/10973821/121153387-99638900-c878-11eb-8f5b-42943baf63e1.png)


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

config:
```javascript
      label: {
        verticalAlign: 'top',
        padding: [50, 50, 0, 50]
      },
```

![image](https://user-images.githubusercontent.com/10973821/121153293-82bd3200-c878-11eb-8cd7-bfc468b229da.png)



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
