### PR TITLE
fix(coord): fix coord dimension undefined for 3rd libs

### DIFF
--- a/src/coord/geo/Geo.ts
+++ b/src/coord/geo/Geo.ts
@@ -44,10 +44,12 @@ const GEO_DEFAULT_PARAMS: {
     }
 } as const;
 
+export const geo2DDimensions = ['lng', 'lat'];
+
 
 class Geo extends View {
 
-    dimensions = ['lng', 'lat'];
+    dimensions = geo2DDimensions;
 
     type = 'geo';
 

--- a/src/coord/geo/geoCreator.ts
+++ b/src/coord/geo/geoCreator.ts
@@ -18,7 +18,7 @@
 */
 
 import * as zrUtil from 'zrender/src/core/util';
-import Geo from './Geo';
+import Geo, { geo2DDimensions } from './Geo';
 import * as layout from '../../util/layout';
 import * as numberUtil from '../../util/number';
 import geoSourceManager from './geoSourceManager';
@@ -130,7 +130,7 @@ function setGeoCoords(geo: Geo, model: MapSeries) {
 class GeoCreator implements CoordinateSystemCreator {
 
     // For deciding which dimensions to use when creating list data
-    dimensions = Geo.prototype.dimensions;
+    dimensions = geo2DDimensions;
 
     create(ecModel: GlobalModel, api: ExtensionAPI): Geo[] {
         const geoList = [] as Geo[];

--- a/src/coord/polar/Polar.ts
+++ b/src/coord/polar/Polar.ts
@@ -26,6 +26,8 @@ import { ParsedModelFinder, ParsedModelFinderKnown } from '../../util/model';
 import { ScaleDataValue } from '../../util/types';
 import ExtensionAPI from '../../core/ExtensionAPI';
 
+export const polarDimensions = ['radius', 'angle'];
+
 interface Polar {
     update(ecModel: GlobalModel, api: ExtensionAPI): void
 }
@@ -33,7 +35,7 @@ class Polar implements CoordinateSystem, CoordinateSystemMaster {
 
     readonly name: string;
 
-    readonly dimensions = ['radius', 'angle'];
+    readonly dimensions = polarDimensions;
 
     readonly type = 'polar';
 

--- a/src/coord/polar/polarCreator.ts
+++ b/src/coord/polar/polarCreator.ts
@@ -20,7 +20,7 @@
 // TODO Axis scale
 
 import * as zrUtil from 'zrender/src/core/util';
-import Polar from './Polar';
+import Polar, { polarDimensions } from './Polar';
 import {parsePercent} from '../../util/number';
 import {
     createScaleByModel,
@@ -132,7 +132,7 @@ function setAxis(axis: RadiusAxis | AngleAxis, axisModel: PolarAxisModel) {
 
 const polarCreator = {
 
-    dimensions: Polar.prototype.dimensions,
+    dimensions: polarDimensions,
 
     create: function (ecModel: GlobalModel, api: ExtensionAPI) {
         const polarList: Polar[] = [];

--- a/src/coord/single/Single.ts
+++ b/src/coord/single/Single.ts
@@ -33,6 +33,7 @@ import SingleAxisModel from './AxisModel';
 import { ParsedModelFinder, ParsedModelFinderKnown } from '../../util/model';
 import { ScaleDataValue } from '../../util/types';
 
+export const singleDimensions = ['single'];
 /**
  * Create a single coordinates system.
  */
@@ -44,7 +45,7 @@ class Single implements CoordinateSystem, CoordinateSystemMaster {
     /**
      * Add it just for draw tooltip.
      */
-    readonly dimensions = ['single'];
+    readonly dimensions = singleDimensions;
 
     name: string;
 

--- a/src/coord/single/singleCreator.ts
+++ b/src/coord/single/singleCreator.ts
@@ -21,7 +21,7 @@
  * Single coordinate system creator.
  */
 
-import Single from './Single';
+import Single, { singleDimensions } from './Single';
 import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import SingleAxisModel from './AxisModel';
@@ -62,7 +62,7 @@ function create(ecModel: GlobalModel, api: ExtensionAPI) {
 
 const singleCreator = {
     create: create,
-    dimensions: Single.prototype.dimensions
+    dimensions: singleDimensions
 };
 
 export default singleCreator;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Currently `echarts.getCoordinateSystemDimensions` will have error because the dimensions property is undefined in most of the coordinate systems since 5.0 refactoring. It will break 3rd lib like echarts-gl