### PR TITLE
[fix] [type]: improve option types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,5 +19,5 @@
 
 import * as echarts from './types/dist/echarts';
 // Export for UMD module.
-export as namespace echarts
+export as namespace echarts;
 export = echarts;

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,4 +17,7 @@
 * under the License.
 */
 
-export * from './types/dist/echarts';
+import * as echarts from './types/dist/echarts';
+// Export for UMD module.
+export as namespace echarts
+export = echarts;

--- a/src/chart/bar/BarSeries.ts
+++ b/src/chart/bar/BarSeries.ts
@@ -27,7 +27,8 @@ import {
     SeriesSamplingOptionMixin,
     SeriesLabelOption,
     SeriesEncodeOptionMixin,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    CallbackDataParams
 } from '../../util/types';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import createSeriesData from '../helper/createSeriesData';
@@ -42,8 +43,8 @@ export type PolarBarLabelPosition = SeriesLabelOption['position']
 export type BarSeriesLabelOption = Omit<SeriesLabelOption, 'position'>
     & {position?: PolarBarLabelPosition | 'outside'};
 
-export interface BarStateOption {
-    itemStyle?: BarItemStyleOption
+export interface BarStateOption<TCbParams = never> {
+    itemStyle?: BarItemStyleOption<TCbParams>
     label?: BarSeriesLabelOption
 }
 
@@ -51,7 +52,7 @@ interface BarStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
 
-export interface BarItemStyleOption extends ItemStyleOption {
+export interface BarItemStyleOption<TCbParams = never> extends ItemStyleOption<TCbParams> {
     // Border radius is not supported for bar on polar
     borderRadius?: number | number[]
 }
@@ -61,7 +62,9 @@ export interface BarDataItemOption extends BarStateOption,
     cursor?: string
 }
 
-export interface BarSeriesOption extends BaseBarSeriesOption<BarStateOption, BarStatesMixin>, BarStateOption,
+export interface BarSeriesOption
+    extends BaseBarSeriesOption<BarStateOption<CallbackDataParams>, BarStatesMixin>,
+    BarStateOption<CallbackDataParams>,
     SeriesStackOptionMixin, SeriesSamplingOptionMixin, SeriesEncodeOptionMixin {
 
     type?: 'bar'

--- a/src/chart/bar/BarSeries.ts
+++ b/src/chart/bar/BarSeries.ts
@@ -26,7 +26,8 @@ import {
     OptionDataItemObject,
     SeriesSamplingOptionMixin,
     SeriesLabelOption,
-    SeriesEncodeOptionMixin
+    SeriesEncodeOptionMixin,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import createSeriesData from '../helper/createSeriesData';
@@ -46,16 +47,21 @@ export interface BarStateOption {
     label?: BarSeriesLabelOption
 }
 
+interface BarStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
+
 export interface BarItemStyleOption extends ItemStyleOption {
     // Border radius is not supported for bar on polar
     borderRadius?: number | number[]
 }
-export interface BarDataItemOption extends BarStateOption, StatesOptionMixin<BarStateOption>,
+export interface BarDataItemOption extends BarStateOption,
+    StatesOptionMixin<BarStateOption, BarStatesMixin>,
     OptionDataItemObject<OptionDataValue> {
     cursor?: string
 }
 
-export interface BarSeriesOption extends BaseBarSeriesOption<BarStateOption>, BarStateOption,
+export interface BarSeriesOption extends BaseBarSeriesOption<BarStateOption, BarStatesMixin>, BarStateOption,
     SeriesStackOptionMixin, SeriesSamplingOptionMixin, SeriesEncodeOptionMixin {
 
     type?: 'bar'
@@ -151,7 +157,7 @@ class BarSeriesModel extends BaseBarSeriesModel<BarSeriesOption> {
         },
 
         realtimeSort: false
-    });
+    } as BarSeriesOption);
 
 }
 

