### PR TITLE
enable pointer's z-level adjustment in gauge chart & set default z-le…

### DIFF
--- a/src/chart/gauge/GaugeSeries.ts
+++ b/src/chart/gauge/GaugeSeries.ts
@@ -43,6 +43,10 @@ interface LabelFormatter {
 interface PointerOption {
     icon?: string
     show?: boolean
+    /** 
+     * If pointer shows above title and detail
+     */
+    showAbove?: boolean,
     keepAspect?: boolean
     itemStyle?: ItemStyleOption
     /**
@@ -260,6 +264,7 @@ class GaugeSeriesModel extends SeriesModel<GaugeSeriesOption> {
             icon: null,
             offsetCenter: [0, 0],
             show: true,
+            showAbove: true,
             length: '60%',
             width: 6,
             keepAspect: false

--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -568,6 +568,8 @@ class GaugeView extends ChartView {
         const newDetailEls: graphic.Text[] = [];
         const hasAnimation = seriesModel.isAnimationEnabled();
 
+        const showPointerAbove = seriesModel.get(['pointer', 'showAbove']);
+
         data.diff(this._data)
             .add((idx) => {
                 newTitleEls[idx] = new graphic.Text({
@@ -598,6 +600,7 @@ class GaugeView extends ChartView {
                 const titleY = posInfo.cy + parsePercent(titleOffsetCenter[1], posInfo.r);
                 const labelEl = newTitleEls[idx];
                 labelEl.attr({
+                    z2: showPointerAbove ? 0 : 2,
                     style: createTextStyle(itemTitleModel, {
                         x: titleX,
                         y: titleY,
@@ -623,7 +626,7 @@ class GaugeView extends ChartView {
                 const labelEl = newDetailEls[idx];
                 const formatter = itemDetailModel.get('formatter');
                 labelEl.attr({
-                    z2: 10,
+                    z2: showPointerAbove ? 0 : 2,
                     style: createTextStyle(itemDetailModel, {
                         x: detailX,
                         y: detailY,


### PR DESCRIPTION
…vel above detail and title

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add a 'showAbove' style to pointer of gauge chart to control whether pointer shows above detail and title item.



### Fixed issues

<!--

- #xxxx: ...
  -->
- https://github.com/apache/echarts/issues/15195


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

After https://github.com/apache/echarts/pull/15326, default z-level is default under detail and title item and can not change. During cases like car speed  dashboard, pointer needs to be above speed number instead of above it. 

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Add a 'showAbove' style to pointer of gauge chart to control whether pointer shows above detail and title item.

![image1](https://user-images.githubusercontent.com/31386769/125386662-3c0aac80-e3cf-11eb-8531-d8b01cae24b3.png)
![image2](https://user-images.githubusercontent.com/31386769/125386767-68262d80-e3cf-11eb-934b-b3c0547d0ebe.png)

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information