### PR TITLE
fix(pie): change the default borderJoin to `round`

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -274,7 +274,8 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
             }
         },
         itemStyle: {
-            borderWidth: 1
+            borderWidth: 1,
+            borderJoin: 'round'
         },
 
         labelLayout: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

v5 doesn't set the default value for the border of the sector. To fix #15021, the PR is intended to change the default `borderJoin` to `round`. (Note that v4 uses `bevel` as the default value).

### Fixed issues

- #15021


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
