### PR TITLE
fix: un-deprecate getTextRect #15823

### DIFF
--- a/src/legacy/getTextRect.ts
+++ b/src/legacy/getTextRect.ts
@@ -31,8 +31,6 @@ export function getTextRect(
     truncate?: boolean,
     lineHeight?: number
 ) {
-    deprecateLog('getTextRect is deprecated.');
-
     const textEl = new Text({
         style: {
             text,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Mark `getTextRect` not to be deprecated since we do not have a replacement.

### Fixed issues

- #15823


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`getTextRect` was deprecated but no replacement plan is provided.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`getTextRect` is not deprecated.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
