### PR TITLE
fix(line): not stop existing expand animation when update.

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -691,9 +691,18 @@ class LineView extends ChartView {
             }
 
             // Update clipPath
-            lineGroup.setClipPath(
-                createLineClipPath(this, coordSys, false, seriesModel)
-            );
+            const oldClipPath = lineGroup.getClipPath();
+            if (oldClipPath) {
+                const newClipPath = createLineClipPath(this, coordSys, false, seriesModel);
+                graphic.initProps(oldClipPath, {
+                    shape: newClipPath.shape
+                }, seriesModel);
+            }
+            else {
+                lineGroup.setClipPath(
+                    createLineClipPath(this, coordSys, true, seriesModel)
+                );
+            }
 
             // Always update, or it is wrong in the case turning on legend
             // because points are not changed

--- a/test/line-animation.html
+++ b/test/line-animation.html
@@ -49,6 +49,8 @@ under the License.
             }
         </style>
 
+        <div class="chart" id="main3"></div>
+
         <button onclick="change()">CHANGE</button>
         <div class="chart" id="main2"></div>
 
@@ -399,6 +401,42 @@ under the License.
 
         </script>
 
+
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                var chart = echarts.init(document.getElementById('main3'), null, {
+                    renderer: 'svg'
+                });
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [{
+                        data: [820, 932, 901, 934, 1290, 1330, 1320],
+                        type: 'line',
+                        areaStyle: {}
+                    }],
+                    animationDuration: 5000,
+                    animationDurationUpdate: 5000
+                };
+
+                chart.setOption(option);
+
+                setTimeout(function() {
+                    chart.setOption(option);
+                }, 1000);
+
+            });
+
+        </script>
 
 
     </body>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Line clipping animation was skipped if calling setOption when the first clipping animation is not done.


### Fixed issues

#15581


## Details

### Before: What was the problem?

```
option = {
    xAxis: {
        type: 'category',
        boundaryGap: false,
        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
    },
    yAxis: {
        type: 'value'
    },
    series: [{
        data: [820, 932, 901, 934, 1290, 1330, 1320],
        type: 'line',
        areaStyle: {}
    }],
    animationDuration: 5000,
    animationDurationUpdate: 5000
};

setTimeout(function() {
    myChart.setOption(option);
}, 1000);
```

### After: How is it fixed in this PR?

Clipping animation should be continued.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
