### PR TITLE
fix(sunburst): radius in levels

### DIFF
--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -95,15 +95,15 @@ export interface SunburstSeriesNodeItemOption extends
 export interface SunburstSeriesLevelOption
     extends SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin> {
 
-    radius?: number | number[]
+    radius?: (number | string)[]
     /**
      * @deprecated use radius instead
      */
-    r?: number
+    r?: number | string
     /**
      * @deprecated use radius instead
      */
-    r0?: number
+    r0?: number | string
 
     highlight?: {
         itemStyle?: SunburstItemStyleOption
@@ -171,10 +171,10 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
 
         completeTreeValue(root);
 
-        this._levelModels = zrUtil.map(option.levels || [], function (levelDefine) {
-            return new Model(levelDefine, this, ecModel);
-        }, this);
-        const levelModels = this._levelModels;
+        const levelModels = this._levelModels
+            = zrUtil.map(option.levels || [], function (levelDefine) {
+                return new Model(levelDefine, this, ecModel);
+            }, this);
 
         // Make sure always a new tree is created when setOption,
         // in TreemapView, we check whether oldTree === newTree

--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -94,6 +94,17 @@ export interface SunburstSeriesNodeItemOption extends
 }
 export interface SunburstSeriesLevelOption
     extends SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin> {
+
+    radius?: number | number[]
+    /**
+     * @deprecated use radius instead
+     */
+    r?: number
+    /**
+     * @deprecated use radius instead
+     */
+    r0?: number
+
     highlight?: {
         itemStyle?: SunburstItemStyleOption
         label?: SunburstLabelOption
@@ -152,6 +163,7 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
     ignoreStyleOnData = true;
 
     private _viewRoot: TreeNode;
+    private _levelModels: Model<SunburstSeriesLevelOption>[];
 
     getInitialData(option: SunburstSeriesOption, ecModel: GlobalModel) {
         // Create a virtual root.
@@ -159,9 +171,10 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
 
         completeTreeValue(root);
 
-        const levelModels = zrUtil.map(option.levels || [], function (levelDefine) {
+        this._levelModels = zrUtil.map(option.levels || [], function (levelDefine) {
             return new Model(levelDefine, this, ecModel);
         }, this);
+        const levelModels = this._levelModels;
 
         // Make sure always a new tree is created when setOption,
         // in TreemapView, we check whether oldTree === newTree
@@ -193,6 +206,10 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
         params.treePathInfo = wrapTreePathInfo<SunburstSeriesNodeItemOption['value']>(node, this);
 
         return params;
+    }
+
+    getLevelModel(node: TreeNode) {
+        return this._levelModels && this._levelModels[node.depth];
     }
 
     static defaultOption: SunburstSeriesOption = {

--- a/src/chart/sunburst/sunburstLayout.ts
+++ b/src/chart/sunburst/sunburstLayout.ts
@@ -23,6 +23,7 @@ import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import SunburstSeriesModel, { SunburstSeriesNodeItemOption, SunburstSeriesOption } from './SunburstSeries';
 import { TreeNode } from '../../data/Tree';
+import SeriesModel from '../../model/Series';
 
 // let PI2 = Math.PI * 2;
 const RADIAN = Math.PI / 180;
@@ -119,16 +120,28 @@ export default function sunburstLayout(
                 let rStart = r0 + rPerLevel * depth;
                 let rEnd = r0 + rPerLevel * (depth + 1);
 
-                const itemModel = node.getModel<SunburstSeriesNodeItemOption>();
-                // @ts-ignore. TODO this is not provided to developer yet. Rename it.
-                if (itemModel.get('r0') != null) {
-                    // @ts-ignore
-                    rStart = parsePercent(itemModel.get('r0'), size / 2);
-                }
-                // @ts-ignore
-                if (itemModel.get('r') != null) {
-                    // @ts-ignore
-                    rEnd = parsePercent(itemModel.get('r'), size / 2);
+                const levelModel = seriesModel.getLevelModel(node);
+                if (levelModel) {
+                    const r0 = levelModel.get('r0', true);
+                    if (r0 != null) {
+                        // Compatible with deprecated r0
+                        rStart = parsePercent(r0, size / 2);
+                    }
+                    const r = levelModel.get('r', true);
+                    if (r != null) {
+                        // Compatible with deprecated r
+                        rEnd = parsePercent(r, size / 2);
+                    }
+
+                    // level-specific radius should override that of series
+                    let radius: number | number[] = levelModel.get('radius', true);
+                    if (radius != null) {
+                        if (typeof radius === 'number') {
+                            radius = [radius, radius];
+                        }
+                        rStart = parsePercent(radius[0], size / 2);
+                        rEnd = parsePercent(radius[1], size / 2);
+                    }
                 }
 
                 node.setLayout({

--- a/src/chart/sunburst/sunburstLayout.ts
+++ b/src/chart/sunburst/sunburstLayout.ts
@@ -122,26 +122,17 @@ export default function sunburstLayout(
 
                 const levelModel = seriesModel.getLevelModel(node);
                 if (levelModel) {
-                    const r0 = levelModel.get('r0', true);
-                    if (r0 != null) {
-                        // Compatible with deprecated r0
-                        rStart = parsePercent(r0, size / 2);
-                    }
-                    const r = levelModel.get('r', true);
-                    if (r != null) {
-                        // Compatible with deprecated r
-                        rEnd = parsePercent(r, size / 2);
+                    let r0 = levelModel.get('r0', true);
+                    let r = levelModel.get('r', true);
+                    let radius = levelModel.get('radius', true);
+
+                    if (radius != null) {
+                        r0 = radius[0];
+                        r = radius[1];
                     }
 
-                    // level-specific radius should override that of series
-                    let radius: number | number[] = levelModel.get('radius', true);
-                    if (radius != null) {
-                        if (typeof radius === 'number') {
-                            radius = [radius, radius];
-                        }
-                        rStart = parsePercent(radius[0], size / 2);
-                        rEnd = parsePercent(radius[1], size / 2);
-                    }
+                    (r0 != null) && (rStart = parsePercent(r0, size / 2));
+                    (r != null) && (rEnd = parsePercent(r, size / 2));
                 }
 
                 node.setLayout({


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Some sunburst examples uses `series.levels.r` and `series.levels.r0` but this option is not exposed in the document. After further examination, we found the original implementation supports `series.data.r` but we don't find the necessary scenario for this by now.  And `radius` typed in `number | number[]` may be a better option name than `r` and `r0` to be consistent with Pie series.

So this PR fixes this problem and exposes `series.levels.radius` to developers.


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Tested and passed all `sunburst*` cases.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
