### PR TITLE
Fix: time axis overlapped labels

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {retrieve, defaults, extend, each, isObject} from 'zrender/src/core/util';
+import {retrieve, defaults, extend, each, isObject, map} from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import {getECData} from '../../util/innerStore';
 import {createTextStyle} from '../../label/labelStyle';
@@ -352,7 +352,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         // This bit fixes the label overlap issue for the Time chart.
         // See https://github.com/apache/echarts/issues/14266 for more.
         if (axisModel.get('type') === 'time') {
-            const labelList = prepareLayoutList(labelEls.map(label => ({
+            const labelList = prepareLayoutList(map(labelEls, label => ({
                 label,
                 priority: label.z2,
                 defaultAttr: {
@@ -781,7 +781,7 @@ function buildAxisLabel(
             y: opt.labelOffset + opt.labelDirection * labelMargin,
             rotation: labelLayout.rotation,
             silent: silent,
-            z2: labelItem.level,
+            z2: 10 + (labelItem.level || 0),
             style: createTextStyle(itemLabelModel, {
                 text: formattedLabel,
                 align: itemLabelModel.getShallow('align', true)

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -33,6 +33,7 @@ import { AxisBaseOption } from '../../coord/axisCommonTypes';
 import Element from 'zrender/src/Element';
 import { PathStyleProps } from 'zrender/src/graphic/Path';
 import OrdinalScale from '../../scale/Ordinal';
+import { prepareLayoutList, hideOverlap } from '../../label/labelLayoutHelper';
 
 const PI = Math.PI;
 
@@ -347,6 +348,16 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         fixMinMaxLabelShow(axisModel, labelEls, ticksEls);
 
         buildAxisMinorTicks(group, transformGroup, axisModel, opt.tickDirection);
+
+        const labelList = prepareLayoutList(labelEls.map(label => ({
+            label,
+            priority: label.style.text?.includes('primary') ? 1 : 0,
+            defaultAttr: {
+                ignore: label.ignore
+            }
+        })));
+
+        hideOverlap(labelList);
     },
 
     axisName(opt, axisModel, group, transformGroup) {

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -349,6 +349,8 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
 
         buildAxisMinorTicks(group, transformGroup, axisModel, opt.tickDirection);
 
+        // This bit fixes the label overlap issue for the Time chart.
+        // See https://github.com/apache/echarts/issues/14266 for more.
         if (axisModel.type === 'xAxis.time') {
             const labelList = prepareLayoutList(labelEls.map(label => ({
                 label,

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -351,10 +351,10 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
 
         // This bit fixes the label overlap issue for the Time chart.
         // See https://github.com/apache/echarts/issues/14266 for more.
-        if (axisModel.type === 'xAxis.time') {
+        if (axisModel.get('type') === 'time') {
             const labelList = prepareLayoutList(labelEls.map(label => ({
                 label,
-                priority: label.zlevel,
+                priority: label.z2,
                 defaultAttr: {
                     ignore: label.ignore
                 }
@@ -781,7 +781,7 @@ function buildAxisLabel(
             y: opt.labelOffset + opt.labelDirection * labelMargin,
             rotation: labelLayout.rotation,
             silent: silent,
-            z2: 10,
+            z2: labelItem.level,
             style: createTextStyle(itemLabelModel, {
                 text: formattedLabel,
                 align: itemLabelModel.getShallow('align', true)
@@ -823,8 +823,6 @@ function buildAxisLabel(
         // FIXME
         transformGroup.add(textEl);
         textEl.updateTransform();
-
-        textEl.zlevel = labelItem.level;
 
         labelEls.push(textEl);
         group.add(textEl);

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -349,15 +349,17 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
 
         buildAxisMinorTicks(group, transformGroup, axisModel, opt.tickDirection);
 
-        const labelList = prepareLayoutList(labelEls.map(label => ({
-            label,
-            priority: label.style.text?.includes('primary') ? 1 : 0,
-            defaultAttr: {
-                ignore: label.ignore
-            }
-        })));
+        if (axisModel.type === 'xAxis.time') {
+            const labelList = prepareLayoutList(labelEls.map(label => ({
+                label,
+                priority: label.zlevel,
+                defaultAttr: {
+                    ignore: label.ignore
+                }
+            })));
 
-        hideOverlap(labelList);
+            hideOverlap(labelList);
+        }
     },
 
     axisName(opt, axisModel, group, transformGroup) {
@@ -819,6 +821,8 @@ function buildAxisLabel(
         // FIXME
         transformGroup.add(textEl);
         textEl.updateTransform();
+
+        textEl.zlevel = labelItem.level;
 
         labelEls.push(textEl);
         group.add(textEl);

--- a/src/coord/axisTickLabelBuilder.ts
+++ b/src/coord/axisTickLabelBuilder.ts
@@ -62,6 +62,7 @@ const inner = makeInner<InnerStore, any>();
 
 export function createAxisLabels(axis: Axis): {
     labels: {
+        level?: number,
         formattedLabel: string,
         rawLabel: string,
         tickValue: number
@@ -176,6 +177,7 @@ function makeRealNumberLabels(axis: Axis) {
     return {
         labels: zrUtil.map(ticks, function (tick, idx) {
             return {
+                level: tick.level,
                 formattedLabel: labelFormatter(tick, idx),
                 rawLabel: axis.scale.getLabel(tick),
                 tickValue: tick.value

--- a/src/label/labelLayoutHelper.ts
+++ b/src/label/labelLayoutHelper.ts
@@ -24,12 +24,12 @@ import type Element from 'zrender/src/Element';
 
 interface LabelLayoutListPrepareInput {
     label: ZRText
-    labelLine: Polyline
-    computedLayoutOption: LabelLayoutOption
+    labelLine?: Polyline
+    computedLayoutOption?: LabelLayoutOption
     priority: number
     defaultAttr: {
         ignore: boolean
-        labelGuideIgnore: boolean
+        labelGuideIgnore?: boolean
     }
 }
 
@@ -44,7 +44,7 @@ export interface LabelLayoutInfo {
     layoutOption: LabelLayoutOption
     defaultAttr: {
         ignore: boolean
-        labelGuideIgnore: boolean
+        labelGuideIgnore?: boolean
     }
     transform: number[]
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -377,6 +377,7 @@ export type ParsedValueNumeric = number | OrdinalNumber;
 export type ScaleDataValue = ParsedValueNumeric | OrdinalRawValue | Date;
 
 export interface ScaleTick {
+    level?: number,
     value: number
 };
 export interface TimeScaleTick extends ScaleTick {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This PR fixes the overlapping labels in the Time Axis.

### Fixed issues

<!--
- #xxxx: ...
-->

- https://github.com/apache/echarts/issues/14266


## Details

| Before  | After |
| ------- | ----- |
| <img width="600" alt="Screenshot 2021-08-23 at 13 22 15" src="https://user-images.githubusercontent.com/3321893/130433229-1d947bfe-57b3-40cb-8160-807d2a3db1e7.png"> | <img width="600" alt="Screenshot 2021-08-23 at 13 21 54" src="https://user-images.githubusercontent.com/3321893/130433254-1e44f5f0-98a1-4583-8733-e4b3abcd075c.png"> |


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
