### PR TITLE
Fix(polar): polar would throw error if no label

### DIFF
--- a/src/chart/bar/BarSeries.ts
+++ b/src/chart/bar/BarSeries.ts
@@ -39,7 +39,7 @@ export type PolarBarLabelPosition = SeriesLabelOption['position']
     | 'start' | 'insideStart' | 'middle' | 'end' | 'insideEnd';
 
 export type BarSeriesLabelOption = Omit<SeriesLabelOption, 'position'>
-    & {position: PolarBarLabelPosition | 'outside'};
+    & {position?: PolarBarLabelPosition | 'outside'};
 
 export interface BarStateOption {
     itemStyle?: BarItemStyleOption

--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -981,11 +981,7 @@ function updateStyle(
     );
 
     const label = el.getTextContent();
-    if (!label) {
-        return;
-    }
-
-    if (isPolar) {
+    if (isPolar && label) {
         const position = itemModel.get(['label', 'position']);
         el.textConfig.inside = position === 'middle' ? true : null;
         setSectorTextRotation(

--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -980,6 +980,11 @@ function updateStyle(
         }
     );
 
+    const label = el.getTextContent();
+    if (!label) {
+        return;
+    }
+
     if (isPolar) {
         const position = itemModel.get(['label', 'position']);
         el.textConfig.inside = position === 'middle' ? true : null;
@@ -991,7 +996,6 @@ function updateStyle(
         );
     }
 
-    const label = el.getTextContent();
     setLabelValueAnimation(
         label,
         labelStatesModels,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Check existence of `label`



### Fixed issues

Open `test/bar-background.html`, an error will throw
<img width="622" alt="Screen Shot 2021-07-08 at 11 24 28 PM" src="https://user-images.githubusercontent.com/20318608/124948868-aaecac00-e043-11eb-9051-398d38ff3847.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/bar-background.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
