### PR TITLE
Label text style support `lineOverflow` and `ellipsis`

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -55,7 +55,7 @@ interface BreadcrumbItemStyleOption extends ItemStyleOption {
 }
 
 interface TreemapSeriesLabelOption extends SeriesLabelOption {
-    ellipsis?: boolean
+    ellipsis?: string
     formatter?: string | ((params: CallbackDataParams) => string)
 }
 
@@ -306,7 +306,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
             upperLabel: {
                 show: true,
                 position: [0, '50%'],
-                ellipsis: true,
+                ellipsis: '...',
                 verticalAlign: 'middle'
             }
         },

--- a/src/component/title/install.ts
+++ b/src/component/title/install.ts
@@ -158,7 +158,8 @@ class TitleView extends ComponentView {
         const textEl = new graphic.Text({
             style: createTextStyle(textStyleModel, {
                 text: titleModel.get('text'),
-                fill: textStyleModel.getTextColor()
+                fill: textStyleModel.getTextColor(),
+                lineOverflow: textStyleModel.get('lineOverflow')
             }, {disableBox: true}),
             z2: 10
         });
@@ -171,7 +172,8 @@ class TitleView extends ComponentView {
                 text: subText,
                 fill: subtextStyleModel.getTextColor(),
                 y: textRect.height + titleModel.get('itemGap'),
-                verticalAlign: 'top'
+                verticalAlign: 'top',
+                lineOverflow: textStyleModel.get('lineOverflow')
             }, {disableBox: true}),
             z2: 10
         });

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -462,7 +462,7 @@ const TEXT_PROPS_WITH_GLOBAL = [
     'textShadowColor', 'textShadowBlur', 'textShadowOffsetX', 'textShadowOffsetY'
 ] as const;
 const TEXT_PROPS_SELF = [
-    'align', 'lineHeight', 'width', 'height', 'tag', 'verticalAlign'
+    'align', 'lineHeight', 'width', 'height', 'tag', 'verticalAlign', 'lineOverflow', 'ellipsis'
 ] as const;
 const TEXT_PROPS_BOX = [
     'padding', 'borderWidth', 'borderRadius', 'borderDashOffset',

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1109,6 +1109,8 @@ export interface LabelOption extends TextCommonOption {
     // formatter?: string | ((params: CallbackDataParams) => string)
 
     rich?: Dictionary<TextCommonOption>
+    lineOverflow?: 'truncate'
+    ellipsis?: string
 }
 
 export interface SeriesLabelOption extends LabelOption {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add `lineOverflow` and `ellipsis` for `label`, also fix `lineOverflow` doesn't affect in `title`


### Fixed issues

Close #15395


## Details

### Before: What was the problem?
<img width="533" alt="Screen Shot 2021-07-21 at 11 25 38 PM" src="https://user-images.githubusercontent.com/20318608/126654364-772098af-e7a5-414f-9c14-98ce1f2b36a2.png">
<img width="517" alt="Screen Shot 2021-07-22 at 10 17 03 PM" src="https://user-images.githubusercontent.com/20318608/126654491-3e84b444-4135-48f7-ab0a-dc8cb41c4ce1.png">
<img width="374" alt="Screen Shot 2021-07-22 at 10 19 25 PM" src="https://user-images.githubusercontent.com/20318608/126654968-64f806c2-84f3-4dd5-b786-29b071f63d4e.png">



### After: How is it fixed in this PR?

<img width="511" alt="Screen Shot 2021-07-21 at 11 22 34 PM" src="https://user-images.githubusercontent.com/20318608/126654132-808e02af-52e4-43cc-a5fe-710104e09c12.png">
<img width="468" alt="Screen Shot 2021-07-22 at 10 16 01 PM" src="https://user-images.githubusercontent.com/20318608/126654338-68b7826b-62ec-4210-9039-b0c7625a5a15.png">
<img width="182" alt="Screen Shot 2021-07-22 at 10 19 47 PM" src="https://user-images.githubusercontent.com/20318608/126654940-e775fde6-cb6b-4bb2-87f0-0b121214b4b5.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