--- a/src/chart/bar/BaseBarSeries.ts
+++ b/src/chart/bar/BaseBarSeries.ts
@@ -24,14 +24,14 @@ import {
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin,
     ScaleDataValue,
-    DefaultExtraStateOpts
+    DefaultStatesMixin
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import SeriesData from '../../data/SeriesData';
 
 
-export interface BaseBarSeriesOption<StateOption, ExtraStateOption = DefaultExtraStateOpts>
+export interface BaseBarSeriesOption<StateOption, ExtraStateOption = DefaultStatesMixin>
     extends SeriesOption<StateOption, ExtraStateOption>,
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin {

--- a/src/chart/boxplot/BoxplotSeries.ts
+++ b/src/chart/boxplot/BoxplotSeries.ts
@@ -28,7 +28,8 @@ import {
     OptionDataValueNumeric,
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
-    DefaultEmphasisFocus
+    DefaultEmphasisFocus,
+    CallbackDataParams
 } from '../../util/types';
 import type Axis2D from '../../coord/cartesian/Axis2D';
 import Cartesian2D from '../../coord/cartesian/Cartesian2D';
@@ -37,9 +38,8 @@ import { mixin } from 'zrender/src/core/util';
 // [min,  Q1,  median (or Q2),  Q3,  max]
 type BoxplotDataValue = OptionDataValueNumeric[];
 
-
-export interface BoxplotStateOption {
-    itemStyle?: ItemStyleOption
+export interface BoxplotStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
 
@@ -55,7 +55,9 @@ interface ExtraStateOption {
     }
 }
 
-export interface BoxplotSeriesOption extends SeriesOption<BoxplotStateOption, ExtraStateOption>, BoxplotStateOption,
+export interface BoxplotSeriesOption
+    extends SeriesOption<BoxplotStateOption<CallbackDataParams>, ExtraStateOption>,
+    BoxplotStateOption<CallbackDataParams>,
     SeriesOnCartesianOptionMixin, SeriesEncodeOptionMixin {
     type?: 'boxplot'
 

--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -28,17 +28,17 @@ import {
     ColorString,
     SeriesLabelOption,
     SeriesLargeOptionMixin,
-    OptionDataValueNumeric,
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
-    DefaultEmphasisFocus
+    DefaultEmphasisFocus,
+    OptionDataValue
 } from '../../util/types';
 import SeriesData from '../../data/SeriesData';
 import Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 import { mixin } from 'zrender/src/core/util';
 
-type CandlestickDataValue = OptionDataValueNumeric[];
+type CandlestickDataValue = OptionDataValue[];
 
 interface CandlestickItemStyleOption extends ItemStyleOption {
     color0?: ZRColor

--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -204,7 +204,7 @@ interface BuiltinShapes {
     circle: Partial<Circle['shape']>
     rect: Partial<Rect['shape']>
     sector: Partial<Sector['shape']>
-    poygon: Partial<Polygon['shape']>
+    polygon: Partial<Polygon['shape']>
     polyline: Partial<Polyline['shape']>
     line: Partial<Line['shape']>
     arc: Partial<Arc['shape']>
@@ -337,12 +337,12 @@ export interface CustomSeriesRenderItemParams {
     actionType?: string;
 }
 
-export type CustomSeriesRenderItemReturn = CustomRootElementOption;
+export type CustomSeriesRenderItemReturn = CustomRootElementOption | undefined | null;
 
-type CustomSeriesRenderItem = (
+export type CustomSeriesRenderItem = (
     params: CustomSeriesRenderItemParams,
     api: CustomSeriesRenderItemAPI
-) => CustomElementOption;
+) => CustomSeriesRenderItemReturn;
 
 export interface CustomSeriesOption extends
     SeriesOption<unknown>,    // don't support StateOption in custom series.

--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -158,9 +158,6 @@ export interface CustomBaseElementOption extends Partial<Pick<
     extra?: Dictionary<unknown> & TransitionAnyOption;
     // updateDuringAnimation
     during?(params: CustomBaseDuringAPI): void;
-
-    focus?: 'none' | 'self' | 'series' | ArrayLike<number>
-    blurScope?: BlurScope
 };
 
 export interface CustomDisplayableOption extends CustomBaseElementOption, Partial<Pick<
@@ -192,7 +189,7 @@ export interface CustomGroupOption extends CustomBaseElementOption {
     height?: number;
     // @deprecated
     diffChildrenByName?: boolean;
-    children: CustomChildElementOption[];
+    children: CustomElementOption[];
     $mergeChildren?: false | 'byName' | 'byIndex';
 }
 export interface CustomBaseZRPathOption<T extends PathProps['shape'] = PathProps['shape']>
@@ -204,17 +201,17 @@ export interface CustomBaseZRPathOption<T extends PathProps['shape'] = PathProps
 }
 
 interface BuiltinShapes {
-    'circle': Circle['shape']
-    'rect': Rect['shape']
-    'sector': Sector['shape']
-    'poygon': Polygon['shape']
-    'polyline': Polyline['shape']
-    'line': Line['shape']
-    'arc': Arc['shape']
-    'bezierCurve': BezierCurve['shape']
-    'ring': Ring['shape']
-    'ellipse': Ellipse['shape'],
-    'compoundPath': CompoundPath['shape']
+    circle: Partial<Circle['shape']>
+    rect: Partial<Rect['shape']>
+    sector: Partial<Sector['shape']>
+    poygon: Partial<Polygon['shape']>
+    polyline: Partial<Polyline['shape']>
+    line: Partial<Line['shape']>
+    arc: Partial<Arc['shape']>
+    bezierCurve: Partial<BezierCurve['shape']>
+    ring: Partial<Ring['shape']>
+    ellipse: Partial<Ellipse['shape']>
+    compoundPath: Partial<CompoundPath['shape']>
 }
 
 interface CustomSVGPathShapeOption {
@@ -270,7 +267,10 @@ export type CustomElementOption = CustomPathOption
     | CustomGroupOption;
 
 // Can only set focus, blur on the root element.
-export type CustomChildElementOption = Omit<CustomElementOption, 'focus' | 'blurScope'>;
+export type CustomRootElementOption = CustomElementOption & {
+    focus?: 'none' | 'self' | 'series' | ArrayLike<number>
+    blurScope?: BlurScope
+};
 
 export type CustomElementOptionOnState = CustomDisplayableOptionOnState
     | CustomImageOptionOnState;
@@ -287,7 +287,13 @@ export interface CustomSeriesRenderItemAPI extends
 
     value(dim: DimensionLoose, dataIndexInside?: number): ParsedValue;
     ordinalRawValue(dim: DimensionLoose, dataIndexInside?: number): ParsedValue | OrdinalRawValue;
+    /**
+     * @deprecated
+     */
     style(userProps?: ZRStyleProps, dataIndexInside?: number): ZRStyleProps;
+    /**
+     * @deprecated
+     */
     styleEmphasis(userProps?: ZRStyleProps, dataIndexInside?: number): ZRStyleProps;
     visual<VT extends NonStyleVisualProps | StyleVisualProps>(
         visualType: VT,
@@ -310,7 +316,7 @@ export interface CustomSeriesRenderItemCoordinateSystemAPI {
     ): number[];
     size?(
         dataSize: OptionDataValue | OptionDataValue[],
-        dataItem: OptionDataValue | OptionDataValue[]
+        dataItem?: OptionDataValue | OptionDataValue[]
     ): number | number[];
 }
 
@@ -330,6 +336,9 @@ export interface CustomSeriesRenderItemParams {
 
     actionType?: string;
 }
+
+export type CustomSeriesRenderItemReturn = CustomRootElementOption;
+
 type CustomSeriesRenderItem = (
     params: CustomSeriesRenderItemParams,
     api: CustomSeriesRenderItemAPI
@@ -354,7 +363,7 @@ export interface CustomSeriesOption extends
     /**
      * @deprecated
      */
-     itemStyle?: ItemStyleOption;
+    itemStyle?: ItemStyleOption;
     /**
      * @deprecated
      */

--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -335,13 +335,8 @@ type CustomSeriesRenderItem = (
     api: CustomSeriesRenderItemAPI
 ) => CustomElementOption;
 
-interface CustomSeriesStateOption {
-    itemStyle?: ItemStyleOption;
-    label?: LabelOption;
-}
-
 export interface CustomSeriesOption extends
-    SeriesOption<never>,    // don't support StateOption in custom series.
+    SeriesOption<unknown>,    // don't support StateOption in custom series.
     SeriesEncodeOptionMixin,
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin,
@@ -356,11 +351,32 @@ export interface CustomSeriesOption extends
 
     renderItem?: CustomSeriesRenderItem;
 
+    /**
+     * @deprecated
+     */
+     itemStyle?: ItemStyleOption;
+    /**
+     * @deprecated
+     */
+    label?: LabelOption;
+
+    /**
+     * @deprecated
+     */
+    emphasis?: {
+        /**
+         * @deprecated
+         */
+        itemStyle?: ItemStyleOption;
+        /**
+         * @deprecated
+         */
+        label?: LabelOption;
+    }
+
     // Only works on polar and cartesian2d coordinate system.
     clip?: boolean;
 }
-
-export interface LegacyCustomSeriesOption extends SeriesOption<CustomSeriesStateOption>, CustomSeriesStateOption {}
 
 export const customInnerStore = makeInner<{
     info: CustomExtraElementInfo;

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -91,7 +91,8 @@ import CustomSeriesModel, {
     customInnerStore,
     LooseElementProps,
     PrepareCustomInfo,
-    CustomPathOption
+    CustomPathOption,
+    CustomRootElementOption
 } from './CustomSeries';
 import {
     prepareShapeOrExtraAllPropsFinal,
@@ -1148,7 +1149,7 @@ function createOrUpdateItem(
     api: ExtensionAPI,
     existsEl: Element,
     dataIndex: number,
-    elOption: CustomElementOption,
+    elOption: CustomRootElementOption,
     seriesModel: CustomSeriesModel,
     group: ViewRootGroup,
     data: SeriesData<CustomSeriesModel>

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -82,7 +82,6 @@ import CustomSeriesModel, {
     CustomDisplayableOption,
     CustomSeriesRenderItemAPI,
     CustomSeriesRenderItemParams,
-    LegacyCustomSeriesOption,
     CustomGroupOption,
     WrapEncodeDefRet,
     NonStyleVisualProps,
@@ -102,6 +101,7 @@ import {
     prepareTransformTransitionFrom
 } from './prepare';
 import { PatternObject } from 'zrender/src/graphic/Pattern';
+import { CustomSeriesOption } from '../../export/option';
 
 const transformPropNamesStr = keys(TRANSFORM_PROPS).join(', ');
 
@@ -879,23 +879,23 @@ function makeRenderItem(
 
     // Do not support call `api` asynchronously without dataIndexInside input.
     let currDataIndexInside: number;
-    let currItemModel: Model<LegacyCustomSeriesOption>;
-    let currItemStyleModels: Partial<Record<DisplayState, Model<LegacyCustomSeriesOption['itemStyle']>>> = {};
-    let currLabelModels: Partial<Record<DisplayState, Model<LegacyCustomSeriesOption['label']>>> = {};
+    let currItemModel: Model<CustomSeriesOption>;
+    let currItemStyleModels: Partial<Record<DisplayState, Model<CustomSeriesOption['itemStyle']>>> = {};
+    let currLabelModels: Partial<Record<DisplayState, Model<CustomSeriesOption['label']>>> = {};
 
-    const seriesItemStyleModels = {} as Record<DisplayState, Model<LegacyCustomSeriesOption['itemStyle']>>;
+    const seriesItemStyleModels = {} as Record<DisplayState, Model<CustomSeriesOption['itemStyle']>>;
 
-    const seriesLabelModels = {} as Record<DisplayState, Model<LegacyCustomSeriesOption['label']>>;
+    const seriesLabelModels = {} as Record<DisplayState, Model<CustomSeriesOption['label']>>;
 
     for (let i = 0; i < STATES.length; i++) {
         const stateName = STATES[i];
-        seriesItemStyleModels[stateName] = (customSeries as Model<LegacyCustomSeriesOption>)
+        seriesItemStyleModels[stateName] = (customSeries as Model<CustomSeriesOption>)
             .getModel(PATH_ITEM_STYLE[stateName]);
-        seriesLabelModels[stateName] = (customSeries as Model<LegacyCustomSeriesOption>)
+        seriesLabelModels[stateName] = (customSeries as Model<CustomSeriesOption>)
             .getModel(PATH_LABEL[stateName]);
     }
 
-    function getItemModel(dataIndexInside: number): Model<LegacyCustomSeriesOption> {
+    function getItemModel(dataIndexInside: number): Model<CustomSeriesOption> {
         return dataIndexInside === currDataIndexInside
             ? (currItemModel || (currItemModel = data.getItemModel(dataIndexInside)))
             : data.getItemModel(dataIndexInside);

--- a/src/chart/effectScatter/EffectScatterSeries.ts
+++ b/src/chart/effectScatter/EffectScatterSeries.ts
@@ -48,8 +48,8 @@ interface EffectScatterStatesOptionMixin {
         scale?: boolean
     }
 }
-export interface EffectScatterStateOption {
-    itemStyle?: ItemStyleOption
+export interface EffectScatterStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
 
@@ -64,7 +64,8 @@ export interface EffectScatterDataItemOption extends SymbolOptionMixin,
 }
 
 export interface EffectScatterSeriesOption
-    extends SeriesOption<EffectScatterStateOption, EffectScatterStatesOptionMixin>, EffectScatterStateOption,
+    extends SeriesOption<EffectScatterStateOption<CallbackDataParams>, EffectScatterStatesOptionMixin>,
+    EffectScatterStateOption<CallbackDataParams>,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin, SymbolOptionMixin<CallbackDataParams>,
     SeriesEncodeOptionMixin {

--- a/src/chart/effectScatter/EffectScatterSeries.ts
+++ b/src/chart/effectScatter/EffectScatterSeries.ts
@@ -32,7 +32,8 @@ import {
     SeriesLabelOption,
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
-    CallbackDataParams
+    CallbackDataParams,
+    DefaultEmphasisFocus
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -41,6 +42,12 @@ import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 
 type ScatterDataValue = OptionDataValue | OptionDataValue[];
 
+interface EffectScatterStatesOptionMixin {
+    emphasis?: {
+        focus?: DefaultEmphasisFocus
+        scale?: boolean
+    }
+}
 export interface EffectScatterStateOption {
     itemStyle?: ItemStyleOption
     label?: SeriesLabelOption
@@ -48,7 +55,7 @@ export interface EffectScatterStateOption {
 
 export interface EffectScatterDataItemOption extends SymbolOptionMixin,
     EffectScatterStateOption,
-    StatesOptionMixin<EffectScatterStateOption> {
+    StatesOptionMixin<EffectScatterStateOption, EffectScatterStatesOptionMixin> {
     name?: string
 
     value?: ScatterDataValue
@@ -56,7 +63,8 @@ export interface EffectScatterDataItemOption extends SymbolOptionMixin,
     rippleEffect?: SymbolDrawItemModelOption['rippleEffect']
 }
 
-export interface EffectScatterSeriesOption extends SeriesOption<EffectScatterStateOption>, EffectScatterStateOption,
+export interface EffectScatterSeriesOption
+    extends SeriesOption<EffectScatterStateOption, EffectScatterStatesOptionMixin>, EffectScatterStateOption,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin, SymbolOptionMixin<CallbackDataParams>,
     SeriesEncodeOptionMixin {

--- a/src/chart/funnel/FunnelSeries.ts
+++ b/src/chart/funnel/FunnelSeries.ts
@@ -36,7 +36,8 @@ import {
     LayoutOrient,
     VerticalAlign,
     SeriesLabelOption,
-    SeriesEncodeOptionMixin
+    SeriesEncodeOptionMixin,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -46,6 +47,10 @@ type FunnelLabelOption = Omit<SeriesLabelOption, 'position'> & {
         | 'outer' | 'inner' | 'center' | 'rightTop' | 'rightBottom' | 'leftTop' | 'leftBottom'
 };
 
+interface FunnelStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
+
 export interface FunnelStateOption {
     itemStyle?: ItemStyleOption
     label?: FunnelLabelOption
@@ -53,7 +58,7 @@ export interface FunnelStateOption {
 }
 
 export interface FunnelDataItemOption
-    extends FunnelStateOption, StatesOptionMixin<FunnelStateOption>,
+    extends FunnelStateOption, StatesOptionMixin<FunnelStateOption, FunnelStatesMixin>,
     OptionDataItemObject<OptionDataValueNumeric> {
 
     itemStyle?: ItemStyleOption & {
@@ -62,7 +67,7 @@ export interface FunnelDataItemOption
     }
 }
 
-export interface FunnelSeriesOption extends SeriesOption<FunnelStateOption>, FunnelStateOption,
+export interface FunnelSeriesOption extends SeriesOption<FunnelStateOption, FunnelStatesMixin>, FunnelStateOption,
     BoxLayoutOptionMixin, SeriesEncodeOptionMixin {
     type?: 'funnel'
 

--- a/src/chart/funnel/FunnelSeries.ts
+++ b/src/chart/funnel/FunnelSeries.ts
@@ -37,7 +37,8 @@ import {
     VerticalAlign,
     SeriesLabelOption,
     SeriesEncodeOptionMixin,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    CallbackDataParams
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -51,8 +52,11 @@ interface FunnelStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
 
-export interface FunnelStateOption {
-    itemStyle?: ItemStyleOption
+export interface FunnelCallbackDataParams extends CallbackDataParams {
+    percent: number
+}
+export interface FunnelStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: FunnelLabelOption
     labelLine?: LabelLineOption
 }
@@ -67,7 +71,9 @@ export interface FunnelDataItemOption
     }
 }
 
-export interface FunnelSeriesOption extends SeriesOption<FunnelStateOption, FunnelStatesMixin>, FunnelStateOption,
+export interface FunnelSeriesOption
+    extends SeriesOption<FunnelStateOption<FunnelCallbackDataParams>, FunnelStatesMixin>,
+    FunnelStateOption<FunnelCallbackDataParams>,
     BoxLayoutOptionMixin, SeriesEncodeOptionMixin {
     type?: 'funnel'
 
@@ -128,9 +134,9 @@ class FunnelSeriesModel extends SeriesModel<FunnelSeriesOption> {
     }
 
     // Overwrite
-    getDataParams(dataIndex: number) {
+    getDataParams(dataIndex: number): FunnelCallbackDataParams {
         const data = this.getData();
-        const params = super.getDataParams(dataIndex);
+        const params = super.getDataParams(dataIndex) as FunnelCallbackDataParams;
         const valueDim = data.mapDimension('value');
         const sum = data.getSum(valueDim);
         // Percent is 0 if sum is 0

--- a/src/chart/gauge/GaugeSeries.ts
+++ b/src/chart/gauge/GaugeSeries.ts
@@ -29,7 +29,8 @@ import {
     OptionDataValueNumeric,
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    CallbackDataParams
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -106,12 +107,12 @@ interface DetailOption extends LabelOption {
 interface GaugeStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
-export interface GaugeStateOption {
-    itemStyle?: ItemStyleOption
+export interface GaugeStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
 }
 
 export interface GaugeDataItemOption extends GaugeStateOption,
-    StatesOptionMixin<GaugeStateOption, GaugeStatesMixin> {
+    StatesOptionMixin<GaugeStateOption<CallbackDataParams>, GaugeStatesMixin> {
     name?: string
     value?: OptionDataValueNumeric
     pointer?: PointerOption
@@ -119,7 +120,8 @@ export interface GaugeDataItemOption extends GaugeStateOption,
     title?: TitleOption
     detail?: DetailOption
 }
-export interface GaugeSeriesOption extends SeriesOption<GaugeStateOption, GaugeStatesMixin>, GaugeStateOption,
+export interface GaugeSeriesOption extends SeriesOption<GaugeStateOption, GaugeStatesMixin>,
+    GaugeStateOption<CallbackDataParams>,
     CircleLayoutOptionMixin, SeriesEncodeOptionMixin {
     type?: 'gauge'
 

--- a/src/chart/gauge/GaugeSeries.ts
+++ b/src/chart/gauge/GaugeSeries.ts
@@ -28,7 +28,8 @@ import {
     ItemStyleOption,
     OptionDataValueNumeric,
     StatesOptionMixin,
-    SeriesEncodeOptionMixin
+    SeriesEncodeOptionMixin,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -102,11 +103,15 @@ interface DetailOption extends LabelOption {
     valueAnimation?: boolean
 }
 
+interface GaugeStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
 export interface GaugeStateOption {
     itemStyle?: ItemStyleOption
 }
 
-export interface GaugeDataItemOption extends GaugeStateOption, StatesOptionMixin<GaugeStateOption> {
+export interface GaugeDataItemOption extends GaugeStateOption,
+    StatesOptionMixin<GaugeStateOption, GaugeStatesMixin> {
     name?: string
     value?: OptionDataValueNumeric
     pointer?: PointerOption
@@ -114,7 +119,7 @@ export interface GaugeDataItemOption extends GaugeStateOption, StatesOptionMixin
     title?: TitleOption
     detail?: DetailOption
 }
-export interface GaugeSeriesOption extends SeriesOption<GaugeStateOption>, GaugeStateOption,
+export interface GaugeSeriesOption extends SeriesOption<GaugeStateOption, GaugeStatesMixin>, GaugeStateOption,
     CircleLayoutOptionMixin, SeriesEncodeOptionMixin {
     type?: 'gauge'
 

--- a/src/chart/graph/GraphSeries.ts
+++ b/src/chart/graph/GraphSeries.ts
@@ -71,16 +71,16 @@ export interface GraphNodeStateOption {
 interface ExtraEmphasisState {
     focus?: DefaultEmphasisFocus | 'adjacency'
 }
-interface ExtraNodeStateOption {
+interface GraphNodeStatesMixin {
     emphasis?: ExtraEmphasisState
 }
 
-interface ExtraEdgeStateOption {
+interface GraphEdgeStatesMixin {
     emphasis?: ExtraEmphasisState
 }
 
 export interface GraphNodeItemOption extends SymbolOptionMixin, GraphNodeStateOption,
-    GraphNodeStateOption, StatesOptionMixin<GraphNodeStateOption, ExtraNodeStateOption> {
+    GraphNodeStateOption, StatesOptionMixin<GraphNodeStateOption, GraphNodeStatesMixin> {
 
     id?: string
     name?: string
@@ -114,7 +114,7 @@ export interface GraphEdgeStateOption {
 }
 export interface GraphEdgeItemOption extends
         GraphEdgeStateOption,
-        StatesOptionMixin<GraphEdgeStateOption, ExtraEdgeStateOption>,
+        StatesOptionMixin<GraphEdgeStateOption, GraphEdgeStatesMixin>,
         GraphEdgeItemObject<OptionDataValueNumeric> {
 
     value?: number
@@ -130,13 +130,13 @@ export interface GraphEdgeItemOption extends
 }
 
 export interface GraphCategoryItemOption extends SymbolOptionMixin,
-    GraphNodeStateOption, StatesOptionMixin<GraphNodeStateOption> {
+    GraphNodeStateOption, StatesOptionMixin<GraphNodeStateOption, GraphNodeStatesMixin> {
     name?: string
 
     value?: OptionDataValue
 }
 
-export interface GraphSeriesOption extends SeriesOption,
+export interface GraphSeriesOption extends SeriesOption<GraphNodeStateOption, GraphNodeStatesMixin>,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin,
     SymbolOptionMixin<CallbackDataParams>,

--- a/src/chart/graph/GraphSeries.ts
+++ b/src/chart/graph/GraphSeries.ts
@@ -62,8 +62,8 @@ interface GraphEdgeLineStyleOption extends LineStyleOption {
     curveness?: number
 }
 
-export interface GraphNodeStateOption {
-    itemStyle?: ItemStyleOption
+export interface GraphNodeStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
 
@@ -136,7 +136,8 @@ export interface GraphCategoryItemOption extends SymbolOptionMixin,
     value?: OptionDataValue
 }
 
-export interface GraphSeriesOption extends SeriesOption<GraphNodeStateOption, GraphNodeStatesMixin>,
+export interface GraphSeriesOption
+    extends SeriesOption<GraphNodeStateOption<CallbackDataParams>, GraphNodeStatesMixin>,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin,
     SymbolOptionMixin<CallbackDataParams>,
@@ -177,7 +178,7 @@ export interface GraphSeriesOption extends SeriesOption<GraphNodeStateOption, Gr
     edgeLabel?: SeriesLineLabelOption
     label?: SeriesLabelOption
 
-    itemStyle?: ItemStyleOption
+    itemStyle?: ItemStyleOption<CallbackDataParams>
     lineStyle?: GraphEdgeLineStyleOption
 
     emphasis?: {

--- a/src/chart/heatmap/HeatmapSeries.ts
+++ b/src/chart/heatmap/HeatmapSeries.ts
@@ -30,7 +30,8 @@ import {
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
     SeriesOnCalendarOptionMixin,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    CallbackDataParams
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -40,9 +41,9 @@ import type Calendar from '../../coord/calendar/Calendar';
 
 type HeatmapDataValue = OptionDataValue[];
 
-export interface HeatmapStateOption {
+export interface HeatmapStateOption<TCbParams = never> {
     // Available on cartesian2d coordinate system
-    itemStyle?: ItemStyleOption
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
 
@@ -54,8 +55,14 @@ export interface HeatmapDataItemOption extends HeatmapStateOption,
     value: HeatmapDataValue
 }
 
-export interface HeatmapSeriesOption extends SeriesOption<HeatmapStateOption, FunnelStatesMixin>, HeatmapStateOption,
-    SeriesOnCartesianOptionMixin, SeriesOnGeoOptionMixin, SeriesOnCalendarOptionMixin, SeriesEncodeOptionMixin {
+export interface HeatmapSeriesOption
+    extends SeriesOption<HeatmapStateOption<CallbackDataParams>, FunnelStatesMixin>,
+    HeatmapStateOption<CallbackDataParams>,
+    SeriesOnCartesianOptionMixin,
+    SeriesOnGeoOptionMixin,
+    SeriesOnCalendarOptionMixin,
+    SeriesEncodeOptionMixin {
+
     type?: 'heatmap'
 
     coordinateSystem?: 'cartesian2d' | 'geo' | 'calendar'
@@ -68,6 +75,8 @@ export interface HeatmapSeriesOption extends SeriesOption<HeatmapStateOption, Fu
 
     data?: (HeatmapDataItemOption | HeatmapDataValue)[]
 }
+
+
 
 class HeatmapSeriesModel extends SeriesModel<HeatmapSeriesOption> {
     static readonly type = 'series.heatmap';

--- a/src/chart/heatmap/HeatmapSeries.ts
+++ b/src/chart/heatmap/HeatmapSeries.ts
@@ -29,7 +29,8 @@ import {
     OptionDataValue,
     StatesOptionMixin,
     SeriesEncodeOptionMixin,
-    SeriesOnCalendarOptionMixin
+    SeriesOnCalendarOptionMixin,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -45,11 +46,15 @@ export interface HeatmapStateOption {
     label?: SeriesLabelOption
 }
 
-export interface HeatmapDataItemOption extends HeatmapStateOption, StatesOptionMixin<HeatmapStateOption> {
+interface FunnelStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
+export interface HeatmapDataItemOption extends HeatmapStateOption,
+    StatesOptionMixin<HeatmapStateOption, FunnelStatesMixin> {
     value: HeatmapDataValue
 }
 
-export interface HeatmapSeriesOption extends SeriesOption<HeatmapStateOption>, HeatmapStateOption,
+export interface HeatmapSeriesOption extends SeriesOption<HeatmapStateOption, FunnelStatesMixin>, HeatmapStateOption,
     SeriesOnCartesianOptionMixin, SeriesOnGeoOptionMixin, SeriesOnCalendarOptionMixin, SeriesEncodeOptionMixin {
     type?: 'heatmap'
 

--- a/src/chart/helper/LineDraw.ts
+++ b/src/chart/helper/LineDraw.ts
@@ -29,7 +29,8 @@ import {
     ZRStyleProps,
     StatesOptionMixin,
     DisplayState,
-    LabelOption
+    LabelOption,
+    StatesMixinBase
 } from '../../util/types';
 import Displayable from 'zrender/src/graphic/Displayable';
 import Model from '../../model/Model';
@@ -50,7 +51,8 @@ interface LineDrawStateOption {
     label?: LineLabelOption
 }
 
-export interface LineDrawModelOption extends LineDrawStateOption, StatesOptionMixin<LineDrawStateOption> {
+export interface LineDrawModelOption extends LineDrawStateOption,
+    StatesOptionMixin<LineDrawStateOption, StatesMixinBase> {
     // If has effect
     effect?: {
         show?: boolean

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -52,8 +52,8 @@ interface LineStateOptionMixin {
     }
 }
 
-export interface LineStateOption {
-    itemStyle?: ItemStyleOption
+export interface LineStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
     endLabel?: LineEndLabelOption
 }
@@ -70,7 +70,7 @@ export interface LineEndLabelOption extends SeriesLabelOption {
 }
 
 
-export interface LineSeriesOption extends SeriesOption<LineStateOption, LineStateOptionMixin & {
+export interface LineSeriesOption extends SeriesOption<LineStateOption<CallbackDataParams>, LineStateOptionMixin & {
     emphasis?: {
         lineStyle?: LineStyleOption | {
             width?: 'bolder'
@@ -81,7 +81,7 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption, LineStat
         lineStyle?: LineStyleOption
         areaStyle?: AreaStyleOption
     }
-}>, LineStateOption,
+}>, LineStateOption<CallbackDataParams>,
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin,
     SeriesStackOptionMixin,

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -115,7 +115,7 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption, ExtraSta
     showSymbol?: boolean
     // false | 'auto': follow the label interval strategy.
     // true: show all symbols.
-    showAllSymbol?: 'auto'
+    showAllSymbol?: 'auto' | boolean
 
     data?: (LineDataValue | LineDataItemOption)[]
 }

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -45,7 +45,7 @@ import {LegendIconParams} from '../../component/legend/LegendModel';
 
 type LineDataValue = OptionDataValue | OptionDataValue[];
 
-interface ExtraStateOption {
+interface LineStateOptionMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus
         scale?: boolean
@@ -59,7 +59,7 @@ export interface LineStateOption {
 }
 
 export interface LineDataItemOption extends SymbolOptionMixin,
-    LineStateOption, StatesOptionMixin<LineStateOption, ExtraStateOption> {
+    LineStateOption, StatesOptionMixin<LineStateOption, LineStateOptionMixin> {
     name?: string
 
     value?: LineDataValue
@@ -70,7 +70,7 @@ export interface LineEndLabelOption extends SeriesLabelOption {
 }
 
 
-export interface LineSeriesOption extends SeriesOption<LineStateOption, ExtraStateOption & {
+export interface LineSeriesOption extends SeriesOption<LineStateOption, LineStateOptionMixin & {
     emphasis?: {
         lineStyle?: LineStyleOption | {
             width?: 'bolder'

--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -34,7 +34,8 @@ import {
     OptionDataValue,
     StatesOptionMixin,
     SeriesLineLabelOption,
-    DimensionDefinitionLoose
+    DimensionDefinitionLoose,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import type { LineDrawModelOption } from '../helper/LineDraw';
@@ -82,12 +83,16 @@ interface LegacyDataItemOption {
     name: string
 }
 
+interface LinesStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
 export interface LinesStateOption {
     lineStyle?: LinesLineStyleOption
     label?: SeriesLineLabelOption
 }
 
-export interface LinesDataItemOption extends LinesStateOption, StatesOptionMixin<LinesStateOption> {
+export interface LinesDataItemOption extends LinesStateOption,
+    StatesOptionMixin<LinesStateOption, LinesStatesMixin> {
     name?: string
 
     fromName?: string
@@ -105,8 +110,8 @@ export interface LinesDataItemOption extends LinesStateOption, StatesOptionMixin
     dimensions?: DimensionDefinitionLoose
 }
 
-export interface LinesSeriesOption extends SeriesOption<LinesStateOption>, LinesStateOption,
-
+export interface LinesSeriesOption
+    extends SeriesOption<LinesStateOption, LinesStatesMixin>, LinesStateOption,
     SeriesOnCartesianOptionMixin, SeriesOnGeoOptionMixin, SeriesOnPolarOptionMixin,
     SeriesOnCalendarOptionMixin, SeriesLargeOptionMixin {
 

--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -35,7 +35,9 @@ import {
     StatesOptionMixin,
     SeriesLineLabelOption,
     DimensionDefinitionLoose,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    ZRColor,
+    CallbackDataParams
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import type { LineDrawModelOption } from '../helper/LineDraw';
@@ -73,7 +75,7 @@ type LinesCoords = number[][];
 
 type LinesValue = OptionDataValue | OptionDataValue[];
 
-interface LinesLineStyleOption extends LineStyleOption {
+interface LinesLineStyleOption<TClr> extends LineStyleOption<TClr> {
     curveness?: number
 }
 
@@ -86,13 +88,13 @@ interface LegacyDataItemOption {
 interface LinesStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
-export interface LinesStateOption {
-    lineStyle?: LinesLineStyleOption
+export interface LinesStateOption<TCbParams = never> {
+    lineStyle?: LinesLineStyleOption<TCbParams extends never ? never : (params: TCbParams) => ZRColor>
     label?: SeriesLineLabelOption
 }
 
-export interface LinesDataItemOption extends LinesStateOption,
-    StatesOptionMixin<LinesStateOption, LinesStatesMixin> {
+export interface LinesDataItemOption extends LinesStateOption<CallbackDataParams>,
+    StatesOptionMixin<LinesStateOption<CallbackDataParams>, LinesStatesMixin> {
     name?: string
 
     fromName?: string

--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -89,7 +89,7 @@ interface LinesStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
 export interface LinesStateOption<TCbParams = never> {
-    lineStyle?: LinesLineStyleOption<TCbParams extends never ? never : (params: TCbParams) => ZRColor>
+    lineStyle?: LinesLineStyleOption<(TCbParams extends never ? never : (params: TCbParams) => ZRColor) | ZRColor>
     label?: SeriesLineLabelOption
 }
 
@@ -108,8 +108,6 @@ export interface LinesDataItemOption extends LinesStateOption<CallbackDataParams
     value?: LinesValue
 
     effect?: LineDrawModelOption['effect']
-
-    dimensions?: DimensionDefinitionLoose
 }
 
 export interface LinesSeriesOption
@@ -141,6 +139,8 @@ export interface LinesSeriesOption
         // Stored as a flat array. In format
         // Points Count(2) | x | y | x | y | Points Count(3) | x |  y | x | y | x | y |
         | ArrayLike<number>
+
+    dimensions?: DimensionDefinitionLoose | DimensionDefinitionLoose[]
 }
 
 class LinesSeriesModel extends SeriesModel<LinesSeriesOption> {

--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -33,7 +33,8 @@ import {
     LineStyleOption,
     OptionDataValue,
     StatesOptionMixin,
-    SeriesLineLabelOption
+    SeriesLineLabelOption,
+    DimensionDefinitionLoose
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import type { LineDrawModelOption } from '../helper/LineDraw';
@@ -98,6 +99,10 @@ export interface LinesDataItemOption extends LinesStateOption, StatesOptionMixin
     coords?: LinesCoords
 
     value?: LinesValue
+
+    effect?: LineDrawModelOption['effect']
+
+    dimensions?: DimensionDefinitionLoose
 }
 
 export interface LinesSeriesOption extends SeriesOption<LinesStateOption>, LinesStateOption,

--- a/src/chart/map/MapSeries.ts
+++ b/src/chart/map/MapSeries.ts
@@ -33,7 +33,8 @@ import {
     SeriesOnGeoOptionMixin,
     StatesOptionMixin,
     SeriesLabelOption,
-    StatesMixinBase
+    StatesMixinBase,
+    CallbackDataParams
 } from '../../util/types';
 import { Dictionary } from 'zrender/src/core/types';
 import GeoModel, { GeoCommonOptionMixin, GeoItemStyleOption } from '../../coord/geo/GeoModel';
@@ -45,11 +46,12 @@ import {createSymbol, ECSymbol} from '../../util/symbol';
 import {LegendIconParams} from '../../component/legend/LegendModel';
 import {Group} from '../../util/graphic';
 
-export interface MapStateOption {
-    itemStyle?: GeoItemStyleOption
+export interface MapStateOption<TCbParams = never> {
+    itemStyle?: GeoItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
-export interface MapDataItemOption extends MapStateOption, StatesOptionMixin<MapStateOption, StatesMixinBase>,
+export interface MapDataItemOption extends MapStateOption,
+    StatesOptionMixin<MapStateOption, StatesMixinBase>,
     OptionDataItemObject<OptionDataValueNumeric> {
     cursor?: string
 }
@@ -57,8 +59,8 @@ export interface MapDataItemOption extends MapStateOption, StatesOptionMixin<Map
 export type MapValueCalculationType = 'sum' | 'average' | 'min' | 'max';
 
 export interface MapSeriesOption extends
-    SeriesOption<MapStateOption, StatesMixinBase>, MapStateOption,
-
+    SeriesOption<MapStateOption<CallbackDataParams>, StatesMixinBase>,
+    MapStateOption<CallbackDataParams>,
     GeoCommonOptionMixin,
     // If `geoIndex` is not specified, a exclusive geo will be
     // created. Otherwise use the specified geo component, and

--- a/src/chart/map/MapSeries.ts
+++ b/src/chart/map/MapSeries.ts
@@ -32,7 +32,8 @@ import {
     ParsedValue,
     SeriesOnGeoOptionMixin,
     StatesOptionMixin,
-    SeriesLabelOption
+    SeriesLabelOption,
+    StatesMixinBase
 } from '../../util/types';
 import { Dictionary } from 'zrender/src/core/types';
 import GeoModel, { GeoCommonOptionMixin, GeoItemStyleOption } from '../../coord/geo/GeoModel';
@@ -48,7 +49,7 @@ export interface MapStateOption {
     itemStyle?: GeoItemStyleOption
     label?: SeriesLabelOption
 }
-export interface MapDataItemOption extends MapStateOption, StatesOptionMixin<MapStateOption>,
+export interface MapDataItemOption extends MapStateOption, StatesOptionMixin<MapStateOption, StatesMixinBase>,
     OptionDataItemObject<OptionDataValueNumeric> {
     cursor?: string
 }
@@ -56,7 +57,7 @@ export interface MapDataItemOption extends MapStateOption, StatesOptionMixin<Map
 export type MapValueCalculationType = 'sum' | 'average' | 'min' | 'max';
 
 export interface MapSeriesOption extends
-    SeriesOption<MapStateOption>, MapStateOption,
+    SeriesOption<MapStateOption, StatesMixinBase>, MapStateOption,
 
     GeoCommonOptionMixin,
     // If `geoIndex` is not specified, a exclusive geo will be

--- a/src/chart/parallel/ParallelSeries.ts
+++ b/src/chart/parallel/ParallelSeries.ts
@@ -33,7 +33,9 @@ import {
     OptionEncodeValue,
     Dictionary,
     OptionEncode,
-    DefaultStatesMixinEmpasis
+    DefaultStatesMixinEmpasis,
+    ZRColor,
+    CallbackDataParams
  } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -46,8 +48,8 @@ type ParallelSeriesDataValue = OptionDataValue[];
 interface ParallelStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
-export interface ParallelStateOption {
-    lineStyle?: LineStyleOption
+export interface ParallelStateOption<TCbParams = never> {
+    lineStyle?: LineStyleOption<TCbParams extends never ? never : (params: TCbParams) => ZRColor>
     label?: SeriesLabelOption
 }
 
@@ -56,7 +58,8 @@ export interface ParallelSeriesDataItemOption extends ParallelStateOption,
     value?: ParallelSeriesDataValue[]
 }
 export interface ParallelSeriesOption extends
-    SeriesOption<ParallelStateOption, ParallelStatesMixin>, ParallelStateOption,
+    SeriesOption<ParallelStateOption<CallbackDataParams>, ParallelStatesMixin>,
+    ParallelStateOption<CallbackDataParams>,
     SeriesEncodeOptionMixin {
 
     type?: 'parallel';
@@ -74,13 +77,10 @@ export interface ParallelSeriesOption extends
 
     parallelAxisDefault?: ParallelAxisOption;
 
-    emphasis?: {
-        label?: SeriesLabelOption;
-        lineStyle?: LineStyleOption;
-    }
 
     data?: (ParallelSeriesDataValue | ParallelSeriesDataItemOption)[]
 }
+
 
 class ParallelSeriesModel extends SeriesModel<ParallelSeriesOption> {
 

--- a/src/chart/parallel/ParallelSeries.ts
+++ b/src/chart/parallel/ParallelSeries.ts
@@ -32,7 +32,8 @@ import {
     StatesOptionMixin,
     OptionEncodeValue,
     Dictionary,
-    OptionEncode
+    OptionEncode,
+    DefaultStatesMixinEmpasis
  } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -42,17 +43,20 @@ import ParallelModel from '../../coord/parallel/ParallelModel';
 
 type ParallelSeriesDataValue = OptionDataValue[];
 
+interface ParallelStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
 export interface ParallelStateOption {
     lineStyle?: LineStyleOption
     label?: SeriesLabelOption
 }
 
-export interface ParallelSeriesDataItemOption extends ParallelStateOption, StatesOptionMixin<ParallelStateOption> {
+export interface ParallelSeriesDataItemOption extends ParallelStateOption,
+    StatesOptionMixin<ParallelStateOption, ParallelStatesMixin> {
     value?: ParallelSeriesDataValue[]
 }
-
 export interface ParallelSeriesOption extends
-    SeriesOption<ParallelStateOption>, ParallelStateOption,
+    SeriesOption<ParallelStateOption, ParallelStatesMixin>, ParallelStateOption,
     SeriesEncodeOptionMixin {
 
     type?: 'parallel';

--- a/src/chart/parallel/ParallelSeries.ts
+++ b/src/chart/parallel/ParallelSeries.ts
@@ -49,7 +49,7 @@ interface ParallelStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
 export interface ParallelStateOption<TCbParams = never> {
-    lineStyle?: LineStyleOption<TCbParams extends never ? never : (params: TCbParams) => ZRColor>
+    lineStyle?: LineStyleOption<(TCbParams extends never ? never : (params: TCbParams) => ZRColor) | ZRColor>
     label?: SeriesLabelOption
 }
 

--- a/src/chart/parallel/ParallelView.ts
+++ b/src/chart/parallel/ParallelView.ts
@@ -172,7 +172,9 @@ function createLinePoints(data: SeriesData, dataIndex: number, dimensions: strin
     return points;
 }
 
-function addEl(data: SeriesData, dataGroup: graphic.Group, dataIndex: number, dimensions: string[], coordSys: Parallel) {
+function addEl(
+    data: SeriesData, dataGroup: graphic.Group, dataIndex: number, dimensions: string[], coordSys: Parallel
+) {
     const points = createLinePoints(data, dataIndex, dimensions, coordSys);
     const line = new graphic.Polyline({
         shape: {points: points},

--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -40,7 +40,7 @@ import {
 } from '../../util/types';
 import SeriesData from '../../data/SeriesData';
 
-interface PieItemStyleOption extends ItemStyleOption {
+interface PieItemStyleOption<TCbParams = never> extends ItemStyleOption<TCbParams> {
     // can be 10
     // which means that both innerCornerRadius and outerCornerRadius are 10
     // can also be an array [20, 10]
@@ -52,9 +52,13 @@ interface PieItemStyleOption extends ItemStyleOption {
     borderRadius?: (number | string)[] | number | string
 }
 
-export interface PieStateOption {
+export interface PieCallbackDataParams extends CallbackDataParams {
+    percent: number
+}
+
+export interface PieStateOption<TCbParams = never> {
     // TODO: TYPE Color Callback
-    itemStyle?: PieItemStyleOption
+    itemStyle?: PieItemStyleOption<TCbParams>
     label?: PieLabelOption
     labelLine?: PieLabelLineOption
 }
@@ -94,7 +98,8 @@ export interface PieDataItemOption extends
     cursor?: string
 }
 export interface PieSeriesOption extends
-    Omit<SeriesOption<PieStateOption, ExtraStateOption>, 'labelLine'>, PieStateOption,
+    Omit<SeriesOption<PieStateOption<PieCallbackDataParams>, ExtraStateOption>, 'labelLine'>,
+    PieStateOption<PieCallbackDataParams>,
     CircleLayoutOptionMixin,
     BoxLayoutOptionMixin,
     SeriesEncodeOptionMixin {
@@ -163,9 +168,9 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
     /**
      * @overwrite
      */
-    getDataParams(dataIndex: number): CallbackDataParams {
+    getDataParams(dataIndex: number): PieCallbackDataParams {
         const data = this.getData();
-        const params = super.getDataParams(dataIndex);
+        const params = super.getDataParams(dataIndex) as PieCallbackDataParams;
         // FIXME toFixed?
 
         const valueList: number[] = [];

--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -91,7 +91,6 @@ interface ExtraStateOption {
 export interface PieDataItemOption extends
     OptionDataItemObject<OptionDataValueNumeric>,
     PieStateOption, StatesOptionMixin<PieStateOption, ExtraStateOption> {
-
     cursor?: string
 }
 export interface PieSeriesOption extends

--- a/src/chart/radar/RadarSeries.ts
+++ b/src/chart/radar/RadarSeries.ts
@@ -32,7 +32,8 @@ import {
     StatesOptionMixin,
     OptionDataItemObject,
     SeriesEncodeOptionMixin,
-    CallbackDataParams
+    CallbackDataParams,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -43,6 +44,9 @@ import {
 
 type RadarSeriesDataValue = OptionDataValue[];
 
+interface RadarStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
 export interface RadarSeriesStateOption {
     lineStyle?: LineStyleOption
     areaStyle?: AreaStyleOption
@@ -50,11 +54,12 @@ export interface RadarSeriesStateOption {
     itemStyle?: ItemStyleOption
 }
 export interface RadarSeriesDataItemOption extends SymbolOptionMixin,
-    RadarSeriesStateOption, StatesOptionMixin<RadarSeriesStateOption>,
+    RadarSeriesStateOption, StatesOptionMixin<RadarSeriesStateOption, RadarStatesMixin>,
     OptionDataItemObject<RadarSeriesDataValue> {
 }
 
-export interface RadarSeriesOption extends SeriesOption<RadarSeriesStateOption>, RadarSeriesStateOption,
+export interface RadarSeriesOption
+    extends SeriesOption<RadarSeriesStateOption, RadarStatesMixin>, RadarSeriesStateOption,
     SymbolOptionMixin<CallbackDataParams>, SeriesEncodeOptionMixin {
     type?: 'radar'
     coordinateSystem?: 'radar'

--- a/src/chart/radar/RadarSeries.ts
+++ b/src/chart/radar/RadarSeries.ts
@@ -47,19 +47,21 @@ type RadarSeriesDataValue = OptionDataValue[];
 interface RadarStatesMixin {
     emphasis?: DefaultStatesMixinEmpasis
 }
-export interface RadarSeriesStateOption {
+export interface RadarSeriesStateOption<TCbParams = never> {
     lineStyle?: LineStyleOption
     areaStyle?: AreaStyleOption
     label?: SeriesLabelOption
-    itemStyle?: ItemStyleOption
+    itemStyle?: ItemStyleOption<TCbParams>
 }
 export interface RadarSeriesDataItemOption extends SymbolOptionMixin,
-    RadarSeriesStateOption, StatesOptionMixin<RadarSeriesStateOption, RadarStatesMixin>,
+    RadarSeriesStateOption<CallbackDataParams>,
+    StatesOptionMixin<RadarSeriesStateOption<CallbackDataParams>, RadarStatesMixin>,
     OptionDataItemObject<RadarSeriesDataValue> {
 }
 
 export interface RadarSeriesOption
-    extends SeriesOption<RadarSeriesStateOption, RadarStatesMixin>, RadarSeriesStateOption,
+    extends SeriesOption<RadarSeriesStateOption, RadarStatesMixin>,
+    RadarSeriesStateOption,
     SymbolOptionMixin<CallbackDataParams>, SeriesEncodeOptionMixin {
     type?: 'radar'
     coordinateSystem?: 'radar'

--- a/src/chart/sankey/SankeySeries.ts
+++ b/src/chart/sankey/SankeySeries.ts
@@ -33,7 +33,8 @@ import {
     OptionDataItemObject,
     GraphEdgeItemObject,
     OptionDataValueNumeric,
-    DefaultEmphasisFocus
+    DefaultEmphasisFocus,
+    CallbackDataParams
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
@@ -43,17 +44,16 @@ import { createTooltipMarkup } from '../../component/tooltip/tooltipMarkup';
 
 type FocusNodeAdjacency = boolean | 'inEdges' | 'outEdges' | 'allEdges';
 
-export interface SankeyNodeStateOption {
+export interface SankeyNodeStateOption<TCbParams = never> {
     label?: SeriesLabelOption
-    itemStyle?: ItemStyleOption
+    itemStyle?: ItemStyleOption<TCbParams>
 }
 
 export interface SankeyEdgeStateOption {
     lineStyle?: SankeyEdgeStyleOption
 }
 
-interface SankeyBothStateOption extends SankeyNodeStateOption, SankeyEdgeStateOption {
-}
+interface SankeyBothStateOption<TCbParams> extends SankeyNodeStateOption<TCbParams>, SankeyEdgeStateOption {}
 
 interface SankeyEdgeStyleOption extends LineStyleOption {
     curveness?: number
@@ -92,7 +92,8 @@ export interface SankeyLevelOption extends SankeyNodeStateOption, SankeyEdgeStat
 }
 
 export interface SankeySeriesOption
-    extends SeriesOption<SankeyBothStateOption, ExtraStateOption>, SankeyBothStateOption,
+    extends SeriesOption<SankeyBothStateOption<CallbackDataParams>, ExtraStateOption>,
+    SankeyBothStateOption<CallbackDataParams>,
     BoxLayoutOptionMixin {
     type?: 'sankey'
 

--- a/src/chart/scatter/ScatterSeries.ts
+++ b/src/chart/scatter/ScatterSeries.ts
@@ -42,8 +42,8 @@ import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
 import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 
-interface ScatterStateOption {
-    itemStyle?: ItemStyleOption
+interface ScatterStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     label?: SeriesLabelOption
 }
 
@@ -60,7 +60,8 @@ export interface ScatterDataItemOption extends SymbolOptionMixin,
 }
 
 export interface ScatterSeriesOption
-    extends SeriesOption<ScatterStateOption, ScatterStatesOptionMixin>, ScatterStateOption,
+    extends SeriesOption<ScatterStateOption<CallbackDataParams>, ScatterStatesOptionMixin>,
+    ScatterStateOption<CallbackDataParams>,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin,
     SeriesLargeOptionMixin, SeriesStackOptionMixin,

--- a/src/chart/scatter/ScatterSeries.ts
+++ b/src/chart/scatter/ScatterSeries.ts
@@ -47,7 +47,7 @@ interface ScatterStateOption {
     label?: SeriesLabelOption
 }
 
-interface ExtraStateOption {
+interface ScatterStatesOptionMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus
         scale?: boolean
@@ -55,11 +55,12 @@ interface ExtraStateOption {
 }
 
 export interface ScatterDataItemOption extends SymbolOptionMixin,
-    ScatterStateOption, StatesOptionMixin<ScatterStateOption, ExtraStateOption>,
+    ScatterStateOption, StatesOptionMixin<ScatterStateOption, ScatterStatesOptionMixin>,
     OptionDataItemObject<OptionDataValue> {
 }
 
-export interface ScatterSeriesOption extends SeriesOption<ScatterStateOption, ExtraStateOption>, ScatterStateOption,
+export interface ScatterSeriesOption
+    extends SeriesOption<ScatterStateOption, ScatterStatesOptionMixin>, ScatterStateOption,
     SeriesOnCartesianOptionMixin, SeriesOnPolarOptionMixin, SeriesOnCalendarOptionMixin,
     SeriesOnGeoOptionMixin, SeriesOnSingleOptionMixin,
     SeriesLargeOptionMixin, SeriesStackOptionMixin,

--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -65,7 +65,7 @@ interface SunburstDataParams extends CallbackDataParams {
     }[]
 }
 
-interface ExtraStateOption {
+interface SunburstStatesMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus | 'descendant' | 'ancestor'
     }
@@ -77,7 +77,7 @@ export interface SunburstStateOption {
 }
 
 export interface SunburstSeriesNodeItemOption extends
-    SunburstStateOption, StatesOptionMixin<SunburstStateOption, ExtraStateOption>,
+    SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin>,
     OptionDataItemObject<OptionDataValue>
 {
     nodeClick?: 'rootToNode' | 'link'
@@ -91,7 +91,8 @@ export interface SunburstSeriesNodeItemOption extends
 
     cursor?: string
 }
-export interface SunburstSeriesLevelOption extends SunburstStateOption, StatesOptionMixin<SunburstStateOption> {
+export interface SunburstSeriesLevelOption
+    extends SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin> {
     highlight?: {
         itemStyle?: SunburstItemStyleOption
         label?: SunburstLabelOption
@@ -105,7 +106,7 @@ interface SortParam {
     getValue(): number
 }
 export interface SunburstSeriesOption extends
-    SeriesOption<SunburstStateOption, ExtraStateOption>, SunburstStateOption,
+    SeriesOption<SunburstStateOption, SunburstStatesMixin>, SunburstStateOption,
     SunburstColorByMixin,
     CircleLayoutOptionMixin {
 

--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -38,7 +38,7 @@ import SeriesData from '../../data/SeriesData';
 import Model from '../../model/Model';
 import enableAriaDecalForTree from '../helper/enableAriaDecalForTree';
 
-interface SunburstItemStyleOption extends ItemStyleOption {
+interface SunburstItemStyleOption<TCbParams = never> extends ItemStyleOption<TCbParams> {
     // can be 10
     // which means that both innerCornerRadius and outerCornerRadius are 10
     // can also be an array [20, 10]
@@ -71,13 +71,14 @@ interface SunburstStatesMixin {
     }
 }
 
-export interface SunburstStateOption {
-    itemStyle?: SunburstItemStyleOption
+export interface SunburstStateOption<TCbParams = never> {
+    itemStyle?: SunburstItemStyleOption<TCbParams>
     label?: SunburstLabelOption
 }
 
 export interface SunburstSeriesNodeItemOption extends
-    SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin>,
+    SunburstStateOption<CallbackDataParams>,
+    StatesOptionMixin<SunburstStateOption<CallbackDataParams>, SunburstStatesMixin>,
     OptionDataItemObject<OptionDataValue>
 {
     nodeClick?: 'rootToNode' | 'link'

--- a/src/chart/themeRiver/ThemeRiverSeries.ts
+++ b/src/chart/themeRiver/ThemeRiverSeries.ts
@@ -33,7 +33,9 @@ import {
     BoxLayoutOptionMixin,
     ZRColor,
     Dictionary,
-    SeriesLabelOption
+    SeriesLabelOption,
+    CallbackDataParams,
+    DefaultStatesMixinEmpasis
 } from '../../util/types';
 import SingleAxis from '../../coord/single/SingleAxis';
 import GlobalModel from '../../model/Global';
@@ -48,12 +50,17 @@ interface ThemeRiverSeriesLabelOption extends SeriesLabelOption {
 
 type ThemerRiverDataItem = [OptionDataValueDate, OptionDataValueNumeric, string];
 
-export interface ThemeRiverStateOption {
+interface ThemeRiverStatesMixin {
+    emphasis?: DefaultStatesMixinEmpasis
+}
+export interface ThemeRiverStateOption<TCbParams = never> {
     label?: ThemeRiverSeriesLabelOption
-    itemStyle?: ItemStyleOption
+    itemStyle?: ItemStyleOption<TCbParams>
 }
 
-export interface ThemeRiverSeriesOption extends SeriesOption<ThemeRiverStateOption>, ThemeRiverStateOption,
+export interface ThemeRiverSeriesOption
+    extends SeriesOption<ThemeRiverStateOption<CallbackDataParams>, ThemeRiverStatesMixin>,
+    ThemeRiverStateOption<CallbackDataParams>,
     SeriesOnSingleOptionMixin, BoxLayoutOptionMixin {
     type?: 'themeRiver'
 

--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -53,7 +53,7 @@ export interface TreeSeriesStateOption {
     label?: SeriesLabelOption
 }
 
-interface ExtraStateOption {
+interface TreeStatesMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus | 'ancestor' | 'descendant'
         scale?: boolean
@@ -61,7 +61,7 @@ interface ExtraStateOption {
 }
 
 export interface TreeSeriesNodeItemOption extends SymbolOptionMixin<CallbackDataParams>,
-    TreeSeriesStateOption, StatesOptionMixin<TreeSeriesStateOption, ExtraStateOption>,
+    TreeSeriesStateOption, StatesOptionMixin<TreeSeriesStateOption, TreeStatesMixin>,
     OptionDataItemObject<OptionDataValue> {
 
     children?: TreeSeriesNodeItemOption[]
@@ -75,12 +75,12 @@ export interface TreeSeriesNodeItemOption extends SymbolOptionMixin<CallbackData
 /**
  * Configuration of leaves nodes.
  */
-export interface TreeSeriesLeavesOption extends TreeSeriesStateOption, StatesOptionMixin<TreeSeriesStateOption> {
-
+export interface TreeSeriesLeavesOption
+    extends TreeSeriesStateOption, StatesOptionMixin<TreeSeriesStateOption, TreeStatesMixin> {
 }
 
 export interface TreeSeriesOption extends
-    SeriesOption<TreeSeriesStateOption, ExtraStateOption>, TreeSeriesStateOption,
+    SeriesOption<TreeSeriesStateOption, TreeStatesMixin>, TreeSeriesStateOption,
     SymbolOptionMixin, BoxLayoutOptionMixin, RoamOptionMixin {
     type?: 'tree'
 

--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -44,8 +44,8 @@ interface CurveLineStyleOption extends LineStyleOption{
     curveness?: number
 }
 
-export interface TreeSeriesStateOption {
-    itemStyle?: ItemStyleOption
+export interface TreeSeriesStateOption<TCbParams = never> {
+    itemStyle?: ItemStyleOption<TCbParams>
     /**
      * Line style of the edge between node and it's parent.
      */
@@ -61,7 +61,8 @@ interface TreeStatesMixin {
 }
 
 export interface TreeSeriesNodeItemOption extends SymbolOptionMixin<CallbackDataParams>,
-    TreeSeriesStateOption, StatesOptionMixin<TreeSeriesStateOption, TreeStatesMixin>,
+    TreeSeriesStateOption<CallbackDataParams>,
+    StatesOptionMixin<TreeSeriesStateOption<CallbackDataParams>, TreeStatesMixin>,
     OptionDataItemObject<OptionDataValue> {
 
     children?: TreeSeriesNodeItemOption[]

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -36,8 +36,7 @@ import {
     DecalObject,
     SeriesLabelOption,
     DefaultEmphasisFocus,
-    AriaOptionMixin,
-    ColorBy
+    AriaOptionMixin
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import { LayoutRect } from '../../util/layout';
@@ -59,7 +58,7 @@ interface TreemapSeriesLabelOption extends SeriesLabelOption {
     formatter?: string | ((params: CallbackDataParams) => string)
 }
 
-interface TreemapSeriesItemStyleOption extends ItemStyleOption {
+interface TreemapSeriesItemStyleOption<TCbParams = never> extends ItemStyleOption<TCbParams> {
     borderRadius?: number | number[]
 
     colorAlpha?: number
@@ -91,8 +90,8 @@ interface ExtraStateOption {
     }
 }
 
-export interface TreemapStateOption {
-    itemStyle?: TreemapSeriesItemStyleOption
+export interface TreemapStateOption<TCbParams = never> {
+    itemStyle?: TreemapSeriesItemStyleOption<TCbParams>
     label?: TreemapSeriesLabelOption
     upperLabel?: TreemapSeriesLabelOption
 }
@@ -149,8 +148,8 @@ export interface TreemapSeriesNodeItemOption extends TreemapSeriesVisualOption,
 }
 
 export interface TreemapSeriesOption
-    extends SeriesOption<TreemapStateOption, ExtraStateOption>,
-    TreemapStateOption,
+    extends SeriesOption<TreemapStateOption<TreemapSeriesCallbackDataParams>, ExtraStateOption>,
+    TreemapStateOption<TreemapSeriesCallbackDataParams>,
     BoxLayoutOptionMixin,
     RoamOptionMixin,
     TreemapSeriesVisualOption {

--- a/src/component/marker/MarkAreaModel.ts
+++ b/src/component/marker/MarkAreaModel.ts
@@ -18,7 +18,7 @@
 */
 
 import MarkerModel, { MarkerOption, MarkerStatisticType, MarkerPositionOption } from './MarkerModel';
-import { SeriesLabelOption, ItemStyleOption, StatesOptionMixin } from '../../util/types';
+import { SeriesLabelOption, ItemStyleOption, StatesOptionMixin, StatesMixinBase } from '../../util/types';
 import GlobalModel from '../../model/Global';
 
 
@@ -27,7 +27,8 @@ interface MarkAreaStateOption {
     label?: SeriesLabelOption
 }
 
-interface MarkAreaDataItemOptionBase extends MarkAreaStateOption, StatesOptionMixin<MarkAreaStateOption> {
+interface MarkAreaDataItemOptionBase extends MarkAreaStateOption,
+    StatesOptionMixin<MarkAreaStateOption, StatesMixinBase> {
     name?: string
 }
 
@@ -55,7 +56,8 @@ export type MarkArea2DDataItemOption = [
     MarkArea2DDataItemDimOption
 ];
 
-export interface MarkAreaOption extends MarkerOption, MarkAreaStateOption, StatesOptionMixin<MarkAreaStateOption> {
+export interface MarkAreaOption extends MarkerOption, MarkAreaStateOption,
+    StatesOptionMixin<MarkAreaStateOption, StatesMixinBase> {
     mainType?: 'markArea'
 
     precision?: number

--- a/src/component/marker/MarkLineModel.ts
+++ b/src/component/marker/MarkLineModel.ts
@@ -24,7 +24,8 @@ import {
     SeriesLineLabelOption,
     SymbolOptionMixin,
     ItemStyleOption,
-    StatesOptionMixin
+    StatesOptionMixin,
+    StatesMixinBase
 } from '../../util/types';
 
 interface MarkLineStateOption {
@@ -35,7 +36,8 @@ interface MarkLineStateOption {
     itemStyle?: ItemStyleOption
     label?: SeriesLineLabelOption
 }
-interface MarkLineDataItemOptionBase extends MarkLineStateOption, StatesOptionMixin<MarkLineStateOption> {
+interface MarkLineDataItemOptionBase extends MarkLineStateOption,
+    StatesOptionMixin<MarkLineStateOption, StatesMixinBase> {
     name?: string
 }
 
@@ -79,7 +81,8 @@ export type MarkLine2DDataItemOption = [
 ];
 
 export interface MarkLineOption extends MarkerOption,
-    MarkLineStateOption, StatesOptionMixin<MarkLineStateOption> {
+    MarkLineStateOption,
+    StatesOptionMixin<MarkLineStateOption, StatesMixinBase> {
     mainType?: 'markLine'
 
     symbol?: string[] | string

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -41,7 +41,6 @@ import {
     logError,
     merge,
     map,
-    defaults,
     curry,
     filter,
     HashMap

--- a/src/component/marker/MarkPointModel.ts
+++ b/src/component/marker/MarkPointModel.ts
@@ -24,7 +24,8 @@ import {
     ItemStyleOption,
     SeriesLabelOption,
     CallbackDataParams,
-    StatesOptionMixin
+    StatesOptionMixin,
+    StatesMixinBase
 } from '../../util/types';
 
 // interface MarkPointCallbackDataParams extends CallbackDataParams {
@@ -37,7 +38,7 @@ interface MarkPointStateOption {
     label?: SeriesLabelOption
 }
 export interface MarkPointDataItemOption extends
-    MarkPointStateOption, StatesOptionMixin<MarkPointStateOption>,
+    MarkPointStateOption, StatesOptionMixin<MarkPointStateOption, StatesMixinBase>,
     // TODO should not support callback in data
     SymbolOptionMixin<CallbackDataParams>,
     MarkerPositionOption {
@@ -46,7 +47,7 @@ export interface MarkPointDataItemOption extends
 
 export interface MarkPointOption extends MarkerOption,
     SymbolOptionMixin<CallbackDataParams>,
-    StatesOptionMixin<MarkPointStateOption>, MarkPointStateOption {
+    StatesOptionMixin<MarkPointStateOption, StatesMixinBase>, MarkPointStateOption {
     mainType?: 'markPoint'
 
     precision?: number

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -28,7 +28,7 @@ import Scale from '../scale/Scale';
 import { DimensionName, ScaleDataValue, ScaleTick } from '../util/types';
 import OrdinalScale from '../scale/Ordinal';
 import Model from '../model/Model';
-import { AxisBaseOption, OptionAxisType } from './axisCommonTypes';
+import { AxisBaseOption, CategoryAxisBaseOption, OptionAxisType } from './axisCommonTypes';
 import { AxisBaseModel } from './AxisBaseModel';
 
 const NORMALIZED_EXTENT = [0, 1] as [number, number];
@@ -63,7 +63,7 @@ class Axis {
 
     // Injected outside
     model: AxisBaseModel;
-    onBand: AxisBaseOption['boundaryGap'] = false;
+    onBand: CategoryAxisBaseOption['boundaryGap'] = false;
     inverse: AxisBaseOption['inverse'] = false;
 
 

--- a/src/coord/AxisBaseModel.ts
+++ b/src/coord/AxisBaseModel.ts
@@ -20,16 +20,16 @@
 /**
  * Base Axis Model for xAxis, yAxis, angleAxis, radiusAxis. singleAxis
  */
-import { AxisBaseOption } from './axisCommonTypes';
+import { AxisBaseOptionCommon } from './axisCommonTypes';
 import ComponentModel from '../model/Component';
 import { AxisModelCommonMixin } from './axisModelCommonMixin';
 import { AxisModelExtendedInCreator } from './axisModelCreator';
 import Axis from './Axis';
 
-export interface AxisBaseModel<T extends AxisBaseOption = AxisBaseOption>
+export interface AxisBaseModel<T extends AxisBaseOptionCommon = AxisBaseOptionCommon>
     extends ComponentModel<T>,
     AxisModelCommonMixin<T>,
-    AxisModelExtendedInCreator<T> {
+    AxisModelExtendedInCreator {
 
     axis: Axis
 }

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -169,9 +169,6 @@ interface AxisTickOption {
     // The length of axisTick.
     length?: number,
     lineStyle?: LineStyleOption
-
-    // --------------------------------------------
-    // [Properties below only for 'category' axis]:
 }
 
 type AxisLabelValueFormatter = (value: number, index: number) => string;

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -20,16 +20,15 @@
 import {
     TextCommonOption, LineStyleOption, OrdinalRawValue, ZRColor,
     AreaStyleOption, ComponentOption, ColorString,
-    AnimationOptionMixin, Dictionary, ScaleDataValue
+    AnimationOptionMixin, Dictionary, ScaleDataValue, CommonAxisPointerOption
 } from '../util/types';
 
 
 export const AXIS_TYPES = {value: 1, category: 1, time: 1, log: 1} as const;
 export type OptionAxisType = keyof typeof AXIS_TYPES;
 
-
-export interface AxisBaseOption extends ComponentOption,
-    AnimationOptionMixin {  // Support transition animation
+export interface AxisBaseOptionCommon extends ComponentOption,
+    AnimationOptionMixin {
     type?: OptionAxisType;
     show?: boolean;
     // Inverse the axis.
@@ -55,20 +54,15 @@ export interface AxisBaseOption extends ComponentOption,
         show?: boolean;
     };
 
-    axisPointer?: any; // FIXME:TS axisPointerOption type?
+    axisLabel?: AxisLabelBaseOption;
+
+    axisPointer?: CommonAxisPointerOption;
     axisLine?: AxisLineOption;
     axisTick?: AxisTickOption;
-    axisLabel?: AxisLabelOption;
     minorTick?: MinorTickOption;
     splitLine?: SplitLineOption;
     minorSplitLine?: MinorSplitLineOption;
     splitArea?: SplitAreaOption;
-
-    // The gap at both ends of the axis.
-    // For category axis: boolean.
-    // For value axis: [GAP, GAP], where
-    // `GAP` can be an absolute pixel number (like `35`), or percent (like `'30%'`)
-    boundaryGap?: boolean | [number | string, number | string];
 
     // Min value of the axis. can be:
     // + ScaleDataValue
@@ -85,43 +79,74 @@ export interface AxisBaseOption extends ComponentOption,
     // + `true`: the extent do not consider value 0.
     scale?: boolean;
 
+}
 
-    // --------------------------------------------
-    // [Properties below only for 'category' axis]:
+interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {
+    /*
+     * The gap at both ends of the axis.
+     * [GAP, GAP], where
+     * `GAP` can be an absolute pixel number (like `35`), or percent (like `'30%'`)
+     */
+    boundaryGap?: [number | string, number | string]
 
-    // Set false to faster category collection.
-    // Only usefull in the case like: category is
-    // ['2012-01-01', '2012-01-02', ...], where the input
-    // data has been ensured not duplicate and is large data.
-    // null means "auto":
-    // if axis.data provided, do not deduplication,
-    // else do deduplication.
-    deduplication?: boolean;
+    /**
+     * AxisTick and axisLabel and splitLine are caculated based on splitNumber.
+     */
+    splitNumber?: number;
+    /**
+     * Interval specifies the span of the ticks is mandatorily.
+     */
+    interval?: number;
+    /**
+     * Specify min interval when auto calculate tick interval.
+     */
+    minInterval?: number;
+    /**
+     * Specify max interval when auto calculate tick interval.
+     */
+    maxInterval?: number;
+}
+
+export interface CategoryAxisBaseOption extends AxisBaseOptionCommon {
+    type?: 'category';
+    boundaryGap?: boolean
+    axisLabel?: AxisLabelOption<'category'> & {
+        interval?: 'auto' | number | ((index: number, value: string) => boolean)
+    };
     data?: (OrdinalRawValue | {
         value: OrdinalRawValue;
         textStyle?: TextCommonOption;
     })[];
+    /*
+     * Set false to faster category collection.
+     * Only usefull in the case like: category is
+     * ['2012-01-01', '2012-01-02', ...], where the input
+     * data has been ensured not duplicate and is large data.
+     * null means "auto":
+     * if axis.data provided, do not deduplication,
+     * else do deduplication.
+     */
+    deduplication?: boolean;
 
-
-    // ------------------------------------------------------
-    // [Properties below only for 'value'/'log'/'time' axes]:
-
-    // AxisTick and axisLabel and splitLine are caculated based on splitNumber.
-    splitNumber?: number;
-    // Interval specifies the span of the ticks is mandatorily.
-    interval?: number;
-    // Specify min interval when auto calculate tick interval.
-    minInterval?: number;
-    // Specify max interval when auto calculate tick interval.
-    maxInterval?: number;
-
-
-    // ---------------------------------------
-    // [Properties below only for 'log' axis]:
-
+    axisTick?: AxisBaseOptionCommon['axisTick'] & {
+        // If tick is align with label when boundaryGap is true
+        alignWithLabel?: boolean,
+        interval?: 'auto' | number | ((index: number, value: string) => boolean)
+    }
+}
+export interface ValueAxisBaseOption extends NumericAxisBaseOptionCommon {
+    type?: 'value';
+    axisLabel?: AxisLabelOption<'value'>;
+}
+export interface LogAxisBaseOption extends NumericAxisBaseOptionCommon {
+    type?: 'log';
+    axisLabel?: AxisLabelOption<'log'>;
     logBase?: number;
 }
-
+export interface TimeAxisBaseOption extends NumericAxisBaseOptionCommon {
+    type?: 'time';
+    axisLabel?: AxisLabelOption<'time'>;
+}
 interface AxisNameTextStyleOption extends TextCommonOption {
     rich?: Dictionary<TextCommonOption>
 }
@@ -147,15 +172,13 @@ interface AxisTickOption {
 
     // --------------------------------------------
     // [Properties below only for 'category' axis]:
-
-    // If tick is align with label when boundaryGap is true
-    alignWithLabel?: boolean,
-    interval?: 'auto' | number | ((index: number, value: string) => boolean)
 }
 
-export type AxisLabelFormatterOption = string | ((value: OrdinalRawValue | number, index: number) => string);
+type AxisLabelValueFormatter = (value: number, index: number) => string;
+type AxisLabelCategoryFormatter = (value: string, index: number) => string;
 
-type TimeAxisLabelUnitFormatter = AxisLabelFormatterOption | string[];
+// export type AxisLabelFormatterOption = string | ((value: OrdinalRawValue | number, index: number) => string);
+type TimeAxisLabelUnitFormatter = AxisLabelValueFormatter | string[] | string;
 
 export type TimeAxisLabelFormatterOption = string
     | ((value: number, index: number, extra: {level: number}) => string)
@@ -171,7 +194,14 @@ export type TimeAxisLabelFormatterOption = string
         inherit?: boolean
     };
 
-interface AxisLabelOption extends Omit<TextCommonOption, 'color'> {
+type LabelFormatters = {
+    value: AxisLabelValueFormatter | string
+    log: AxisLabelValueFormatter | string
+    category: AxisLabelCategoryFormatter | string
+    time: TimeAxisLabelFormatterOption
+};
+
+interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     show?: boolean,
     // Whether axisLabel is inside the grid or outside the grid.
     inside?: boolean,
@@ -181,18 +211,13 @@ interface AxisLabelOption extends Omit<TextCommonOption, 'color'> {
     // true | false | null/undefined (auto)
     showMaxLabel?: boolean,
     margin?: number,
-    // value is supposed to be OptionDataPrimitive but for time axis, it is time stamp.
-    formatter?: AxisLabelFormatterOption | TimeAxisLabelFormatterOption,
-
-    // --------------------------------------------
-    // [Properties below only for 'category' axis]:
-
-    interval?: 'auto' | number | ((index: number, value: string) => boolean)
+    rich?: Dictionary<TextCommonOption>
 
     // Color can be callback
     color?: ColorString | ((value?: string | number, index?: number) => ColorString)
-
-    rich?: Dictionary<TextCommonOption>
+}
+interface AxisLabelOption<TType extends OptionAxisType> extends AxisLabelBaseOption {
+    formatter?: LabelFormatters[TType]
 }
 
 interface MinorTickOption {
@@ -220,3 +245,7 @@ interface SplitAreaOption {
     // colors will display in turn
     areaStyle?: AreaStyleOption<ZRColor[]>
 }
+
+
+export type AxisBaseOption = ValueAxisBaseOption | LogAxisBaseOption
+    | CategoryAxisBaseOption | TimeAxisBaseOption | AxisBaseOptionCommon;

--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -33,7 +33,13 @@ import Model from '../model/Model';
 import { AxisBaseModel } from './AxisBaseModel';
 import LogScale from '../scale/Log';
 import Axis from './Axis';
-import { AxisBaseOption, TimeAxisLabelFormatterOption } from './axisCommonTypes';
+import {
+    AxisBaseOption,
+    CategoryAxisBaseOption,
+    LogAxisBaseOption,
+    TimeAxisLabelFormatterOption,
+    ValueAxisBaseOption
+} from './axisCommonTypes';
 import type CartesianAxisModel from './cartesian/AxisModel';
 import SeriesData from '../data/SeriesData';
 import { getStackedDimension } from '../data/helper/dataStackHelper';
@@ -143,7 +149,8 @@ function adjustScaleForOverflow(
 // Precondition of calling this method:
 // The scale extent has been initailized using series data extent via
 // `scale.setExtent` or `scale.unionExtentFromData`;
-export function niceScaleExtent(scale: Scale, model: AxisBaseModel) {
+export function niceScaleExtent(scale: Scale, inModel: AxisBaseModel) {
+    const model = inModel as AxisBaseModel<LogAxisBaseOption>;
     const extentInfo = getScaleExtent(scale, model);
     const extent = extentInfo.extent;
     const splitNumber = model.get('splitNumber');
@@ -221,7 +228,8 @@ export function ifAxisCrossZero(axis: Axis) {
  *         return: {string} label string.
  */
 export function makeLabelFormatter(axis: Axis): (tick: ScaleTick, idx?: number) => string {
-    const labelFormatter = axis.getLabelModel().get('formatter');
+    const labelFormatter = (axis.getLabelModel() as Model<ValueAxisBaseOption['axisLabel']>)
+        .get('formatter');
     const categoryTickStart = axis.type === 'category' ? axis.scale.getExtent()[0] : null;
 
     if (axis.scale.type === 'time') {
@@ -263,7 +271,7 @@ export function makeLabelFormatter(axis: Axis): (tick: ScaleTick, idx?: number) 
                     } : null
                 );
             };
-        })(labelFormatter);
+        })(labelFormatter as (...args: any[]) => string);
     }
     else {
         return function (tick: ScaleTick) {
@@ -347,7 +355,7 @@ function rotateTextRect(textRect: RectLike, rotate: number) {
  * @return {number|String} Can be null|'auto'|number|function
  */
 export function getOptionCategoryInterval(model: Model<AxisBaseOption['axisLabel']>) {
-    const interval = model.get('interval');
+    const interval = (model as Model<CategoryAxisBaseOption['axisLabel']>).get('interval');
     return interval == null ? 'auto' : interval;
 }
 

--- a/src/coord/axisModelCreator.ts
+++ b/src/coord/axisModelCreator.ts
@@ -26,7 +26,7 @@ import {
 } from '../util/layout';
 import OrdinalMeta from '../data/OrdinalMeta';
 import { DimensionName, BoxLayoutOptionMixin, OrdinalRawValue } from '../util/types';
-import { AxisBaseOption, AXIS_TYPES } from './axisCommonTypes';
+import { AxisBaseOption, AXIS_TYPES, CategoryAxisBaseOption } from './axisCommonTypes';
 import GlobalModel from '../model/Global';
 import { each, merge } from 'zrender/src/core/util';
 import { EChartsExtensionInstallRegisters } from '../extension';
@@ -34,8 +34,8 @@ import { EChartsExtensionInstallRegisters } from '../extension';
 
 type Constructor<T> = new (...args: any[]) => T;
 
-export interface AxisModelExtendedInCreator<Opt extends AxisBaseOption> {
-    getCategories(rawData?: boolean): OrdinalRawValue[] | Opt['data']
+export interface AxisModelExtendedInCreator {
+    getCategories(rawData?: boolean): OrdinalRawValue[] | CategoryAxisBaseOption['data']
     getOrdinalMeta(): OrdinalMeta
 }
 
@@ -60,7 +60,7 @@ export default function axisModelCreator<
             extraDefaultOption, true
         );
 
-        class AxisModel extends BaseAxisModelClass implements AxisModelExtendedInCreator<AxisOptionT> {
+        class AxisModel extends BaseAxisModelClass implements AxisModelExtendedInCreator {
 
             static type = axisName + 'Axis.' + axisType;
             type = axisName + 'Axis.' + axisType;
@@ -97,13 +97,13 @@ export default function axisModelCreator<
              * Should not be called before all of 'getInitailData' finished.
              * Because categories are collected during initializing data.
              */
-            getCategories(rawData?: boolean): OrdinalRawValue[] | AxisBaseOption['data'] {
+            getCategories(rawData?: boolean): OrdinalRawValue[] | CategoryAxisBaseOption['data'] {
                 const option = this.option;
                 // FIXME
                 // warning if called before all of 'getInitailData' finished.
                 if (option.type === 'category') {
                     if (rawData) {
-                        return option.data as AxisBaseOption['data'];
+                        return (option as CategoryAxisBaseOption).data;
                     }
                     return this.__ordinalMeta.categories;
                 }
@@ -125,5 +125,5 @@ export default function axisModelCreator<
 
 function getAxisType(option: AxisBaseOption) {
     // Default axis with data is category axis
-    return option.type || (option.data ? 'category' : 'value');
+    return option.type || ((option as CategoryAxisBaseOption).data ? 'category' : 'value');
 }

--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -31,21 +31,21 @@ import { SINGLE_REFERRING } from '../../util/model';
 
 export type CartesianAxisPosition = 'top' | 'bottom' | 'left' | 'right';
 
-export interface CartesianAxisOption extends AxisBaseOption {
+export type CartesianAxisOption = AxisBaseOption & {
     gridIndex?: number;
     gridId?: string;
     position?: CartesianAxisPosition;
     // Offset is for multiple axis on the same position.
     offset?: number;
     categorySortInfo?: OrdinalSortInfo;
-}
+};
 
-export interface XAXisOption extends CartesianAxisOption {
+export type XAXisOption = CartesianAxisOption & {
     mainType?: 'xAxis'
-}
-export interface YAXisOption extends CartesianAxisOption {
+};
+export type YAXisOption = CartesianAxisOption & {
     mainType?: 'yAxis'
-}
+};
 
 export class CartesianAxisModel extends ComponentModel<CartesianAxisOption>
     implements AxisBaseModel<CartesianAxisOption> {
@@ -60,7 +60,7 @@ export class CartesianAxisModel extends ComponentModel<CartesianAxisOption>
 }
 
 export interface CartesianAxisModel extends AxisModelCommonMixin<CartesianAxisOption>,
-    AxisModelExtendedInCreator<CartesianAxisOption> {}
+    AxisModelExtendedInCreator {}
 
 zrUtil.mixin(CartesianAxisModel, AxisModelCommonMixin);
 

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -47,6 +47,8 @@ import { ScaleDataValue } from '../../util/types';
 import SeriesData from '../../data/SeriesData';
 import OrdinalScale from '../../scale/Ordinal';
 import { isCartesian2DSeries, findAxisModels } from './cartesianAxisHelper';
+import { CategoryAxisBaseOption } from '../axisCommonTypes';
+import { AxisBaseModel } from '../AxisBaseModel';
 
 
 type Cartesian2DDimensionName = 'x' | 'y';
@@ -388,7 +390,7 @@ class Grid implements CoordinateSystemMaster {
                 );
 
                 const isCategory = axis.type === 'category';
-                axis.onBand = isCategory && axisModel.get('boundaryGap');
+                axis.onBand = isCategory && (axisModel as AxisBaseModel<CategoryAxisBaseOption>).get('boundaryGap');
                 axis.inverse = axisModel.get('inverse');
 
                 // Inject axis into axisModel

--- a/src/coord/geo/GeoModel.ts
+++ b/src/coord/geo/GeoModel.ts
@@ -43,7 +43,7 @@ import GlobalModel from '../../model/Global';
 import geoSourceManager from './geoSourceManager';
 
 
-export interface GeoItemStyleOption extends ItemStyleOption {
+export interface GeoItemStyleOption<TCbParams = never> extends ItemStyleOption<TCbParams> {
     areaColor?: ZRColor;
 };
 interface GeoLabelOption extends LabelOption {

--- a/src/coord/geo/GeoModel.ts
+++ b/src/coord/geo/GeoModel.ts
@@ -35,7 +35,8 @@ import {
     AnimationOptionMixin,
     StatesOptionMixin,
     Dictionary,
-    CommonTooltipOption
+    CommonTooltipOption,
+    StatesMixinBase
 } from '../../util/types';
 import { NameMap } from './geoTypes';
 import GlobalModel from '../../model/Global';
@@ -58,7 +59,7 @@ interface GeoLabelFormatterDataParams {
     status: DisplayState;
 }
 
-export interface RegoinOption extends GeoStateOption, StatesOptionMixin<GeoStateOption> {
+export interface RegoinOption extends GeoStateOption, StatesOptionMixin<GeoStateOption, StatesMixinBase> {
     name?: string
     selected?: boolean
     tooltip?: CommonTooltipOption<GeoTooltipFormatterParams>
@@ -102,7 +103,7 @@ export interface GeoOption extends
     // For lens animation on geo.
     AnimationOptionMixin,
     GeoCommonOptionMixin,
-    StatesOptionMixin<GeoStateOption>, GeoStateOption {
+    StatesOptionMixin<GeoStateOption, StatesMixinBase>, GeoStateOption {
     mainType?: 'geo';
 
     show?: boolean;

--- a/src/coord/parallel/AxisModel.ts
+++ b/src/coord/parallel/AxisModel.ts
@@ -40,7 +40,7 @@ export type ParallelAreaSelectStyleProps = Pick<PathStyleProps, ParallelAreaSele
     width: number;
 };
 
-export interface ParallelAxisOption extends AxisBaseOption {
+export type ParallelAxisOption = AxisBaseOption & {
     /**
      * 0, 1, 2, ...
      */
@@ -55,7 +55,7 @@ export interface ParallelAxisOption extends AxisBaseOption {
     };
     // Whether realtime update view when select.
     realtime?: boolean;
-}
+};
 
 class ParallelAxisModel extends ComponentModel<ParallelAxisOption> {
 
@@ -140,7 +140,7 @@ class ParallelAxisModel extends ComponentModel<ParallelAxisOption> {
 
 }
 interface ParallelAxisModel extends AxisModelCommonMixin<ParallelAxisOption>,
-    AxisModelExtendedInCreator<ParallelAxisOption> {}
+    AxisModelExtendedInCreator {}
 
 zrUtil.mixin(ParallelAxisModel, AxisModelCommonMixin);
 

--- a/src/coord/parallel/Parallel.ts
+++ b/src/coord/parallel/Parallel.ts
@@ -38,6 +38,8 @@ import { Dictionary, DimensionName, ScaleDataValue } from '../../util/types';
 import { CoordinateSystem, CoordinateSystemMaster } from '../CoordinateSystem';
 import ParallelAxisModel, { ParallelActiveState } from './AxisModel';
 import SeriesData from '../../data/SeriesData';
+import { AxisBaseModel } from '../AxisBaseModel';
+import { CategoryAxisBaseOption } from '../axisCommonTypes';
 
 const each = zrUtil.each;
 const mathMin = Math.min;
@@ -131,7 +133,8 @@ class Parallel implements CoordinateSystemMaster, CoordinateSystem {
             ));
 
             const isCategory = axis.type === 'category';
-            axis.onBand = isCategory && axisModel.get('boundaryGap');
+            axis.onBand = isCategory
+                && (axisModel as AxisBaseModel<CategoryAxisBaseOption>).get('boundaryGap');
             axis.inverse = axisModel.get('inverse');
 
             // Injection

--- a/src/coord/polar/AxisModel.ts
+++ b/src/coord/polar/AxisModel.ts
@@ -27,7 +27,7 @@ import RadiusAxis from './RadiusAxis';
 import { AxisBaseModel } from '../AxisBaseModel';
 import { SINGLE_REFERRING } from '../../util/model';
 
-export interface AngleAxisOption extends AxisBaseOption {
+export type AngleAxisOption = AxisBaseOption & {
     mainType?: 'angleAxis';
     /**
      * Index of host polar component
@@ -41,12 +41,10 @@ export interface AngleAxisOption extends AxisBaseOption {
     startAngle?: number;
     clockwise?: boolean;
 
-    splitNumber?: number;
-
     axisLabel?: AxisBaseOption['axisLabel']
-}
+};
 
-export interface RadiusAxisOption extends AxisBaseOption {
+export type RadiusAxisOption = AxisBaseOption & {
     mainType?: 'radiusAxis';
     /**
      * Index of host polar component
@@ -56,7 +54,7 @@ export interface RadiusAxisOption extends AxisBaseOption {
      * Id of host polar component
      */
     polarId?: string;
-}
+};
 
 type PolarAxisOption = AngleAxisOption | RadiusAxisOption;
 
@@ -72,7 +70,7 @@ class PolarAxisModel<T extends PolarAxisOption = PolarAxisOption> extends Compon
 }
 
 interface PolarAxisModel<T extends PolarAxisOption = PolarAxisOption>
-    extends AxisModelCommonMixin<T>, AxisModelExtendedInCreator<T> {}
+    extends AxisModelCommonMixin<T>, AxisModelExtendedInCreator {}
 
 zrUtil.mixin(PolarAxisModel, AxisModelCommonMixin);
 

--- a/src/coord/polar/polarCreator.ts
+++ b/src/coord/polar/polarCreator.ts
@@ -38,6 +38,8 @@ import { PolarAxisModel, AngleAxisModel, RadiusAxisModel } from './AxisModel';
 import SeriesModel from '../../model/Series';
 import { SeriesOption } from '../../util/types';
 import { SINGLE_REFERRING } from '../../util/model';
+import { AxisBaseModel } from '../AxisBaseModel';
+import { CategoryAxisBaseOption } from '../axisCommonTypes';
 
 /**
  * Resize method bound to the polar
@@ -115,7 +117,8 @@ function isAngleAxisModel(axisModel: AngleAxisModel | PolarAxisModel): axisModel
 function setAxis(axis: RadiusAxis | AngleAxis, axisModel: PolarAxisModel) {
     axis.type = axisModel.get('type');
     axis.scale = createScaleByModel(axisModel);
-    axis.onBand = axisModel.get('boundaryGap') && axis.type === 'category';
+    axis.onBand = (axisModel as AxisBaseModel<CategoryAxisBaseOption>).get('boundaryGap')
+        && axis.type === 'category';
     axis.inverse = axisModel.get('inverse');
 
     if (isAngleAxisModel(axisModel)) {

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -28,7 +28,7 @@ import {
     LabelOption,
     ColorString
 } from '../../util/types';
-import { AxisBaseOption } from '../axisCommonTypes';
+import { AxisBaseOption, CategoryAxisBaseOption, ValueAxisBaseOption } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
 import Radar from './Radar';
 import {CoordinateSystemHostModel} from '../../coord/CoordinateSystem';
@@ -79,15 +79,16 @@ export interface RadarOption extends ComponentOption, CircleLayoutOptionMixin {
     scale?: boolean
     splitNumber?: number
 
-    boundaryGap?: AxisBaseOption['boundaryGap']
+    boundaryGap?: CategoryAxisBaseOption['boundaryGap']
+        | ValueAxisBaseOption['boundaryGap']
 
     indicator?: RadarIndicatorOption[]
 }
 
-export interface InnerIndicatorAxisOption extends AxisBaseOption {
+export type InnerIndicatorAxisOption = AxisBaseOption & {
     // TODO Use type?
     // axisType?: 'value' | 'log'
-}
+};
 
 class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystemHostModel {
     static readonly type = 'radar';

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -42,6 +42,7 @@ function defaultsShow(opt: object, show: boolean) {
 }
 
 export interface RadarIndicatorOption {
+    name?: string
     text?: string
     min?: number
     max?: number

--- a/src/coord/scaleRawExtentInfo.ts
+++ b/src/coord/scaleRawExtentInfo.ts
@@ -21,7 +21,7 @@ import { assert, isArray, eqNaN, isFunction } from 'zrender/src/core/util';
 import Scale from '../scale/Scale';
 import { AxisBaseModel } from './AxisBaseModel';
 import { parsePercent } from 'zrender/src/contain/text';
-import { AxisBaseOption } from './axisCommonTypes';
+import { AxisBaseOption, CategoryAxisBaseOption } from './axisCommonTypes';
 import { ScaleDataValue } from '../util/types';
 
 
@@ -129,7 +129,7 @@ export class ScaleRawExtentInfo {
             this._axisDataLen = model.getCategories().length;
         }
         else {
-            const boundaryGap = model.get('boundaryGap');
+            const boundaryGap = (model as AxisBaseModel<CategoryAxisBaseOption>).get('boundaryGap');
             const boundaryGapArr = isArray(boundaryGap)
                 ? boundaryGap : [boundaryGap || 0, boundaryGap || 0];
 

--- a/src/coord/single/AxisModel.ts
+++ b/src/coord/single/AxisModel.ts
@@ -29,11 +29,11 @@ import { mixin } from 'zrender/src/core/util';
 
 export type SingleAxisPosition = 'top' | 'bottom' | 'left' | 'right';
 
-export interface SingleAxisOption extends AxisBaseOption, BoxLayoutOptionMixin {
+export type SingleAxisOption = AxisBaseOption & BoxLayoutOptionMixin & {
     mainType?: 'singleAxis'
     position?: SingleAxisPosition
     orient?: LayoutOrient
-}
+};
 
 class SingleAxisModel extends ComponentModel<SingleAxisOption>
     implements AxisBaseModel<SingleAxisOption> {
@@ -102,7 +102,7 @@ class SingleAxisModel extends ComponentModel<SingleAxisOption>
 }
 
 interface SingleAxisModel extends AxisModelCommonMixin<SingleAxisOption>,
-    AxisModelExtendedInCreator<SingleAxisOption> {}
+    AxisModelExtendedInCreator {}
 
 mixin(SingleAxisModel, AxisModelCommonMixin.prototype);
 

--- a/src/coord/single/Single.ts
+++ b/src/coord/single/Single.ts
@@ -32,6 +32,8 @@ import BoundingRect from 'zrender/src/core/BoundingRect';
 import SingleAxisModel from './AxisModel';
 import { ParsedModelFinder, ParsedModelFinderKnown } from '../../util/model';
 import { ScaleDataValue } from '../../util/types';
+import { AxisBaseModel } from '../AxisBaseModel';
+import { CategoryAxisBaseOption } from '../axisCommonTypes';
 
 export const singleDimensions = ['single'];
 /**
@@ -80,7 +82,7 @@ class Single implements CoordinateSystem, CoordinateSystemMaster {
         );
 
         const isCategory = axis.type === 'category';
-        axis.onBand = isCategory && axisModel.get('boundaryGap');
+        axis.onBand = isCategory && (axisModel as AxisBaseModel<CategoryAxisBaseOption>).get('boundaryGap');
         axis.inverse = axisModel.get('inverse');
         axis.orient = axisModel.get('orient');
 

--- a/src/data/helper/transform.ts
+++ b/src/data/helper/transform.ts
@@ -42,7 +42,7 @@ export type DataTransformConfig = unknown;
 
 export interface DataTransformOption {
     type: DataTransformType;
-    config: DataTransformConfig;
+    config?: DataTransformConfig;
     // Print the result via `console.log` when transform performed. Only work in dev mode for debug.
     print?: boolean;
 }

--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -86,7 +86,12 @@ import type {HeatmapSeriesOption as HeatmapSeriesOptionInner} from '../chart/hea
 import type {PictorialBarSeriesOption as PictorialBarSeriesOptionInner} from '../chart/bar/PictorialBarSeries';
 import type {ThemeRiverSeriesOption as ThemeRiverSeriesOptionInner} from '../chart/themeRiver/ThemeRiverSeries';
 import type {SunburstSeriesOption as SunburstSeriesOptionInner} from '../chart/sunburst/SunburstSeries';
-import type {CustomSeriesOption as CustomSeriesOptionInner} from '../chart/custom/CustomSeries';
+import type {
+    CustomSeriesOption as CustomSeriesOptionInner,
+    CustomSeriesRenderItemAPI,
+    CustomSeriesRenderItemParams,
+    CustomSeriesRenderItemReturn
+} from '../chart/custom/CustomSeries';
 
 import type { GraphicComponentLooseOption as GraphicComponentOption } from '../component/graphic/install';
 import type { DatasetOption as DatasetComponentOption } from '../component/dataset/install';
@@ -264,5 +269,9 @@ export {
     TooltipFormatterCallback as TooltipComponentFormatterCallback,
     TopLevelFormatterParams as TooltipComponentFormatterCallbackParams,
     TooltipPositionCallback as TooltipComponentPositionCallback,
-    TooltipPositionCallbackParams as TooltipComponentPositionCallbackParams
+    TooltipPositionCallbackParams as TooltipComponentPositionCallbackParams,
+
+    CustomSeriesRenderItemParams,
+    CustomSeriesRenderItemAPI,
+    CustomSeriesRenderItemReturn
 };

--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -90,7 +90,8 @@ import type {
     CustomSeriesOption as CustomSeriesOptionInner,
     CustomSeriesRenderItemAPI,
     CustomSeriesRenderItemParams,
-    CustomSeriesRenderItemReturn
+    CustomSeriesRenderItemReturn,
+    CustomSeriesRenderItem
 } from '../chart/custom/CustomSeries';
 
 import type { GraphicComponentLooseOption as GraphicComponentOption } from '../component/graphic/install';
@@ -273,5 +274,6 @@ export {
 
     CustomSeriesRenderItemParams,
     CustomSeriesRenderItemAPI,
-    CustomSeriesRenderItemReturn
+    CustomSeriesRenderItemReturn,
+    CustomSeriesRenderItem
 };

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -661,7 +661,7 @@ export function setLabelLineStyle(
 
 
 export function getLabelLineStatesModels<LabelName extends string = 'labelLine'>(
-    itemModel: Model<StatesOptionMixin<any> & Partial<Record<LabelName, any>>>,
+    itemModel: Model<StatesOptionMixin<any, any> & Partial<Record<LabelName, any>>>,
     labelLineName?: LabelName
 ): Record<DisplayState, LabelLineModel> {
     labelLineName = (labelLineName || 'labelLine') as LabelName;

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -293,7 +293,7 @@ function setLabelStyle<TLabelDataIndex>(
 export { setLabelStyle };
 
 export function getLabelStatesModels<LabelName extends string = 'label'>(
-    itemModel: Model<StatesOptionMixin<any> & Partial<Record<LabelName, any>>>,
+    itemModel: Model<StatesOptionMixin<any, any> & Partial<Record<LabelName, any>>>,
     labelName?: LabelName
 ): Record<DisplayState, LabelModel> {
     labelName = (labelName || 'label') as LabelName;

--- a/src/layout/barGrid.ts
+++ b/src/layout/barGrid.ts
@@ -77,11 +77,11 @@ type BarWidthAndOffset = Dictionary<Dictionary<{
 export interface BarGridLayoutOptionForCustomSeries {
     count: number
 
-    barWidth?: number
-    barMaxWidth?: number
-    barMinWidth?: number
-    barGap?: number
-    barCategoryGap?: number
+    barWidth?: number | string
+    barMaxWidth?: number | string
+    barMinWidth?: number | string
+    barGap?: number | string
+    barCategoryGap?: number | string
 }
 interface LayoutOption extends BarGridLayoutOptionForCustomSeries {
     axis: Axis2D

--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -36,11 +36,11 @@ import {
     OrdinalScaleTick,
     ScaleTick
 } from '../util/types';
-import { AxisBaseOption } from '../coord/axisCommonTypes';
+import { CategoryAxisBaseOption } from '../coord/axisCommonTypes';
 import { isArray, map, isObject } from 'zrender/src/core/util';
 
 type OrdinalScaleSetting = {
-    ordinalMeta?: OrdinalMeta | AxisBaseOption['data'];
+    ordinalMeta?: OrdinalMeta | CategoryAxisBaseOption['data'];
     extent?: [number, number];
 };
 

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -260,7 +260,7 @@ export function getTooltipMarker(inOpt: ColorString | GetTooltipMarkerOpt, extra
  *           and `module:echarts/util/number#parseDate`.
  * @inner
  */
-export function formatTime(tpl: string, value: unknown, isUTC: boolean) {
+export function formatTime(tpl: string, value: unknown, isUTC?: boolean) {
     if (__DEV__) {
         deprecateReplaceLog('echarts.format.formatTime', 'echarts.time.format');
     }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -965,6 +965,10 @@ export interface ItemStyleOption extends ShadowOptionMixin, BorderOptionMixin {
     decal?: DecalObject | 'none'
 }
 
+export interface SeriesItemStyleOption<TParams = CallbackDataParams> extends Omit<ItemStyleOption, 'color'> {
+    color?: ZRColor | ((params: TParams) => string)
+}
+
 /**
  * ItemStyleOption is a option set to control styles on lines.
  * Used in the components or series like `line`, `axis`
@@ -1499,15 +1503,16 @@ export type BlurScope = 'coordinateSystem' | 'series' | 'global';
  */
 export type InnerFocus = DefaultEmphasisFocus | ArrayLike<number> | Dictionary<ArrayLike<number>>;
 
-export interface DefaultExtraStateOpts {
-    emphasis: any
-    select: any
-    blur: any
+export interface DefaultStatesMixin {
+    // FIXME
+    emphasis?: any
+    select?: any
+    blur?: any
 }
 
 export type DefaultEmphasisFocus = 'none' | 'self' | 'series';
 
-export interface DefaultExtraEmpasisState {
+export interface DefaultStatesMixinEmpasis {
     /**
      * self: Focus self and blur all others.
      * series: Focus series and blur all other series.
@@ -1515,19 +1520,20 @@ export interface DefaultExtraEmpasisState {
     focus?: DefaultEmphasisFocus
 }
 
-interface ExtraStateOptsBase {
-    emphasis?: {
-        focus?: string
-    },
-    select?: any
-    blur?: any
+export interface StatesMixinBase {
+    emphasis?: unknown
+    select?: unknown
+    blur?: unknown
 }
 
-export interface StatesOptionMixin<StateOption, ExtraStateOpts extends ExtraStateOptsBase = DefaultExtraStateOpts> {
+export interface StatesOptionMixin<
+    StateOption,
+    StatesMixin extends StatesMixinBase
+> {
     /**
      * Emphasis states
      */
-    emphasis?: StateOption & ExtraStateOpts['emphasis'] & {
+    emphasis?: StateOption & StatesMixin['emphasis'] & {
         /**
          * Scope of blurred element when focus.
          *
@@ -1542,11 +1548,11 @@ export interface StatesOptionMixin<StateOption, ExtraStateOpts extends ExtraStat
     /**
      * Select states
      */
-    select?: StateOption & ExtraStateOpts['select']
+    select?: StateOption & StatesMixin['select']
     /**
      * Blur states.
      */
-    blur?: StateOption & ExtraStateOpts['blur']
+    blur?: StateOption & StatesMixin['blur']
 }
 
 export interface UniversalTransitionOption {
@@ -1574,11 +1580,13 @@ export interface UniversalTransitionOption {
 }
 
 export interface SeriesOption<
-    StateOption=any, ExtraStateOpts extends ExtraStateOptsBase = DefaultExtraStateOpts> extends
+    StateOption = unknown,
+    StatesMixin extends StatesMixinBase = DefaultStatesMixin
+> extends
     ComponentOption,
     AnimationOptionMixin,
     ColorPaletteOptionMixin,
-    StatesOptionMixin<StateOption, ExtraStateOpts>
+    StatesOptionMixin<StateOption, StatesMixin>
 {
     mainType?: 'series'
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -938,35 +938,31 @@ export type SymbolOffsetCallback<T> = (rawValue: any, params: T) => string | num
  * Mixin of option set to control the element symbol.
  * Include type of symbol, and size of symbol.
  */
-export interface SymbolOptionMixin<T = unknown> {
+export interface SymbolOptionMixin<T = never> {
     /**
      * type of symbol, like `cirlce`, `rect`, or custom path and image.
      */
-    symbol?: string | (unknown extends T ? never : SymbolCallback<T>)
+    symbol?: string | (T extends never ? never : SymbolCallback<T>)
     /**
      * Size of symbol.
      */
-    symbolSize?: number | number[] | (unknown extends T ? never : SymbolSizeCallback<T>)
+    symbolSize?: number | number[] | (T extends never ? never : SymbolSizeCallback<T>)
 
-    symbolRotate?: number | (unknown extends T ? never : SymbolRotateCallback<T>)
+    symbolRotate?: number | (T extends never ? never : SymbolRotateCallback<T>)
 
     symbolKeepAspect?: boolean
 
-    symbolOffset?: string | number | (string | number)[] | (unknown extends T ? never : SymbolOffsetCallback<T>)
+    symbolOffset?: string | number | (string | number)[] | (T extends never ? never : SymbolOffsetCallback<T>)
 }
 
 /**
  * ItemStyleOption is a most common used set to config element styles.
  * It includes both fill and stroke style.
  */
-export interface ItemStyleOption extends ShadowOptionMixin, BorderOptionMixin {
-    color?: ZRColor
+export interface ItemStyleOption<TCbParams = never> extends ShadowOptionMixin, BorderOptionMixin {
+    color?: ZRColor | (TCbParams extends never ? never : ((params: TCbParams) => ZRColor))
     opacity?: number
     decal?: DecalObject | 'none'
-}
-
-export interface SeriesItemStyleOption<TParams = CallbackDataParams> extends Omit<ItemStyleOption, 'color'> {
-    color?: ZRColor | ((params: TParams) => string)
 }
 
 /**

--- a/test/types/basic.ts
+++ b/test/types/basic.ts
@@ -26,7 +26,12 @@ const chart: echarts.EChartsType = echarts.init(dom);
 
 const option: echarts.EChartsOption = {
     series: [{
-        type: 'bar'
+        type: 'bar',
+        emphasis: {
+            itemStyle: {
+                color: 'red'
+            }
+        }
     }]
 };
 chart.setOption(option);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

This PR aimed to improve option types found during the work of rewriting example code with TypeScript. It includes:

1. Improve return type in `renderItem` of custom series.
2. Export `CustomSeriesRenderItem`, `CustomSeriesRenderItemParams`, `CustomSeriesRenderItemAPI`, `CustomSeriesRenderItemReturn`
3. More precise axis type inference based on `axis.type`.
4. Fix callback type in `itemStyle.color` #14279 
5. Fix `emphasis`, `blur`, `select` is `any` in some series. 