### PR TITLE
feat(axis): add axisLabel.hideOverlap

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -349,9 +349,9 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
 
         buildAxisMinorTicks(group, transformGroup, axisModel, opt.tickDirection);
 
-        // This bit fixes the label overlap issue for the Time chart.
+        // This bit fixes the label overlap issue for the time chart.
         // See https://github.com/apache/echarts/issues/14266 for more.
-        if (axisModel.get('type') === 'time') {
+        if (axisModel.get(['axisLabel', 'hideOverlap'])) {
             const labelList = prepareLayoutList(map(labelEls, label => ({
                 label,
                 priority: label.z2,

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -64,15 +64,19 @@ export interface AxisBaseOptionCommon extends ComponentOption,
     minorSplitLine?: MinorSplitLineOption;
     splitArea?: SplitAreaOption;
 
-    // Min value of the axis. can be:
-    // + ScaleDataValue
-    // + 'dataMin': use the min value in data.
-    // + null/undefined: auto decide min value (consider pretty look and boundaryGap).
+    /**
+     * Min value of the axis. can be:
+     * + ScaleDataValue
+     * + 'dataMin': use the min value in data.
+     * + null/undefined: auto decide min value (consider pretty look and boundaryGap).
+     */
     min?: ScaleDataValue | 'dataMin' | ((extent: {min: number, max: number}) => ScaleDataValue);
-    // Max value of the axis. can be:
-    // + ScaleDataValue
-    // + 'dataMax': use the max value in data.
-    // + null/undefined: auto decide max value (consider pretty look and boundaryGap).
+    /**
+     * Max value of the axis. can be:
+     * + ScaleDataValue
+     * + 'dataMax': use the max value in data.
+     * + null/undefined: auto decide max value (consider pretty look and boundaryGap).
+     */
     max?: ScaleDataValue | 'dataMax' | ((extent: {min: number, max: number}) => ScaleDataValue);
     // Optional value can be:
     // + `false`: always include value 0.
@@ -209,7 +213,10 @@ interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     showMaxLabel?: boolean,
     margin?: number,
     rich?: Dictionary<TextCommonOption>
-
+    /**
+     * If hide overlapping labels.
+     */
+    hideOverlap?: boolean;
     // Color can be callback
     color?: ColorString | ((value?: string | number, index?: number) => ColorString)
 }

--- a/test/timeScale.html
+++ b/test/timeScale.html
@@ -153,6 +153,7 @@ under the License.
                             min: 'dataMin',
                             max: 'dataMax',
                             axisLabel: {
+                                hideOverlap: true
                             }
                         }
                     ],


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Use `axisLabel.hideOverlap` to control the overlapping strategy for labels of xAxis. To avoid potential breaking change if we force to hide these overlapped labels in https://github.com/apache/echarts/pull/15583 . Like in the following case, 
It can be accepted if we display all the labels. But the new strategy(on the right) will hide these slightly overlapped labels.

![image](https://user-images.githubusercontent.com/841551/133049042-c88bcc35-c45c-4d5e-9e2d-72eaad728bb0.png)
