### PR TITLE
fix(bar): set label to be inside when position is middle

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -982,6 +982,9 @@ function updateStyle(
 
     if (isPolar) {
         const position = seriesModel.get(['label', 'position']);
+        if (position === 'middle') {
+            el.textConfig.inside = true;
+        }
         setSectorTextRotation(
             el as Sector,
             position === 'outside' ? labelPositionOutside : position,

--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -981,15 +981,13 @@ function updateStyle(
     );
 
     if (isPolar) {
-        const position = seriesModel.get(['label', 'position']);
-        if (position === 'middle') {
-            el.textConfig.inside = true;
-        }
+        const position = itemModel.get(['label', 'position']);
+        el.textConfig.inside = position === 'middle' ? true : null;
         setSectorTextRotation(
             el as Sector,
             position === 'outside' ? labelPositionOutside : position,
             createPolarPositionMapping(isHorizontalOrRadial),
-            seriesModel.get(['label', 'rotate'])
+            itemModel.get(['label', 'rotate'])
         );
     }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

#15182 enables user to set the polar bar labels to be `'middle'`. But color may not have enough contrast to the background. In this PR, we set the text to be `inside` when position is `'middle'` for polar bars.

### Before

![image](https://user-images.githubusercontent.com/779050/124858397-8b706780-dfe0-11eb-9c87-8337bb10d1aa.png)

### After

![image](https://user-images.githubusercontent.com/779050/124858329-6a0f7b80-dfe0-11eb-9f2c-a7c05c0b7ca6.png)

