### PR TITLE
Time axis shadow

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -30,6 +30,7 @@ import OrdinalScale from '../scale/Ordinal';
 import Model from '../model/Model';
 import { AxisBaseOption, OptionAxisType } from './axisCommonTypes';
 import { AxisBaseModel } from './AxisBaseModel';
+import TimeScale from '../scale/Time';
 
 const NORMALIZED_EXTENT = [0, 1] as [number, number];
 
@@ -246,7 +247,13 @@ class Axis {
         const axisExtent = this._extent;
         const dataExtent = this.scale.getExtent();
 
-        let len = dataExtent[1] - dataExtent[0] + (this.onBand ? 1 : 0);
+        let len = 0;
+        if (this.scale.type === 'time') {
+            len = Math.ceil((dataExtent[1] - dataExtent[0]) / (this.scale as TimeScale)._approxInterval);
+        }
+        else {
+            len = dataExtent[1] - dataExtent[0] + (this.onBand ? 1 : 0);
+        }
         // Fix #2728, avoid NaN when only one data.
         len === 0 && (len = 1);
 

--- a/test/axis-interval2.html
+++ b/test/axis-interval2.html
@@ -59,6 +59,7 @@ under the License.
         <div class="chart" id="main8"></div>
         <div class="chart" id="main9"></div>
         <div class="chart" id="main10"></div>
+        <div class="chart" id="main11"></div>
 
 
         <script>
@@ -1336,6 +1337,52 @@ under the License.
                         'The dataZoom window range is at the critical value of changing axis interval from 2 to 3.',
                         'Move the dataZoom bar, the **xAxis labels should be stable**.',
                         'That is, xAxis labels should not be sometimes [c21, c24, c27] sometimes [c20, c24, c28]'
+                    ],
+                    option: option,
+                    // Should be fixed this width to make the dataZoom window range at the critical value.
+                    width: 653,
+                    height: 300,
+                    autoResize: false
+                });
+
+            });
+
+        </script>
+
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: {
+                            type: 'shadow'
+                        }
+                    },
+                    xAxis: {
+                        type: "time",
+                    },
+                    yAxis: {},
+                    series: [
+                        {
+                            name: 'Param1',
+                            type: 'bar',
+                            data: [["2019-01-12", 5], ["2019-01-13", 20], ["2019-01-14", 36], ["2019-01-15", 10], ["2019-01-16", 10], ["2019-01-17", 20]]
+                        },
+                        {
+                            name: 'Param2',
+                            type: 'bar',
+                            data: [["2019-01-12", 39], ["2019-01-13", 13], ["2019-01-14", 13], ["2019-01-15", 23], ["2019-01-16", 8], ["2019-01-17", 23]]
+                        },
+                    ]
+                };
+
+
+                chart = myChart = testHelper.create(echarts, 'main11', {
+                    title: [
+                        'The axis shadow should appear when x is time axis',
                     ],
                     option: option,
                     // Should be fixed this width to make the dataZoom window range at the critical value.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`time` axis `bandWith`calculation  is different from others. 


### Fixed issues

- Close #9843 


## Details

<img width="1294" alt="Screen Shot 2021-07-25 at 10 10 23 PM" src="https://user-images.githubusercontent.com/20318608/126902139-697de879-fc85-44ec-8d78-823bfdb7c9ed.png">

No shadow appear for `time` axis



### After: How is it fixed in this PR?

<img width="707" alt="Screen Shot 2021-07-25 at 10 09 59 PM" src="https://user-images.githubusercontent.com/20318608/126902151-6f765324-11cb-47d4-8189-8005c4122aad.png">



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs


test/axis-interval2.html

## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
