### PR TITLE
fix(type): there is no function 'clampData' error in 'getMarkerPosition' 

### DIFF
--- a/src/chart/bar/BaseBarSeries.ts
+++ b/src/chart/bar/BaseBarSeries.ts
@@ -84,7 +84,7 @@ class BaseBarSeriesModel<Opts extends BaseBarSeriesOption<unknown> = BaseBarSeri
 
     getMarkerPosition(value: ScaleDataValue[]) {
         const coordSys = this.coordinateSystem;
-        if (coordSys) {
+        if (coordSys && coordSys.clampData) {
             // PENDING if clamp ?
             const pt = coordSys.dataToPoint(coordSys.clampData(value));
             const data = this.getData();


### PR DESCRIPTION
fix no function 'clampData' error in 'getMarkerPosition'  method of BaseBarSeriesModel

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fix no function 'clampData' error in 'getMarkerPosition'  method of BaseBarSeriesModel

### Fixed issues

[Issues 15109](https://github.com/apache/echarts/issues/15109)


## Details

### Before: What was the problem?

In that example will generate an error message of 'clampData is not a function'


### After: How is it fixed in this PR?

Add an additonal judgement on 'clampData'


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
