### PR TITLE
fix(radar): lineStyle.join default round #13201

### DIFF
--- a/src/chart/radar/RadarSeries.ts
+++ b/src/chart/radar/RadarSeries.ts
@@ -152,7 +152,8 @@ class RadarSeriesModel extends SeriesModel<RadarSeriesOption> {
         radarIndex: 0,
         lineStyle: {
             width: 2,
-            type: 'solid'
+            type: 'solid',
+            join: 'round'
         },
         label: {
             position: 'top'

--- a/test/radar4.html
+++ b/test/radar4.html
@@ -100,6 +100,38 @@ under the License.
                             ],
                             center : ['75%', 210],
                             radius : 150
+                        },
+                        {
+                            indicator: [{
+                                name: 'a',
+                                max: 13
+                            },
+                            {
+                                name: 'b',
+                                max: 1,
+                                min: 0
+                            },
+                            {
+                                name: 'c',
+                                max: 16000
+                            },
+                            {
+                                name: 'd',
+                                max: 30000
+                            },
+                            {
+                                name: 'e',
+                                max: 38000
+                            },
+                            {
+                                name: 'f',
+                                max: 52000
+                            },
+                            {
+                                name: 'g',
+                                max: 25000
+                            }],
+                            radius : 150
                         }
                     ],
                     series : [
@@ -191,6 +223,22 @@ under the License.
                                     }
                                 }
                             ]
+                        },
+                        {
+                            name: 'join',
+                            polarIndex: 2,
+                            type: 'radar',
+                            data: [{
+                                value: [
+                                    3,
+                                    1,
+                                    1,
+                                    53,
+                                    66,
+                                    18,
+                                    0.0121
+                                ]
+                            }]
                         }
                     ]
                 });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Set `lineStyle.join` of radar series to be `'round'` by default to solve the unexpected joint problem.

![image](https://user-images.githubusercontent.com/779050/126258661-21547bb0-5c56-4495-96ed-8a9c154a1950.png)


### Fixed issues

- #13201


## Details

### Before: What was the problem?

Unexpected angle outside of the radar area at the joint position.

### After: How is it fixed in this PR?

Nothing outside the radar area.



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
