### PR TITLE
chore(stack): remove stack only same sign

### DIFF
--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -121,18 +121,13 @@ function calculateStack(stackInfoList: StackInfo[]) {
                     const val = stackInfo.data.getByRawIndex(
                         stackInfo.stackResultDimension, stackedDataRawIndex
                     ) as number;
-
                     // Considering positive stack, negative stack and empty data
-                    if ((sum >= 0 && val > 0) // Positive stack
-                        || (sum <= 0 && val < 0) // Negative stack
-                    ) {
-                        // The sum should be as less as possible to be effected
-                        // by floating arithmetic problem. A wrong result probably
-                        // filtered incorrectly by axis min/max.
-                        sum = addSafe(sum, val);
-                        stackedOver = val;
-                        break;
-                    }
+                    // The sum should be as less as possible to be effected
+                    // by floating arithmetic problem. A wrong result probably
+                    // filtered incorrectly by axis min/max.
+                    sum = addSafe(sum, val);
+                    stackedOver = val;
+                    break;
                 }
             }
 

--- a/test/stack-area.html
+++ b/test/stack-area.html
@@ -40,6 +40,8 @@ under the License.
     <div id="main2" class="main"></div>
     <div id="main3" class="main"></div>
     <div id="main4" class="main"></div>
+    <div id="main5" class="main"></div>
+    <div id="main6" class="main"></div>
     <script>
 
         require(['echarts'], function (echarts) {
@@ -237,6 +239,152 @@ under the License.
                     }
                 ]
             };
+            chart.setOption(option)
+
+            chart = echarts.init(document.getElementById('main5'));
+
+            option = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {            // 坐标轴指示器，坐标轴触发有效
+                        type: 'shadow'        // 默认为直线，可选为：'line' | 'shadow'
+                    }
+                },
+                legend: {
+                    data: ['利润', '支出', '收入']
+                },
+                grid: {
+                    left: '3%',
+                    right: '4%',
+                    bottom: '3%',
+                    containLabel: true
+                },
+                xAxis: [
+                    {
+                        max: 500,
+                        type: 'value'
+                    }
+                ],
+                yAxis: [
+                    {
+                        data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                    }
+                ],
+                series: [
+                    {
+                        name: '支出',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true,
+                            position: 'left'
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [-120, -132, -101, -134, -190, -230, -210]
+                    },
+                    {
+                        name: '利润',
+                        type: 'bar',
+                        label: {
+                            show: true,
+                            position: 'inside'
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [200, 170, 240, 244, 200, 220, 210]
+                    },
+                    {
+                        name: '收入',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [320, 302, 341, 374, 390, 450, 420]
+                    },
+                ]
+            };
+
+            chart.setOption(option)
+
+            chart = echarts.init(document.getElementById('main6'));
+            option = {
+                legend: {
+                    data: ['利润', '支出', '收入', '预算']
+                },
+                yAxis: [
+                    {
+                        max: 800,
+                        type: 'value'
+                    }
+                ],
+                xAxis: [
+                    {
+                        type: 'category',
+                        data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                    }
+                ],
+                series: [
+                    {
+                        name: '预算',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true,
+                            position: 'left'
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [-210, -232, -151, -184, -230, -280, -270]
+                    },
+                    {
+                        name: '支出',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true,
+                            position: 'left'
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [-20, -132, -101, -134, -190, -230, -210]
+                    },
+                    {
+                        name: '利润',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true,
+                            position: 'inside'
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [200, 170, 240, 244, 200, 220, 210]
+                    },
+                    {
+                        name: '收入',
+                        type: 'bar',
+                        stack: '总量',
+                        label: {
+                            show: true
+                        },
+                        emphasis: {
+                            focus: 'series'
+                        },
+                        data: [320, 302, 341, 374, 390, 450, 420]
+                    },
+                ]
+            };
+
             chart.setOption(option)
 
 

