### PR TITLE
Fix #13195 - Update way of parsing date

### DIFF
--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -329,7 +329,7 @@ export function parseDate(value: unknown): Date {
                 +match[4] || 0,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +(match[7] ? match[7].substring(0,3) : match[7]) || 0
+                match[7] ? +match[7].substring(0, 3) : 0
             );
         }
         // Timezoneoffset of Javascript Date has considered DST (Daylight Saving Time,
@@ -351,7 +351,7 @@ export function parseDate(value: unknown): Date {
                 hour,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +(match[7] ? match[7].substring(0,3) : match[7]) || 0
+                match[7] ? +match[7].substring(0, 3) : 0
             ));
         }
     }

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -329,7 +329,7 @@ export function parseDate(value: unknown): Date {
                 +match[4] || 0,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +match[7] || 0
+                +(match[7] ? match[7].substring(0,3) : match[7]) || 0
             );
         }
         // Timezoneoffset of Javascript Date has considered DST (Daylight Saving Time,
@@ -351,7 +351,7 @@ export function parseDate(value: unknown): Date {
                 hour,
                 +(match[5] || 0),
                 +match[6] || 0,
-                +match[7] || 0
+                +(match[7] ? match[7].substring(0,3) : match[7]) || 0
             ));
         }
     }

--- a/test/ut/spec/util/number.test.ts
+++ b/test/ut/spec/util/number.test.ts
@@ -271,6 +271,7 @@ describe('util/number', function () {
             expect(+parseDate('2012-03-04T05:06:07.123-0700')).toEqual(1330862767123);
             expect(+parseDate('2012-03-04T05:06:07.123-07:00')).toEqual(1330862767123);
             expect(+parseDate('2012-03-04T5:6:7.123-07:00')).toEqual(1330862767123);
+            expect(+parseDate('2012-03-04T05:06:07.123000Z')).toEqual(+new Date('2012-03-04T05:06:07.123Z'));
 
             // Other string
             expect(+parseDate('2012')).toEqual(+new Date('2012-01-01T00:00:00'));


### PR DESCRIPTION
## Important Note
This is a re-commit for original PR #13227 . I didn't modify the original one because due to some reason I can not find my original branch.


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

The PR updated way of parsing 7th part of date string from simply treat it as milliseconds to pick first 3 digits as milliseconds to avoid unexpected result when backend API return date string with precision of microseconds.

### Fixed issues

#13195 


## Details

### Before: What was the problem?

Though 3 digits milliseconds is widely used in most situations, some date formatter will return date string 6 digit microseconds (`yyyy-MM-ddTHH:mm:ss.micros`) . ECharts will treat micro seconds as milliseconds when parsing DateTime string and cause unexpected result.

### After: How is it fixed in this PR?

Keep conistent with default constructor of JavaScript Date - only pick first 3 digits when the length of input part between dot and zulu time marker is longer than 3 digits.

## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [X] Please squash the commits into a single one when merge.

### Other information
