### PR TITLE
fix(axis): fix charts render abnormally when `yAxis.max` is set to be a value less than the min value of the series data.

### DIFF
--- a/src/coord/scaleRawExtentInfo.ts
+++ b/src/coord/scaleRawExtentInfo.ts
@@ -201,11 +201,6 @@ export class ScaleRawExtentInfo {
         (min == null || !isFinite(min)) && (min = NaN);
         (max == null || !isFinite(max)) && (max = NaN);
 
-        if (min > max) {
-            min = NaN;
-            max = NaN;
-        }
-
         const isBlank = eqNaN(min)
             || eqNaN(max)
             || (isOrdinal && !axisDataLen);

--- a/test/axis-filter-extent2.html
+++ b/test/axis-filter-extent2.html
@@ -37,7 +37,7 @@ under the License.
 
 
         <div id="main-stack-extreme"></div>
-
+        <div id="main2"></div>
 
         <script>
         require(['echarts'], function (echarts) {
@@ -150,6 +150,46 @@ under the License.
                 height: 300
             });
         });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+
+                var option = option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    },
+                    yAxis: {
+                        type: 'value',
+                        // it works
+                        // max: 820
+                        // less than the min value of data
+                        max: 500
+                    },
+                    series: [
+                        {
+                            data: [820, 932, 901, 934, 1290, 1330, 1320],
+                            type: 'line'
+                        },
+                        {
+                            data: [820, 932, 901, 934, 1290, 1330, 1320],
+                            type: 'bar'
+                        }
+                    ]
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'The **line** series should be **invisible**',
+                        'The **bar** series should be **partially visible**',
+                        'The y-axis should be shown',
+                        'The max value of y-axis should be 500'
+                    ],
+                    option: option,
+                    height: 300
+                });
+            });
         </script>
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

In ECharts 5.x, the line/bar chart renders abnormally when `yAxis.max` is set to be a value less than the min value of the series data. See #14812 for more details.

I'm not sure if the root cause was found. Related commit is b116faa8ad5db4a887d4b6c0f9a23ec52534f8f2 in PR #12832.

### Fixed issues

- #14812


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img src="https://user-images.githubusercontent.com/26999792/137250234-99b9fbad-1570-4f7d-a16a-04e202eb21a4.png" width="400">


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img src="https://user-images.githubusercontent.com/26999792/137250297-5190d491-c3b0-4752-bd36-462454699a81.png" width="400">


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/axis-filter-extent2.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
