### PR TITLE
fix(xAxis): fix hour format at millisecond unit. close #15426

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -37,8 +37,8 @@ export const defaultLeveledFormatter = {
     hour: '{HH}:{mm}',
     minute: '{HH}:{mm}',
     second: '{HH}:{mm}:{ss}',
-    millisecond: '{hh}:{mm}:{ss} {SSS}',
-    none: '{yyyy}-{MM}-{dd} {hh}:{mm}:{ss} {SSS}'
+    millisecond: '{HH}:{mm}:{ss} {SSS}',
+    none: '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss} {SSS}'
 };
 
 const fullDayFormatter = '{yyyy}-{MM}-{dd}';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information
时间轴label的默认格式在时间点是分钟时为24小时制，毫秒时为12小时制。时间点间隔较小时显示有问题

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
默认时间格式统一改为24小时制
<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
Close #15426
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![图像 2](https://user-images.githubusercontent.com/46096473/127501684-e07117a9-c36f-42a3-8aca-9f132aa45925.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="1268" alt="截屏2021-07-29 下午5 59 34" src="https://user-images.githubusercontent.com/46096473/127501710-6112d6b9-3e62-4094-9d8c-177f3c29fff1.png">



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
