### PR TITLE
fix(tooltip): tweak the calculation of tooltip offset to make it look not so near to the target element.

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -519,21 +519,6 @@ class TooltipHTMLContent {
         this.el.parentNode.removeChild(this.el);
     }
 
-    getOuterSize() {
-        let width = this.el.clientWidth;
-        let height = this.el.clientHeight;
-
-        // Consider browser compatibility.
-        // IE8 does not support getComputedStyle.
-        const stl = getComputedStyle(this.el);
-        if (stl) {
-            width += parseInt(stl.borderLeftWidth, 10) + parseInt(stl.borderRightWidth, 10);
-            height += parseInt(stl.borderTopWidth, 10) + parseInt(stl.borderBottomWidth, 10);
-        }
-
-        return {width: width, height: height};
-    }
-
 }
 
 export default TooltipHTMLContent;

--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -205,14 +205,6 @@ class TooltipRichContent {
         return this._show;
     }
 
-    getOuterSize() {
-        const size = this.getSize();
-        return {
-            width: size[0],
-            height: size[1]
-        };
-    }
-
     dispose() {
         this._zr.remove(this.el);
     }

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -905,7 +905,7 @@ class TooltipView extends ComponentView {
         // Specify tooltip position by string 'top' 'bottom' 'left' 'right' around graphic element
         else if (zrUtil.isString(positionExpr) && el) {
             const pos = calcTooltipPosition(
-                positionExpr, rect, contentSize, tooltipModel.get('borderWidth'),
+                positionExpr, rect, contentSize, tooltipModel.get('borderWidth')
             );
             x = pos[0];
             y = pos[1];
@@ -1067,9 +1067,9 @@ function refixTooltipPosition(
     viewWidth: number, viewHeight: number,
     gapH: number, gapV: number
 ) {
-    const size = content.getOuterSize();
-    const width = size.width;
-    const height = size.height;
+    const size = content.getSize();
+    const width = size[0];
+    const height = size[1];
 
     if (gapH != null) {
         // Add extra 2 pixels for this case:
@@ -1100,9 +1100,9 @@ function confineTooltipPosition(
     viewWidth: number,
     viewHeight: number
 ): [number, number] {
-    const size = content.getOuterSize();
-    const width = size.width;
-    const height = size.height;
+    const size = content.getSize();
+    const width = size[0];
+    const height = size[1];
 
     x = Math.min(x + width, viewWidth) - width;
     y = Math.min(y + height, viewHeight) - height;
@@ -1120,7 +1120,7 @@ function calcTooltipPosition(
 ): [number, number] {
     const domWidth = contentSize[0];
     const domHeight = contentSize[1];
-    const offset = Math.max(Math.ceil(Math.sqrt(2 * borderWidth * borderWidth)), 5);
+    const offset = Math.ceil(Math.SQRT2 * borderWidth) + 8;
     let x = 0;
     let y = 0;
     const rectWidth = rect.width;


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

1) tweak the calculation of tooltip offset to make it look not so near to the target element. Appreciated it if there is a better solution.

2) remove unnecessary `getOuterSize` method beacuse `getSize` is now using `offsetWidth/offsetHeight` that contains the `borderWidth`. (Please ensure it has no side effect)


### Fixed issues

- #14393

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `scatter.html` or `new-tooltip.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
