### PR TITLE
fix(markpoint): value didn't show when coord specified

### DIFF
--- a/src/component/marker/markerHelper.ts
+++ b/src/component/marker/markerHelper.ts
@@ -165,6 +165,8 @@ export function dataTransform(
             }
             item.coord = coord;
         }
+    } else if (isArray(item.coord)) {
+        item.value = item.coord[1] as number;
     }
     return item;
 }

--- a/test/markPoint.html
+++ b/test/markPoint.html
@@ -101,6 +101,10 @@ under the License.
                                         xAxis: '类目3',
                                         yAxis: 0.5,
                                         value: 2
+                                    },
+                                    {
+                                        name: '指定 coord',
+                                        coord: [1, .9]
                                     }
                                 ]
                             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

When marker point was specified a `coord`, the value should be displayed on point.


### Fixed issues




## Details

### Before: What was the problem?

<img width="379" alt="Screen Shot 2021-06-29 at 11 00 24 PM" src="https://user-images.githubusercontent.com/20318608/123821543-1345da00-d92e-11eb-8685-8dcbbd9fa9a4.png">




### After: How is it fixed in this PR?

<img width="447" alt="Screen Shot 2021-06-29 at 10 59 55 PM" src="https://user-images.githubusercontent.com/20318608/123821570-193bbb00-d92e-11eb-98a0-20f0a5d513b0.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
