### PR TITLE
fix: use precision defaults only when markline type is average

### DIFF
--- a/src/component/marker/MarkLineModel.ts
+++ b/src/component/marker/MarkLineModel.ts
@@ -118,7 +118,7 @@ class MarkLineModel extends MarkerModel<MarkLineOption> {
         //symbolRotate: 0,
         symbolOffset: 0,
 
-        precision: 2,
+        // precision: 2,
         tooltip: {
             trigger: 'item'
         },

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -22,7 +22,7 @@ import * as numberUtil from '../../util/number';
 import * as markerHelper from './markerHelper';
 import LineDraw from '../../chart/helper/LineDraw';
 import MarkerView from './MarkerView';
-import {getStackedDimension} from '../../data/helper/dataStackHelper';
+import { getStackedDimension } from '../../data/helper/dataStackHelper';
 import { CoordinateSystem, isCoordinateSystemType } from '../../coord/CoordinateSystem';
 import MarkLineModel, { MarkLine2DDataItemOption, MarkLineOption } from './MarkLineModel';
 import { ScaleDataValue, ColorString } from '../../util/types';
@@ -111,7 +111,19 @@ const markLineTransform = function (
             mlFrom.coord[baseIndex] = -Infinity;
             mlTo.coord[baseIndex] = Infinity;
 
-            const precision = mlModel.get('precision');
+            let precision = mlModel.get('precision');
+
+            if (precision === undefined) {
+                data.each(valueAxis.dim, function (val: number, idx: number) {
+                    if (!Number.isInteger(val)) {
+                        const decLength = val.toString().split('.')[1].length;
+                        if (!precision || decLength > precision) {
+                            precision = decLength;
+                        }
+                    }
+                });
+            }
+
             if (precision >= 0 && typeof value === 'number') {
                 value = +value.toFixed(Math.min(precision, 20));
             }
@@ -186,7 +198,7 @@ function markLineFilter(
         if (
             fromCoord && toCoord
             && (ifMarkLineHasOnlyDim(1, fromCoord, toCoord, coordSys)
-            || ifMarkLineHasOnlyDim(0, fromCoord, toCoord, coordSys))
+                || ifMarkLineHasOnlyDim(0, fromCoord, toCoord, coordSys))
         ) {
             return true;
         }
@@ -442,7 +454,7 @@ function createList(coordSys: CoordinateSystem, seriesModel: SeriesModel, mlMode
                 seriesModel.getData().mapDimension(coordDim)
             ) || {};
             // In map series data don't have lng and lat dimension. Fallback to same with coordSys
-            return defaults({name: coordDim}, info);
+            return defaults({ name: coordDim }, info);
         });
     }
     else {

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -113,15 +113,8 @@ const markLineTransform = function (
 
             let precision = mlModel.get('precision');
 
-            if (precision === undefined) {
-                data.each(valueAxis.dim, function (val: number, idx: number) {
-                    if (!Number.isInteger(val)) {
-                        const decLength = val.toString().split('.')[1].length;
-                        if (!precision || decLength > precision) {
-                            precision = decLength;
-                        }
-                    }
-                });
+            if (mlType === 'average' && precision === undefined) {
+                precision = 2;
             }
 
             if (precision >= 0 && typeof value === 'number') {


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
fix: rm default val of precision and calc val automatically
<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
close #15247
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
The max and min markline should not follow the precision option 
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
Use precision defaults only when markline type is average

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
