### PR TITLE
fix(dts): Wrong type for svg handling in .d.ts. close #15262

### DIFF
--- a/src/coord/geo/geoTypes.ts
+++ b/src/coord/geo/geoTypes.ts
@@ -23,8 +23,8 @@ import { Group } from '../../util/graphic';
 import { Region } from './Region';
 
 
-export type GeoSVGSourceInput = 'string' | Document | SVGElement;
-export type GeoJSONSourceInput = 'string' | GeoJSON | GeoJSONCompressed;
+export type GeoSVGSourceInput = string | Document | SVGElement;
+export type GeoJSONSourceInput = string | GeoJSON | GeoJSONCompressed;
 
 export interface NameMap {
     [regionName: string]: string


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Wrong type for svg handling

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
export type GeoSVGSourceInput = 'string' | Document | SVGElement;

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
export type GeoSVGSourceInput = string | Document | SVGElement;


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
