### PR TITLE
fix: root node related edge not removed when update data

### DIFF
--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -114,13 +114,13 @@ under the License.
                 });
 
                 setTimeout(function() {
-                    var newData = echarts.util.clone(data);
-                    newData.children.splice(0, 1);
+                    // replace root node
+                    var newData = [data.children[1]];
                     chart.setOption({
                         series: [{
                             type: 'tree',
                             id: '3',
-                            data: [newData]
+                            data: newData
                         }]
                     }, false);
                 }, 1000);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

https://github.com/apache/echarts/issues/15217


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![Jun-28-2021 16-37-52](https://user-images.githubusercontent.com/10973821/123606987-0b077500-d830-11eb-96d8-54790df34316.gif)


### After: How is it fixed in this PR?

The original logic misses the condition when the root node is changed to its child.
In this condition, the edge between the root node and its child node should be removed;

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![Jun-28-2021 16-40-13](https://user-images.githubusercontent.com/10973821/123607010-122e8300-d830-11eb-9ab7-5c24decba138.gif)



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
