### PR TITLE
fix(tooltip): tooltip should show DOM content instead of the string [object HTMLSpanElement]

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -403,7 +403,10 @@ class TooltipHTMLContent {
         borderColor?: ZRColor,
         arrowPosition?: TooltipOption['position']
     ) {
+        const el = this.el;
+
         if (content == null) {
+            el.innerHTML = '';
             return;
         }
 
@@ -412,7 +415,6 @@ class TooltipHTMLContent {
             && !shouldTooltipConfine(tooltipModel)) {
             arrow = assembleArrow(tooltipModel.get('backgroundColor'), borderColor, arrowPosition);
         }
-        const el = this.el;
         if (isString(content)) {
             el.innerHTML = content + arrow;
         }

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -397,7 +397,7 @@ class TooltipHTMLContent {
     }
 
     setContent(
-        content: string | HTMLElement[],
+        content: string | HTMLElement | HTMLElement[],
         markers: unknown,
         tooltipModel: Model<TooltipOption>,
         borderColor?: ZRColor,
@@ -407,14 +407,14 @@ class TooltipHTMLContent {
             return;
         }
 
-        const el = this.el;
-
+        let arrow = '';
         if (isString(arrowPosition) && tooltipModel.get('trigger') === 'item'
             && !shouldTooltipConfine(tooltipModel)) {
-            content += assembleArrow(tooltipModel.get('backgroundColor'), borderColor, arrowPosition);
+            arrow = assembleArrow(tooltipModel.get('backgroundColor'), borderColor, arrowPosition);
         }
+        const el = this.el;
         if (isString(content)) {
-            el.innerHTML = content;
+            el.innerHTML = content + arrow;
         }
         else if (content) {
             // Clear previous
@@ -426,6 +426,14 @@ class TooltipHTMLContent {
                 if (isDom(content[i]) && content[i].parentNode !== el) {
                     el.appendChild(content[i]);
                 }
+            }
+            // no arrow if empty
+            if (arrow && el.childNodes.length) {
+                // no need to create a new parent element, but it's not supported by IE 10 and older.
+                // const arrowEl = document.createRange().createContextualFragment(arrow);
+                const arrowEl = document.createElement('div');
+                arrowEl.innerHTML = arrow;
+                el.appendChild(arrowEl);
             }
         }
     }

--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -71,7 +71,7 @@ class TooltipRichContent {
      * Set tooltip content
      */
     setContent(
-        content: string | HTMLElement[],
+        content: string | HTMLElement | HTMLElement[],
         markupStyleCreator: TooltipMarkupStyleCreator,
         tooltipModel: Model<TooltipOption>,
         borderColor: ZRColor,

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -784,7 +784,7 @@ class TooltipView extends ComponentView {
 
         const formatter = tooltipModel.get('formatter');
         positionExpr = positionExpr || tooltipModel.get('position');
-        let html: string | HTMLElement[] = defaultHtml;
+        let html: string | HTMLElement | HTMLElement[] = defaultHtml;
         const nearPoint = this._getNearestPoint(
             [x, y],
             params,
@@ -793,27 +793,32 @@ class TooltipView extends ComponentView {
         );
         const nearPointColor = nearPoint.color;
 
-        if (formatter && zrUtil.isString(formatter)) {
-            const useUTC = tooltipModel.ecModel.get('useUTC');
-            const params0 = zrUtil.isArray(params) ? params[0] : params;
-            const isTimeAxis = params0 && params0.axisType && params0.axisType.indexOf('time') >= 0;
-            html = formatter;
-            if (isTimeAxis) {
-                html = timeFormat(params0.axisValue, html, useUTC);
-            }
-            html = formatUtil.formatTpl(html, params, true);
-        }
-        else if (zrUtil.isFunction(formatter)) {
-            const callback = bind(function (cbTicket: string, html: string | HTMLElement[]) {
-                if (cbTicket === this._ticket) {
-                    tooltipContent.setContent(html, markupStyleCreator, tooltipModel, nearPointColor, positionExpr);
-                    this._updatePosition(
-                        tooltipModel, positionExpr, x, y, tooltipContent, params, el
-                    );
+        if (formatter) {
+            if (zrUtil.isString(formatter)) {
+                const useUTC = tooltipModel.ecModel.get('useUTC');
+                const params0 = zrUtil.isArray(params) ? params[0] : params;
+                const isTimeAxis = params0 && params0.axisType && params0.axisType.indexOf('time') >= 0;
+                html = formatter;
+                if (isTimeAxis) {
+                    html = timeFormat(params0.axisValue, html, useUTC);
                 }
-            }, this);
-            this._ticket = asyncTicket;
-            html = formatter(params, asyncTicket, callback);
+                html = formatUtil.formatTpl(html, params, true);
+            }
+            else if (zrUtil.isFunction(formatter)) {
+                const callback = bind(function (cbTicket: string, html: string | HTMLElement | HTMLElement[]) {
+                    if (cbTicket === this._ticket) {
+                        tooltipContent.setContent(html, markupStyleCreator, tooltipModel, nearPointColor, positionExpr);
+                        this._updatePosition(
+                            tooltipModel, positionExpr, x, y, tooltipContent, params, el
+                        );
+                    }
+                }, this);
+                this._ticket = asyncTicket;
+                html = formatter(params, asyncTicket, callback);
+            }
+            else {
+                html = formatter;
+            }
         }
 
         tooltipContent.setContent(html, markupStyleCreator, tooltipModel, nearPointColor, positionExpr);

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1228,13 +1228,15 @@ export interface TooltipFormatterCallback<T> {
      * For sync callback
      * params will be an array on axis trigger.
      */
-    (params: T, asyncTicket: string): string | HTMLElement[]
+    (params: T, asyncTicket: string): string | HTMLElement | HTMLElement[]
     /**
      * For async callback.
      * Returned html string will be a placeholder when callback is not invoked.
      */
-    (params: T, asyncTicket: string, callback: (cbTicket: string, htmlOrDomNodes: string | HTMLElement[]) => void)
-        : string | HTMLElement[]
+    (
+        params: T, asyncTicket: string,
+        callback: (cbTicket: string, htmlOrDomNodes: string | HTMLElement | HTMLElement[]) => void
+    ) : string | HTMLElement | HTMLElement[]
 }
 
 type TooltipBuiltinPosition = 'inside' | 'top' | 'left' | 'right' | 'bottom';

--- a/test/tooltip-domnode.html
+++ b/test/tooltip-domnode.html
@@ -33,6 +33,9 @@ under the License.
     </head>
     <body>
         <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+        <div id="main3"></div>
         <script>
             require(['echarts'/*, 'map/js/china' */], function (echarts) {
                 var option;
@@ -69,6 +72,91 @@ under the License.
             });
         </script>
 
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+                var tooltipContent = document.createElement('span');
+                tooltipContent.innerText = 'Tooltip formatter is a DOM node (not function callback)';
+
+                option = {
+                    xAxis: {},
+                    yAxis: {},
+                    series: {
+                        type: 'line',
+                        data: [[11, 22], [33, 44], [55, 66]]
+                    },
+                    tooltip: {
+                        formatter: tooltipContent
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Tooltip formatter is DOM node (not function callback)'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+                var tooltipContent = document.createElement('a');
+                tooltipContent.href = 'javascript:void(0);';
+                tooltipContent.onclick = () => console.log('test');
+                tooltipContent.textContent = 'Olala';
+
+                option = {
+                    xAxis: {},
+                    yAxis: {},
+                    series: {
+                        type: 'line',
+                        data: [[11, 22], [33, 44], [55, 66]]
+                    },
+                    tooltip: {
+                        position: 'top',
+                        enterable: true,
+                        formatter: [tooltipContent]
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Tooltip should show DOM content instead of the string **[object HTMLSpanElement]**',
+                        'https://github.com/apache/echarts/issues/15307'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+
+                option = {
+                    xAxis: {},
+                    yAxis: {},
+                    series: {
+                        type: 'line',
+                        data: [[11, 22], [33, 44], [55, 66]]
+                    },
+                    tooltip: {
+                        position: 'top',
+                        enterable: true,
+                        formatter: []
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Tooltip should show nothing',
+                    ],
+                    option: option
+                });
+            });
+        </script>
 
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

1) fix(tooltip): tooltip should show DOM content instead of the string [object HTMLSpanElement], resolves #15307.

2) fix(tooltip): should clear the DOM content if user-specified content is null, resolves #14832. Related previous commit: https://github.com/apache/echarts/pull/12947/commits/3ddb125af1870c233b5d3d8c345bdd17015851eb

3) feat(tooltip): formatter can be HTMLElement. (only string/HTMLElement array previously)

4) chore(tooltip): don't show arrow when empty.

### Fixed issues

- #15307
- #14832

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
1. Tooltip shows `[object HTMLSpanElement]` instead of expected DOM content.

2. Tooltip doesn't hide when content is null.


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
1. Tooltip shows DOM content instead of the string `[object HTMLSpanElement]`

2. Hide tooltip when content is null

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

Tooltip formatted now accepts single HTMLElement.

### Related test cases or examples to use the new APIs

Please refer to `test/tooltip-domnode.html` and #14832.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
