### PR TITLE
add rotate arg to fix text position bugs in symbol rotate

### DIFF
--- a/src/chart/helper/Symbol.ts
+++ b/src/chart/helper/Symbol.ts
@@ -65,7 +65,8 @@ class Symbol extends graphic.Group {
         data: List,
         idx: number,
         symbolSize: number[],
-        keepAspect: boolean
+        keepAspect: boolean,
+        rotate: number
     ) {
         // Remove paths created before
         this.removeAll();
@@ -77,7 +78,7 @@ class Symbol extends graphic.Group {
         // and macOS Sierra, a circle stroke become a rect, no matter what
         // the scale is set. So we set width/height as 2. See #4150.
         const symbolPath = createSymbol(
-            symbolType, -1, -1, 2, 2, null, keepAspect
+            symbolType, -1, -1, 2, 2, null, keepAspect, rotate
         );
 
         symbolPath.attr({
@@ -162,7 +163,8 @@ class Symbol extends graphic.Group {
 
         if (isInit) {
             const keepAspect = data.getItemVisual(idx, 'symbolKeepAspect');
-            this._createSymbol(symbolType as string, data, idx, symbolSize, keepAspect);
+            const rotate = data.getItemVisual(idx, 'symbolRotate') || 0;
+            this._createSymbol(symbolType as string, data, idx, symbolSize, keepAspect, rotate);
         }
         else {
             const symbolPath = this.childAt(0) as ECSymbol;

--- a/src/util/symbol.ts
+++ b/src/util/symbol.ts
@@ -277,15 +277,18 @@ const SymbolClz = graphic.Path.extend({
         x: 0,
         y: 0,
         width: 0,
-        height: 0
+        height: 0,
+        rotate: 0
     },
 
     calculateTextPosition(out, config, rect) {
         const res = calculateTextPosition(out, config, rect);
         const shape = this.shape;
         if (shape && shape.symbolType === 'pin' && config.position === 'inside') {
-            res.y = rect.y + rect.height * 0.4;
+            res.x = res.x - rect.width * 0.1 * Math.sin(Math.PI * shape.rotate / 180);
+            res.y = res.y + rect.height * 0.001 * Math.cos(Math.PI * shape.rotate / 180);;
         }
+
         return res;
     },
 
@@ -337,7 +340,9 @@ export function createSymbol(
     h: number,
     color?: ZRColor,
     // whether to keep the ratio of w/h,
-    keepAspect?: boolean
+    keepAspect?: boolean,
+    // rotation degree of symbol
+    rotate?: number
 ) {
     // TODO Support image object, DynamicImage.
 
@@ -369,7 +374,8 @@ export function createSymbol(
                 x: x,
                 y: y,
                 width: w,
-                height: h
+                height: h,
+                rotate: rotate
             }
         }) as unknown as ECSymbol;
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add a rotate argument in createSymbol function to fix text position bugs in symbol rotate

### Fixed issues

https://github.com/apache/echarts/issues/14718

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

Text position is not in right place when Pin Symbol rotates

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

As shown in issues

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Add a rotate argument to fix that. Calculate offset by rectangle's width and height instead of simply adding a fixed number.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/31386769/126062818-b7495ee3-6326-494b-b3f3-1ed1c03f485c.png)
![image](https://user-images.githubusercontent.com/31386769/126062835-30233542-9ed5-44d4-a932-c3d2d12bc7ea.png)
![image](https://user-images.githubusercontent.com/31386769/126062876-35f7ddf3-b66f-46ea-a235-3f808b063bd8.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information


