### PR TITLE
Feat: new selectedMode and selectable for item

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -967,6 +967,7 @@ export interface ItemStyleOption extends ShadowOptionMixin, BorderOptionMixin {
     color?: ZRColor
     opacity?: number
     decal?: DecalObject | 'none'
+    selectable?: boolean
 }
 
 /**
@@ -1654,7 +1655,7 @@ export interface SeriesOption<
      * key is name or index of data.
      */
     selectedMap?: Dictionary<boolean>
-    selectedMode?: 'single' | 'multiple' | boolean
+    selectedMode?: 'single' | 'multiple' | 'series' | boolean
 }
 
 export interface SeriesOnCartesianOptionMixin {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Since `5.0`, ECharts supports item `select`, It would be nice to have `selectable` option for each item. The idea came from #14712

Also add `series` for `selectedMode`, it's would make whole series `selected` by on click.

## Details


### After: How is it fixed in this PR?

![Kapture 2021-08-14 at 23 50 23](https://user-images.githubusercontent.com/20318608/129452185-2b360904-65aa-4111-8581-cc180cbf908d.gif)




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
