### PR TITLE
fix(type): there is no polarIndex when coordinate of series is polar

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1656,13 +1656,8 @@ export interface SeriesOnCartesianOptionMixin {
 }
 
 export interface SeriesOnPolarOptionMixin {
-    radiusAxisIndex?: number
-    angleAxisIndex?: number
-
-    radiusAxisId?: string
-    angleAxisId?: string
-
     polarIndex?: number
+    polarId?: string;
 }
 
 export interface SeriesOnSingleOptionMixin {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1661,6 +1661,8 @@ export interface SeriesOnPolarOptionMixin {
 
     radiusAxisId?: string
     angleAxisId?: string
+
+    polarIndex?: number
 }
 
 export interface SeriesOnSingleOptionMixin {


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
添加一个类型
<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
close #15197
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
#15197
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
在SeriesOnPolarOptionMixin添加了类型polarIndex?: number
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
