### PR TITLE
feat(effectScatter): make ripple effect count configurable

### DIFF
--- a/src/chart/effectScatter/EffectScatterSeries.ts
+++ b/src/chart/effectScatter/EffectScatterSeries.ts
@@ -116,7 +116,9 @@ class EffectScatterSeriesModel extends SeriesModel<EffectScatterSeriesOption> {
             // Scale of ripple
             scale: 2.5,
             // Brush type can be fill or stroke
-            brushType: 'fill'
+            brushType: 'fill',
+            // Count of ripple effect
+            count: 3
         },
 
         universalTransition: {

--- a/src/chart/effectScatter/EffectScatterSeries.ts
+++ b/src/chart/effectScatter/EffectScatterSeries.ts
@@ -117,8 +117,8 @@ class EffectScatterSeriesModel extends SeriesModel<EffectScatterSeriesOption> {
             scale: 2.5,
             // Brush type can be fill or stroke
             brushType: 'fill',
-            // Count of ripple effect
-            count: 3
+            // Ripple number
+            number: 3
         },
 
         universalTransition: {

--- a/src/chart/helper/EffectSymbol.ts
+++ b/src/chart/helper/EffectSymbol.ts
@@ -26,8 +26,6 @@ import type { ZRColor, ECElement } from '../../util/types';
 import type Displayable from 'zrender/src/graphic/Displayable';
 import { SymbolDrawItemModelOption } from './SymbolDraw';
 
-const EFFECT_RIPPLE_NUMBER = 3;
-
 interface RippleEffectCfg {
     showEffectOn?: 'emphasis' | 'render'
     rippleScale?: number
@@ -38,7 +36,8 @@ interface RippleEffectCfg {
     zlevel?: number
     symbolType?: string
     color?: ZRColor
-    rippleEffectColor?: ZRColor
+    rippleEffectColor?: ZRColor,
+    effectCount?: number
 }
 
 function updateRipplePath(rippleGroup: Group, effectCfg: RippleEffectCfg) {
@@ -78,9 +77,10 @@ class EffectSymbol extends Group {
     startEffectAnimation(effectCfg: RippleEffectCfg) {
         const symbolType = effectCfg.symbolType;
         const color = effectCfg.color;
+        const effectCount = effectCfg.effectCount;
         const rippleGroup = this.childAt(1) as Group;
 
-        for (let i = 0; i < EFFECT_RIPPLE_NUMBER; i++) {
+        for (let i = 0; i < effectCount; i++) {
             // If width/height are set too small (e.g., set to 1) on ios10
             // and macOS Sierra, a circle stroke become a rect, no matter what
             // the scale is set. So we set width/height as 2. See #4136.
@@ -97,7 +97,7 @@ class EffectSymbol extends Group {
                 scaleY: 0.5
             });
 
-            const delay = -i / EFFECT_RIPPLE_NUMBER * effectCfg.period + effectCfg.effectOffset;
+            const delay = -i / effectCount * effectCfg.period + effectCfg.effectOffset;
             // TODO Configurable effectCfg.period
             ripplePath.animate('', true)
                 .when(effectCfg.period, {
@@ -202,6 +202,7 @@ class EffectSymbol extends Group {
         effectCfg.symbolType = symbolType;
         effectCfg.color = color;
         effectCfg.rippleEffectColor = itemModel.get(['rippleEffect', 'color']);
+        effectCfg.effectCount = itemModel.get(['rippleEffect', 'count']);
 
         this.off('mouseover').off('mouseout').off('emphasis').off('normal');
 

--- a/src/chart/helper/EffectSymbol.ts
+++ b/src/chart/helper/EffectSymbol.ts
@@ -37,7 +37,7 @@ interface RippleEffectCfg {
     symbolType?: string
     color?: ZRColor
     rippleEffectColor?: ZRColor,
-    effectCount?: number
+    rippleNumber?: number
 }
 
 function updateRipplePath(rippleGroup: Group, effectCfg: RippleEffectCfg) {
@@ -77,10 +77,10 @@ class EffectSymbol extends Group {
     startEffectAnimation(effectCfg: RippleEffectCfg) {
         const symbolType = effectCfg.symbolType;
         const color = effectCfg.color;
-        const effectCount = effectCfg.effectCount;
+        const rippleNumber = effectCfg.rippleNumber;
         const rippleGroup = this.childAt(1) as Group;
 
-        for (let i = 0; i < effectCount; i++) {
+        for (let i = 0; i < rippleNumber; i++) {
             // If width/height are set too small (e.g., set to 1) on ios10
             // and macOS Sierra, a circle stroke become a rect, no matter what
             // the scale is set. So we set width/height as 2. See #4136.
@@ -97,7 +97,7 @@ class EffectSymbol extends Group {
                 scaleY: 0.5
             });
 
-            const delay = -i / effectCount * effectCfg.period + effectCfg.effectOffset;
+            const delay = -i / rippleNumber * effectCfg.period + effectCfg.effectOffset;
             ripplePath.animate('', true)
                 .when(effectCfg.period, {
                     scaleX: effectCfg.rippleScale / 2,
@@ -126,7 +126,7 @@ class EffectSymbol extends Group {
         const rippleGroup = this.childAt(1) as Group;
 
         // Must reinitialize effect if following configuration changed
-        const DIFFICULT_PROPS = ['symbolType', 'period', 'rippleScale', 'effectCount'] as const;
+        const DIFFICULT_PROPS = ['symbolType', 'period', 'rippleScale', 'rippleNumber'] as const;
         for (let i = 0; i < DIFFICULT_PROPS.length; i++) {
             const propName = DIFFICULT_PROPS[i];
             if (oldEffectCfg[propName] !== effectCfg[propName]) {
@@ -201,7 +201,7 @@ class EffectSymbol extends Group {
         effectCfg.symbolType = symbolType;
         effectCfg.color = color;
         effectCfg.rippleEffectColor = itemModel.get(['rippleEffect', 'color']);
-        effectCfg.effectCount = itemModel.get(['rippleEffect', 'count']);
+        effectCfg.rippleNumber = itemModel.get(['rippleEffect', 'number']);
 
         this.off('mouseover').off('mouseout').off('emphasis').off('normal');
 

--- a/src/chart/helper/EffectSymbol.ts
+++ b/src/chart/helper/EffectSymbol.ts
@@ -98,7 +98,6 @@ class EffectSymbol extends Group {
             });
 
             const delay = -i / effectCount * effectCfg.period + effectCfg.effectOffset;
-            // TODO Configurable effectCfg.period
             ripplePath.animate('', true)
                 .when(effectCfg.period, {
                     scaleX: effectCfg.rippleScale / 2,
@@ -127,7 +126,7 @@ class EffectSymbol extends Group {
         const rippleGroup = this.childAt(1) as Group;
 
         // Must reinitialize effect if following configuration changed
-        const DIFFICULT_PROPS = ['symbolType', 'period', 'rippleScale'] as const;
+        const DIFFICULT_PROPS = ['symbolType', 'period', 'rippleScale', 'effectCount'] as const;
         for (let i = 0; i < DIFFICULT_PROPS.length; i++) {
             const propName = DIFFICULT_PROPS[i];
             if (oldEffectCfg[propName] !== effectCfg[propName]) {

--- a/src/chart/helper/SymbolDraw.ts
+++ b/src/chart/helper/SymbolDraw.ts
@@ -83,7 +83,12 @@ interface RippleEffectOption {
 
     brushType?: 'fill' | 'stroke'
 
-    color?: ZRColor
+    color?: ZRColor,
+
+    /**
+     * Count of ripple effect
+     */
+    count?: number
 }
 
 interface SymbolDrawStateOption {

--- a/src/chart/helper/SymbolDraw.ts
+++ b/src/chart/helper/SymbolDraw.ts
@@ -86,9 +86,9 @@ interface RippleEffectOption {
     color?: ZRColor,
 
     /**
-     * Count of ripple effect
+     * ripple number
      */
-    count?: number
+    number?: number
 }
 
 interface SymbolDrawStateOption {

--- a/test/effectScatter.html
+++ b/test/effectScatter.html
@@ -547,12 +547,17 @@ under the License.
                 });
 
                 setInterval(function () {
+                    var rippleEffectCount = ~~(Math.random() * 9) + 1;
+                    console.log('rippleEffectCount', rippleEffectCount);
                     myChart.setOption({
                         series: [{
                             name: 'Top 5',
                             data: convertData(data.sort(function (a, b) {
                                 return b.value - a.value;
-                            }).slice(0, Math.round(6 * Math.random())))
+                            }).slice(0, Math.round(6 * Math.random()))),
+                            rippleEffect: {
+                                count: rippleEffectCount
+                            }
                         }]
                     });
                 }, 2000);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Allow configuring the count of ripple effect in `effectScatter` series.

### Fixed issues

- #15252


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The count of ripple effect is hard-coded `3`.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Make ripple effect count configurable. `3` by default.

<img src="https://user-images.githubusercontent.com/26999792/125376694-28a31580-e3be-11eb-89c7-60e2eff130a5.png" width="400">


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

Add a new option `count` into `rippleEffect` option.

### Related test cases or examples to use the new APIs

Please refer to `effectScatter.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
