### PR TITLE
fix(pie/sunburst): fix `borderRadius` can't be reset in pie series and sunburst series when setting it to `null` or `undefined`

### DIFF
--- a/src/chart/helper/pieHelper.ts
+++ b/src/chart/helper/pieHelper.ts
@@ -24,11 +24,12 @@ import { parsePercent } from 'zrender/src/contain/text';
 
 export function getSectorCornerRadius(
     model: Model<{ borderRadius?: string | number | (string | number)[] }>,
-    shape: Pick<Sector['shape'], 'r0' | 'r'>
+    shape: Pick<Sector['shape'], 'r0' | 'r'>,
+    zeroIfNull?: boolean
 ) {
     let cornerRadius = model.get('borderRadius');
     if (cornerRadius == null) {
-        return null;
+        return zeroIfNull ? {innerCornerRadius: 0, cornerRadius: 0} : null;
     }
     if (!isArray(cornerRadius)) {
         cornerRadius = [cornerRadius, cornerRadius];

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -59,7 +59,7 @@ class PiePiece extends graphic.Sector {
         const itemModel = data.getItemModel<PieDataItemOption>(idx);
         const emphasisModel = itemModel.getModel('emphasis');
         const layout = data.getItemLayout(idx) as graphic.Sector['shape'];
-        // cornerRadius & innerCornerRadius may not exist in initial layout. Use `0` if null value is specified.
+        // cornerRadius & innerCornerRadius doesn't exist in the item layout. Use `0` if null value is specified.
         // see `setItemLayout` in `pieLayout.ts`.
         const sectorShape = extend(
             getSectorCornerRadius(itemModel.getModel('itemStyle'), layout, true),

--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -59,8 +59,10 @@ class PiePiece extends graphic.Sector {
         const itemModel = data.getItemModel<PieDataItemOption>(idx);
         const emphasisModel = itemModel.getModel('emphasis');
         const layout = data.getItemLayout(idx) as graphic.Sector['shape'];
+        // cornerRadius & innerCornerRadius may not exist in initial layout. Use `0` if null value is specified.
+        // see `setItemLayout` in `pieLayout.ts`.
         const sectorShape = extend(
-            getSectorCornerRadius(itemModel.getModel('itemStyle'), layout) || {},
+            getSectorCornerRadius(itemModel.getModel('itemStyle'), layout, true),
             layout
         );
 

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -99,7 +99,7 @@ class SunburstPiece extends graphic.Sector {
             normalStyle.decal = createOrUpdatePatternFromDecal(decal, api);
         }
 
-        const cornerRadius = getSectorCornerRadius(itemModel.getModel('itemStyle'), sectorShape);
+        const cornerRadius = getSectorCornerRadius(itemModel.getModel('itemStyle'), sectorShape, true);
         zrUtil.extend(sectorShape, cornerRadius);
 
         zrUtil.each(SPECIAL_STATES, function (stateName) {

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -981,7 +981,6 @@ function renderNode(
             }
         );
 
-        
         const textEl = rectEl.getTextContent();
         if (!textEl) {
             return;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the bug that `borderRadius` can't be reset in pie series and sunburst series when setting it to `null`.


### Fixed issues

- #15242


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`borderRadius` doesn't be removed when setting it to `null` or `undefined`.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Set `borderRadius` to `0` if it's `null` or `undefined`.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
