### PR TITLE
feat(legend): use series/data name in legend according to series.colorBy

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -204,7 +204,7 @@ class LegendView extends ComponentView {
             }
 
             // Legend to control series.
-            if (seriesModel) {
+            if (seriesModel && seriesModel.isColorBySeries()) {
                 const data = seriesModel.getData();
                 const lineVisualStyle = data.getVisual('legendLineStyle') || {};
                 const legendIcon = data.getVisual('legendIcon');
@@ -232,7 +232,7 @@ class LegendView extends ComponentView {
                 ecModel.eachRawSeries(function (seriesModel) {
 
                     // In case multiple series has same data name
-                    if (legendDrawnMap.get(name)) {
+                    if (legendDrawnMap.get(name) || seriesModel.isColorBySeries()) {
                         return;
                     }
 

--- a/src/model/Series.ts
+++ b/src/model/Series.ts
@@ -234,6 +234,14 @@ class SeriesModel<Opt extends SeriesOption = SeriesOption> extends ComponentMode
         autoSeriesName(this);
 
         this._initSelectedMapFromData(data);
+
+        /**
+         * The default provider for legend. Whether the data name should be used
+         * is decided by the legend component based on the series colorBy.
+         */
+        this.legendVisualProvider = new LegendVisualProvider(
+            zrUtil.bind(this.getData, this), zrUtil.bind(this.getRawData, this)
+        );
     }
 
     /**

--- a/src/processor/dataFilter.ts
+++ b/src/processor/dataFilter.ts
@@ -35,7 +35,7 @@ export default function dataFilter(seriesType: string): StageHandler {
                 // If in any legend component the status is not selected.
                 for (let i = 0; i < legendModels.length; i++) {
                     // @ts-ignore FIXME: LegendModel
-                    if (!legendModels[i].isSelected(name)) {
+                    if (!legendModels[i].isSelected(name, seriesModel)) {
                         return false;
                     }
                 }

--- a/test/legend-colorBy.html
+++ b/test/legend-colorBy.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+
+
+
+        <script>
+        require(['echarts'/*, 'map/js/china' */], function (echarts) {
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                legend: {
+                    show: true
+                },
+                grid: {
+                    right: '50%'
+                },
+                series: [{
+                    name: 'bar1',
+                    data: [{
+                        name: 'a1',
+                        value: 10
+                    }, {
+                        name: 'b1',
+                        value: 12
+                    }, {
+                        value: 15
+                    }],
+                    type: 'bar'
+                }, {
+                    name: 'bar2',
+                    data: [{
+                        name: 'a2',
+                        value: 10
+                    }, {
+                        name: 'b2',
+                        value: 12
+                    }, {
+                        value: 15
+                    }],
+                    type: 'bar',
+                    colorBy: 'data'
+                }, {
+                    name: 'pie3',
+                    data: [{
+                        name: 'bar1',
+                        value: 10
+                    }, {
+                        name: 'b3',
+                        value: 12
+                    }, {
+                        value: 15
+                    }],
+                    type: 'pie',
+                    center: ['75%', '25%'],
+                    radius: [0, '25%']
+                }, {
+                    name: 'pie4',
+                    data: [{
+                        name: 'a4',
+                        value: 10
+                    }, {
+                        name: 'b4',
+                        value: 12
+                    }, {
+                        value: 15
+                    }],
+                    colorBy: 'series',
+                    type: 'pie',
+                    center: ['75%', '75%'],
+                    radius: [0, '25%']
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'The legend should be: bar1, a2, b2, Wed, b3, pie4'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

`colorBy` was supported in #13788 , enabling using color palettes for each series/data. This PR enhances the legend component so that names of series/data are used in legend items according to `colorBy`.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

For bar series colored by data, only the series name is shown in the legend and the color is not representing the data. 



### After: How is it fixed in this PR?

By default, if the bar series is colored by data, multiple legend items are in the legend component with the name of the data. 

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
