### PR TITLE
fix: hovered tooltip not update when options' series data changed

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -958,10 +958,7 @@ class TooltipView extends ComponentView {
                 // check is cbParams data value changed
                 lastCbParamsList && zrUtil.each(lastItem.seriesDataIndices, (idxItem) => {
                     const cbParams = cbParamsList[idxItem.seriesIndex];
-                    if (!cbParams) {
-                        return;
-                    }
-                    if (lastCbParamsList[idxItem.seriesIndex].data !== cbParams.data) {
+                    if (cbParams && lastCbParamsList[idxItem.seriesIndex].data !== cbParams.data) {
                         contentNotChanged = false;
                     }
                 });

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -957,7 +957,10 @@ class TooltipView extends ComponentView {
 
                 // check is cbParams data value changed
                 lastCbParamsList && zrUtil.each(lastItem.seriesDataIndices, (idxItem) => {
-                    const cbParams = cbParamsList[idxItem.dataIndexInside];
+                    const cbParams = cbParamsList[idxItem.seriesIndex];
+                    if (!cbParams) {
+                        return;
+                    }
                     if (lastCbParamsList[idxItem.seriesIndex].data !== cbParams.data) {
                         contentNotChanged = false;
                     }

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -931,14 +931,13 @@ class TooltipView extends ComponentView {
         let contentNotChanged = !!lastCoordSys
             && lastCoordSys.length === dataByCoordSys.length;
 
-        const self = this;
-        contentNotChanged && each(lastCoordSys, function (lastItemCoordSys, indexCoordSys) {
+        contentNotChanged && each(lastCoordSys, (lastItemCoordSys, indexCoordSys) => {
             const lastDataByAxis = lastItemCoordSys.dataByAxis || [] as DataByAxis[];
             const thisItemCoordSys = dataByCoordSys[indexCoordSys] || {} as DataByCoordSys;
             const thisDataByAxis = thisItemCoordSys.dataByAxis || [] as DataByAxis[];
             contentNotChanged = contentNotChanged && lastDataByAxis.length === thisDataByAxis.length;
 
-            contentNotChanged && each(lastDataByAxis, function (lastItem, indexAxis) {
+            contentNotChanged && each(lastDataByAxis, (lastItem, indexAxis) => {
                 const thisItem = thisDataByAxis[indexAxis] || {} as DataByAxis;
                 const lastIndices = lastItem.seriesDataIndices || [] as DataIndex[];
                 const newIndices = thisItem.seriesDataIndices || [] as DataIndex[];
@@ -949,7 +948,7 @@ class TooltipView extends ComponentView {
                     && lastItem.axisId === thisItem.axisId
                     && lastIndices.length === newIndices.length;
 
-                contentNotChanged && each(lastIndices, function (lastIdxItem, j) {
+                contentNotChanged && each(lastIndices, (lastIdxItem, j) => {
                     const newIdxItem = newIndices[j];
                     contentNotChanged = contentNotChanged
                         && lastIdxItem.seriesIndex === newIdxItem.seriesIndex
@@ -958,8 +957,7 @@ class TooltipView extends ComponentView {
 
                 // check is cbParams data value changed
                 lastCbParamsList && zrUtil.each(lastItem.seriesDataIndices, (idxItem) => {
-                    const series = self._ecModel.getSeriesByIndex(idxItem.seriesIndex);
-                    const cbParams = series.getDataParams(idxItem.dataIndexInside) as TooltipCallbackDataParams;
+                    const cbParams = cbParamsList[idxItem.dataIndexInside];
                     if (lastCbParamsList[idxItem.seriesIndex].data !== cbParams.data) {
                         contentNotChanged = false;
                     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

### Fixed issues

https://github.com/apache/echarts/issues/15188

## Details

### Before: What was the problem?

Originally, when we update the series' data, the shown tooltip will not update until we move the mouse.


After fixing, the tooltip will update, like below:
(the series data changed in the background 2 seconds after tooltip shows)

![Jun-19-2021 21-40-17](https://user-images.githubusercontent.com/10973821/122644329-3ced4d00-d147-11eb-960a-eb84e046494a.gif)


### After: How is it fixed in this PR?

Originally the `TooltipView` only checks if the series data's size changed, if the user didn't change size but the value in-place, the tooltip will not update.