--- a/test/stack-area.html
+++ b/test/stack-area.html
@@ -1,0 +1,248 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+</head>
+
+<body>
+    <style>
+        html,
+        body,
+        .main {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+    <div id="main1" class="main"></div>
+    <div id="main2" class="main"></div>
+    <div id="main3" class="main"></div>
+    <div id="main4" class="main"></div>
+    <script>
+
+        require(['echarts'], function (echarts) {
+
+            var chart = echarts.init(document.getElementById('main1'));
+            option = {
+                xAxis: [
+                    {
+                        type: 'category',
+                        // boundaryGap: false,
+                        data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                    }
+                ],
+                yAxis: [
+                    {
+                        type: 'value',
+                        min: 100
+                    }
+                ],
+                series: [
+                    {
+                        name: 'low',
+                        type: 'line',
+                        stack: '总量',
+                        areaStyle: {
+                        },
+                        data: [-150, 132, 101, 154, 190, 130, 110]
+                    },
+                    {
+                        name: 'up',
+                        type: 'line',
+                        stack: '总量',
+                        areaStyle: {
+                            origin: 'start'
+                        },
+                        data: [220, 182, 191, 234, 290, 330, 310]
+                    },
+                    {
+                        name: 'middle',
+                        type: 'line',
+                        stack: '总量',
+                        areaStyle: {
+                            // origin: 'start'
+                        },
+                        data: [240, 282, 291, 334, 390, 430, 410]
+                    },
+
+                ]
+            };
+            chart.setOption(option);
+
+            chart = echarts.init(document.getElementById('main2'));
+
+
+            option = {
+                title: {
+                    text: '堆叠区域图'
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'cross',
+                        label: {
+                            backgroundColor: '#6a7985'
+                        }
+                    }
+                },
+                legend: {
+                    data: ['今日值', 'up', 'low']
+                },
+                toolbox: {
+                    feature: {
+                        saveAsImage: {}
+                    }
+                },
+                grid: {
+                    left: '3%',
+                    right: '4%',
+                    bottom: '3%',
+                    containLabel: true
+                },
+                xAxis: [
+                    {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                    }
+                ],
+                yAxis: [
+                    {
+                        type: 'value',
+
+                    }
+                ],
+                series: [
+                    {
+                        name: 'low',
+                        type: 'line',
+                        stack: '总量',
+                        areaStyle: {
+                            color: 'transparent'
+                        },
+                        data: [-150, 132, 101, 154, 190, 130, 110]
+                    },
+                    {
+                        name: 'up',
+                        type: 'line',
+                        stack: '总量',
+                        areaStyle: {
+                            color: '',
+                            origin: 'start'
+                        },
+                        data: [220, 182, 191, 234, 290, 330, 310]
+                    },
+
+                ]
+            };
+
+            chart.setOption(option)
+
+
+            chart = echarts.init(document.getElementById('main3'));
+
+            option = {
+                xAxis: [
+                    {
+                        type: 'category',
+                        data: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    }
+                ],
+                yAxis: [
+                    {
+                        type: 'value'
+                    }
+                ],
+                series: [
+                    {
+                        name: 'stack',
+                        type: 'line',
+                        stack: 'stack',
+                        data: [3, 1, 2, -1, -3, 1, 3]
+                    },
+                    {
+                        name: 'stack',
+                        type: 'line',
+                        stack: 'stack',
+                        areaStyle: {},
+                        data: [1, 1, 1, 1, 1, 1, 1]
+                    }
+                ]
+            };
+
+            chart.setOption(option)
+
+
+            chart = echarts.init(document.getElementById('main4'));
+
+            option = {
+
+                grid: {
+                    left: '3%',
+                    right: '4%',
+                    bottom: '3%',
+                    containLabel: true
+                },
+                xAxis: [
+                    {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: [1, 2, 3, 4, 5]
+                    }
+                ],
+                yAxis: [
+                    {
+                        type: 'value'
+                    }
+                ],
+                series: [
+                    {
+                        type: 'line',
+                        stack: '1',
+                        data: [110, 120, 120, 101, 115]
+                    },
+                    {
+                        type: 'line',
+                        stack: '1',
+                        label: {
+                            normal: {
+                                show: true,
+                                position: 'top'
+                            }
+                        },
+                        areaStyle: { normal: {} },
+                        data: [134, 200, -20, 181, 143]
+                    }
+                ]
+            };
+            chart.setOption(option)
+
+
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

According @100pah comment in [9317](https://github.com/apache/echarts/issues/9317#issuecomment-434767874), ECharts  only stack those value with same sign.  I can't see why this rule was made, but seems this has cause a lot of question for `areaStyle` in `stacked` chart, also stack on different sign is reaonable for statistic.  So I tried to lift this limitation, and done some experiment under `line` and `bar`,  looks good for me. 


### Fixed issues

Close #9317 #9141 #13747 #15083 #14365

## Details

### Before: What was the problem?

<img width="1298" alt="Screen Shot 2021-06-23 at 12 17 46 AM" src="https://user-images.githubusercontent.com/20318608/122963070-885a6200-d3b8-11eb-8252-569e9bb168e2.png">
<img width="1395" alt="Screen Shot 2021-06-23 at 12 17 54 AM" src="https://user-images.githubusercontent.com/20318608/122963080-8a242580-d3b8-11eb-88e4-d7502d374c85.png">
<img width="911" alt="Screen Shot 2021-06-23 at 12 18 00 AM" src="https://user-images.githubusercontent.com/20318608/122963084-8abcbc00-d3b8-11eb-85f5-4e0199d83a43.png">
<img width="1410" alt="Screen Shot 2021-06-23 at 12 18 09 AM" src="https://user-images.githubusercontent.com/20318608/122963089-8b555280-d3b8-11eb-91e3-b3ecf04b3ce2.png">



### After: How is it fixed in this PR?

<img width="919" alt="Screen Shot 2021-06-23 at 12 16 06 AM" src="https://user-images.githubusercontent.com/20318608/122962752-4cbf9800-d3b8-11eb-8bd3-0ddc0850dbe1.png">
<img width="1375" alt="Screen Shot 2021-06-23 at 12 16 17 AM" src="https://user-images.githubusercontent.com/20318608/122962761-4f21f200-d3b8-11eb-8021-1de7b19434e0.png">
<img width="1249" alt="Screen Shot 2021-06-23 at 12 16 24 AM" src="https://user-images.githubusercontent.com/20318608/122962762-4fba8880-d3b8-11eb-950c-32131778ee1c.png">
<img width="1374" alt="Screen Shot 2021-06-23 at 12 18 44 AM" src="https://user-images.githubusercontent.com/20318608/122963281-b475e300-d3b8-11eb-9db4-97f1ee291763.png">





## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
