### PR TITLE
fix(treemap): remove old nodes on disabled animation

### DIFF
--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -202,9 +202,11 @@ class TreemapView extends ChartView {
             : null;
 
         const containerGroup = this._giveContainerGroup(layoutInfo);
+        const hasAnimation = seriesModel.get('animation');
 
         const renderResult = this._doRender(containerGroup, seriesModel, reRoot);
         (
+            hasAnimation &&
             !isInit && (
                 !payloadType
                 || payloadType === 'treemapZoomToNode'
@@ -357,11 +359,6 @@ class TreemapView extends ChartView {
         seriesModel: TreemapSeriesModel,
         reRoot: ReRoot
     ) {
-        if (!seriesModel.get('animation')) {
-            renderResult.renderFinally();
-            return;
-        }
-
         const durationOption = seriesModel.get('animationDurationUpdate');
         const easingOption = seriesModel.get('animationEasing');
         // TODO: do not support function until necessary.

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -358,6 +358,7 @@ class TreemapView extends ChartView {
         reRoot: ReRoot
     ) {
         if (!seriesModel.get('animation')) {
+            renderResult.renderFinally();
             return;
         }
 

--- a/test/treemap-setOption-twice-noAnimation.html
+++ b/test/treemap-setOption-twice-noAnimation.html
@@ -1,0 +1,121 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+</head>
+
+<body>
+    <style>
+        html,
+        body,
+        #main {
+            width: 100%;
+            padding: 0;
+            margin: 0;
+            height: 100%;
+        }
+    </style>
+    <div id="main"></div>
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var chart = echarts.init(document.getElementById('main'), null, {
+
+            });
+
+            chart.setOption({
+                series: [
+                    {
+                        type: 'treemap',
+                        animation: false,
+                        data: [
+                            {
+                                name: 'nodeA', // First tree
+                                value: 10,
+                                children: [
+                                    {
+                                        name: 'nodeAa', // First leaf of first tree
+                                        value: 4,
+                                    },
+                                    {
+                                        name: 'nodeAb', // Second leaf of first tree
+                                        value: 6,
+                                    },
+                                ],
+                            },
+                            {
+                                name: 'nodeB', // Second tree
+                                value: 20,
+                                children: [
+                                    {
+                                        name: 'nodeBa', // Son of first tree
+                                        value: 20,
+                                        children: [
+                                            {
+                                                name: 'nodeBa1', // Granson of first tree
+                                                value: 20,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            setTimeout(function () {
+                chart.setOption({
+                    series: [
+                        {
+                            type: 'treemap',
+                            animation: false,
+                            data: [
+                                {
+                                    name: 'nodeA', // First tree
+                                    value: 10,
+                                    children: [
+                                        {
+                                            name: 'nodeAa', // First leaf of first tree
+                                            value: 4,
+                                        },
+                                        {
+                                            name: 'nodeAb', // Second leaf of first tree
+                                            value: 6,
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                    true);
+            }, 500);
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
When `animation` is set to `false` on `treemap`, `renderFinally()` isn't called when calling `setOption` for the second time.

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

This PR makes sure `renderFinally()` is always called even if `animation` is disabled.

### Fixed issues

- closes #15282 

## Details

### Before: What was the problem?
In this screenshot, Alexia and Beth should have been removed (they were present in the first option, but were removed in the second option):
![image](https://user-images.githubusercontent.com/33317356/124269656-d81cf400-db43-11eb-9d63-8b1692202b3b.png)

### After: How is it fixed in this PR?
After the change, the names are removed correctly when calling `setOption` again.
![image](https://user-images.githubusercontent.com/33317356/124269711-ea972d80-db43-11eb-994e-b6110cb3a796.png)

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
