### PR TITLE
fix(types) export DataItem from LegendModel

### DIFF
--- a/src/component/legend/LegendModel.ts
+++ b/src/component/legend/LegendModel.ts
@@ -117,7 +117,7 @@ export interface LegendStyleOption {
     symbolRotate?: number | 'inherit'
 }
 
-interface DataItem extends LegendStyleOption {
+export interface DataItem extends LegendStyleOption {
     name?: string
     icon?: string
     textStyle?: LabelOption


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This PR export the DataItem interface from LegendModel.ts. I guess it was an oversight.


### Fixed issues

No issue opened


## Details

### Before: What was the problem?

Unable to fully use the type `LegendOption`


### After: How is it fixed in this PR?

I can use `DataItem` to describe the legends

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.

## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
