### PR TITLE
fix(sankey): gradient should follow orient

### DIFF
--- a/src/chart/sankey/SankeyView.ts
+++ b/src/chart/sankey/SankeyView.ts
@@ -207,7 +207,7 @@ class SankeyView extends ChartView {
                     const sourceColor = edge.node1.getVisual('color');
                     const targetColor = edge.node2.getVisual('color');
                     if (typeof sourceColor === 'string' && typeof targetColor === 'string') {
-                        curve.style.fill = new graphic.LinearGradient(0, 0, 1, 0, [{
+                        curve.style.fill = new graphic.LinearGradient(0, 0, +(orient === 'horizontal'), +(orient === 'vertical'), [{
                             color: sourceColor,
                             offset: 0
                         }, {

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -70,7 +70,18 @@ under the License.
                                 color: 'gradient',
                                 curveness: 0.5
                             }
-                        }
+                        },
+                        {
+                            orient: 'vertical',
+                            type: 'sankey',
+                            focusNodeAdjacency: true,
+                            data: data.nodes,
+                            links: data.links,
+                            lineStyle: {
+                                color: 'gradient',
+                                curveness: 0.5
+                            }
+                        },
                     ]
                 });
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Sankey line's gradient color should folllow orient.



### Fixed issues

Close #15358

## Details

### Before: What was the problem?
<img width="1258" alt="Screen Shot 2021-07-15 at 11 34 53 PM" src="https://user-images.githubusercontent.com/20318608/125815732-96529e45-bd82-4854-890b-e773a767933f.png">




### After: How is it fixed in this PR?
<img width="1205" alt="Screen Shot 2021-07-15 at 11 34 40 PM" src="https://user-images.githubusercontent.com/20318608/125815751-60fcba34-58b2-44d8-8df1-e6bb3fae272a.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`sankey.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
