### PR TITLE
perf(calendar):Invalid date range do not affect the normal use of setOption

### DIFF
--- a/src/component/calendar/CalendarView.ts
+++ b/src/component/calendar/CalendarView.ts
@@ -57,6 +57,10 @@ class CalendarView extends ComponentView {
     type = CalendarView.type;
 
     /**
+     * invalid date line points
+     */
+    private _invalidpoints: number[] = [0, 0];
+    /**
      * top/left line points
      */
     private _tlpoints: number[][];
@@ -177,8 +181,8 @@ class CalendarView extends ComponentView {
 
             const points = self._getLinePointsOfOneWeek(calendarModel, date, orient);
 
-            self._tlpoints.push(points[0]);
-            self._blpoints.push(points[points.length - 1]);
+            self._tlpoints.push(points[0] ?? self._invalidpoints);
+            self._blpoints.push(points[points.length - 1] ?? self._invalidpoints);
 
             show && self._drawSplitline(points, lineStyleModel, group);
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Invalid date range do not affect the normal use of setOption

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?
If the value is not four-digit, set the default value [0,0] for top/left line points and bottom/right line points.


### Fixed issues
This may be a  improves performance raised from [#15037](https://github.com/apache/echarts/issues/15037) .


## Details
According to ISO 8601, we must type year in four-digit to avoid Y2K.
how to fix this issue, it depends on whether echarts should support it or not.
Obviously,Years other than four digits are not supported in echarts.
