### PR TITLE
fix(radar): name being - in tooltip when name.show is false #15915

### DIFF
--- a/src/component/radar/RadarView.ts
+++ b/src/component/radar/RadarView.ts
@@ -47,7 +47,11 @@ class RadarView extends ComponentView {
         const radar = radarModel.coordinateSystem;
         const indicatorAxes = radar.getIndicatorAxes();
         const axisBuilders = zrUtil.map(indicatorAxes, function (indicatorAxis) {
+            const axisName = indicatorAxis.model.get('showName')
+                ? indicatorAxis.name
+                : ''; // hide name
             const axisBuilder = new AxisBuilder(indicatorAxis.model, {
+                axisName: axisName,
                 position: [radar.cx, radar.cy],
                 rotation: indicatorAxis.angle,
                 labelDirection: -1,

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -88,6 +88,7 @@ export interface RadarOption extends ComponentOption, CircleLayoutOptionMixin {
 export type InnerIndicatorAxisOption = AxisBaseOption & {
     // TODO Use type?
     // axisType?: 'value' | 'log'
+    showName?: boolean
 };
 
 class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystemHostModel {
@@ -137,15 +138,13 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
                 axisLabel: axisLabel,
                 // Compatible with 2 and use text
                 name: indicatorOpt.text,
+                showName: showName,
                 nameLocation: 'end',
                 nameGap: nameGap,
                 // min: 0,
                 nameTextStyle: iNameTextStyle,
                 triggerEvent: triggerEvent
             } as InnerIndicatorAxisOption, false);
-            if (!showName) {
-                innerIndicatorOpt.name = '';
-            }
             if (typeof nameFormatter === 'string') {
                 const indName = innerIndicatorOpt.name;
                 innerIndicatorOpt.name = nameFormatter.replace('{value}', indName != null ? indName : '');

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -43,6 +43,9 @@ function defaultsShow(opt: object, show: boolean) {
 
 export interface RadarIndicatorOption {
     name?: string
+    /**
+     * @deprecated Use `name` instead.
+     */
     text?: string
     min?: number
     max?: number

--- a/src/preprocessor/helper/compatStyle.ts
+++ b/src/preprocessor/helper/compatStyle.ts
@@ -307,6 +307,11 @@ export default function globalCompatStyle(option: any, isTheme?: boolean) {
                 deprecateLog('nameGap property in radar component has been changed to axisNameGap');
             }
         }
+        each(radarOpt.indicator, function (indicatorOpt: any) {
+            if (__DEV__ && indicatorOpt.text) {
+                deprecateReplaceLog('text', 'name', 'radar.indicator');
+            }
+        });
     });
 
     each(toArr(option.geo), function (geoOpt) {

--- a/src/preprocessor/helper/compatStyle.ts
+++ b/src/preprocessor/helper/compatStyle.ts
@@ -307,11 +307,13 @@ export default function globalCompatStyle(option: any, isTheme?: boolean) {
                 deprecateLog('nameGap property in radar component has been changed to axisNameGap');
             }
         }
-        each(radarOpt.indicator, function (indicatorOpt: any) {
-            if (__DEV__ && indicatorOpt.text) {
-                deprecateReplaceLog('text', 'name', 'radar.indicator');
-            }
-        });
+        if (__DEV__) {
+            each(radarOpt.indicator, function (indicatorOpt: any) {
+                if (indicatorOpt.text) {
+                    deprecateReplaceLog('text', 'name', 'radar.indicator');
+                }
+            });
+        }
     });
 
     each(toArr(option.geo), function (geoOpt) {

--- a/test/radar3.html
+++ b/test/radar3.html
@@ -41,9 +41,14 @@ under the License.
                 var chart = echarts.init(document.getElementById('main'));
 
                 chart.setOption({
-                    title: {
+                    title: [{
                         text: '多雷达图'
-                    },
+                    }, {
+                        text: 'Tooltip series names should not be "-"',
+                        left: '25%',
+                        top: '70%',
+                        textAlign: 'center'
+                    }],
                     tooltip: {
                         trigger: 'axis'
                     },
@@ -54,13 +59,18 @@ under the License.
                     radar: [
                         {
                             indicator: [
-                                {text: '品牌', max: 100},
-                                {text: '内容', max: 100},
-                                {text: '可用性', max: 100},
+                                {name: '品牌', max: 100},
+                                {name: '内容', max: 100},
+                                {name: '可用性', max: 100},
+                                // text is deprecated
                                 {text: '功能', max: 100}
                             ],
                             center: ['25%',200],
-                            radius: 80
+                            radius: 80,
+                            axisName: {
+                                show: false,
+                                formatter: 'name: {value}'
+                            }
                         },
                         {
                             indicator: [

--- a/test/radar3.html
+++ b/test/radar3.html
@@ -46,7 +46,7 @@ under the License.
                     }, {
                         text: 'Tooltip series names should not be "-"',
                         left: '25%',
-                        top: '70%',
+                        top: 320,
                         textAlign: 'center'
                     }],
                     tooltip: {
@@ -68,8 +68,7 @@ under the License.
                             center: ['25%',200],
                             radius: 80,
                             axisName: {
-                                show: false,
-                                formatter: 'name: {value}'
+                                show: false
                             }
                         },
                         {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Radar indicator names were displayed in the tooltip as "-" when `indicator.name.show` is set to be false. 

### Fixed issues


- #15915



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Radar indicator names were displayed in the tooltip as "-" when `indicator.name.show` is set to be false. 

![image](https://user-images.githubusercontent.com/779050/139644658-d2d1defc-cc53-4d08-b443-9387a3f75791.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Radar indicator name should be displayed in the tooltip.

![image](https://user-images.githubusercontent.com/779050/139644855-e4b3ddbe-e242-476a-be40-65ce3244d0c2.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
