### PR TITLE
fix(gauge): guage detail label should be on top

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -623,6 +623,7 @@ class GaugeView extends ChartView {
                 const labelEl = newDetailEls[idx];
                 const formatter = itemDetailModel.get('formatter');
                 labelEl.attr({
+                    z2: 10,
                     style: createTextStyle(itemDetailModel, {
                         x: detailX,
                         y: detailY,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Update guage label `z2`.



### Fixed issues

Close #15195


## Details

### Before: What was the problem?
<img width="787" alt="Screen Shot 2021-07-11 at 10 08 44 AM" src="https://user-images.githubusercontent.com/20318608/125180720-01b6d900-e230-11eb-8b30-2cba3ffb1e33.png">




### After: How is it fixed in this PR?

<img width="654" alt="Screen Shot 2021-07-11 at 10 08 31 AM" src="https://user-images.githubusercontent.com/20318608/125180722-067b8d00-e230-11eb-883d-4cdbbb362e38.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
