### PR TITLE
fix(axis): only `value` has `scale` in cartesian

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -111,7 +111,7 @@ interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {
     maxInterval?: number;
 }
 
-export interface CategoryAxisBaseOption extends AxisBaseOptionCommon {
+export interface CategoryAxisBaseOption extends Omit<AxisBaseOptionCommon, 'scale'> {
     type?: 'category';
     boundaryGap?: boolean
     axisLabel?: AxisLabelOption<'category'> & {
@@ -142,12 +142,12 @@ export interface ValueAxisBaseOption extends NumericAxisBaseOptionCommon {
     type?: 'value';
     axisLabel?: AxisLabelOption<'value'>;
 }
-export interface LogAxisBaseOption extends NumericAxisBaseOptionCommon {
+export interface LogAxisBaseOption extends Omit<NumericAxisBaseOptionCommon, 'scale'> {
     type?: 'log';
     axisLabel?: AxisLabelOption<'log'>;
     logBase?: number;
 }
-export interface TimeAxisBaseOption extends NumericAxisBaseOptionCommon {
+export interface TimeAxisBaseOption extends Omit<NumericAxisBaseOptionCommon, 'scale'> {
     type?: 'time';
     axisLabel?: AxisLabelOption<'time'>;
 }

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -78,10 +78,6 @@ export interface AxisBaseOptionCommon extends ComponentOption,
      * + null/undefined: auto decide max value (consider pretty look and boundaryGap).
      */
     max?: ScaleDataValue | 'dataMax' | ((extent: {min: number, max: number}) => ScaleDataValue);
-    // Optional value can be:
-    // + `false`: always include value 0.
-    // + `true`: the extent do not consider value 0.
-    scale?: boolean;
 
 }
 
@@ -111,7 +107,7 @@ interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {
     maxInterval?: number;
 }
 
-export interface CategoryAxisBaseOption extends Omit<AxisBaseOptionCommon, 'scale'> {
+export interface CategoryAxisBaseOption extends AxisBaseOptionCommon {
     type?: 'category';
     boundaryGap?: boolean
     axisLabel?: AxisLabelOption<'category'> & {
@@ -141,13 +137,20 @@ export interface CategoryAxisBaseOption extends Omit<AxisBaseOptionCommon, 'scal
 export interface ValueAxisBaseOption extends NumericAxisBaseOptionCommon {
     type?: 'value';
     axisLabel?: AxisLabelOption<'value'>;
+
+    /**
+     * Optional value can be:
+     * + `false`: always include value 0.
+     * + `false`: always include value 0.
+     */
+     scale?: boolean;
 }
-export interface LogAxisBaseOption extends Omit<NumericAxisBaseOptionCommon, 'scale'> {
+export interface LogAxisBaseOption extends NumericAxisBaseOptionCommon {
     type?: 'log';
     axisLabel?: AxisLabelOption<'log'>;
     logBase?: number;
 }
-export interface TimeAxisBaseOption extends Omit<NumericAxisBaseOptionCommon, 'scale'> {
+export interface TimeAxisBaseOption extends NumericAxisBaseOptionCommon {
     type?: 'time';
     axisLabel?: AxisLabelOption<'time'>;
 }

--- a/src/coord/axisDefault.ts
+++ b/src/coord/axisDefault.ts
@@ -171,7 +171,6 @@ const valueAxis: AxisBaseOption = zrUtil.merge({
 }, defaultOption);
 
 const timeAxis: AxisBaseOption = zrUtil.merge({
-    scale: true,
     splitNumber: 6,
     axisLabel: {
         // To eliminate labels that are not nice
@@ -189,7 +188,6 @@ const timeAxis: AxisBaseOption = zrUtil.merge({
 }, valueAxis);
 
 const logAxis: AxisBaseOption = zrUtil.defaults({
-    scale: true,
     logBase: 10
 }, valueAxis);
 

--- a/src/coord/axisModelCommonMixin.ts
+++ b/src/coord/axisModelCommonMixin.ts
@@ -19,7 +19,7 @@
 
 import Model from '../model/Model';
 import Axis from './Axis';
-import { AxisBaseOption, AxisBaseOptionCommon } from './axisCommonTypes';
+import { AxisBaseOption, ValueAxisBaseOption } from './axisCommonTypes';
 import { CoordinateSystemHostModel } from './CoordinateSystem';
 
 
@@ -31,7 +31,7 @@ interface AxisModelCommonMixin<Opt extends AxisBaseOption> extends Pick<Model<Op
 class AxisModelCommonMixin<Opt extends AxisBaseOption> {
 
     getNeedCrossZero(): boolean {
-        const option: AxisBaseOptionCommon = this.option;
+        const option: ValueAxisBaseOption = this.option;
         return !option.scale;
     }
 

--- a/src/coord/axisModelCommonMixin.ts
+++ b/src/coord/axisModelCommonMixin.ts
@@ -19,7 +19,7 @@
 
 import Model from '../model/Model';
 import Axis from './Axis';
-import { AxisBaseOption } from './axisCommonTypes';
+import { AxisBaseOption, AxisBaseOptionCommon } from './axisCommonTypes';
 import { CoordinateSystemHostModel } from './CoordinateSystem';
 
 
@@ -31,7 +31,7 @@ interface AxisModelCommonMixin<Opt extends AxisBaseOption> extends Pick<Model<Op
 class AxisModelCommonMixin<Opt extends AxisBaseOption> {
 
     getNeedCrossZero(): boolean {
-        const option = this.option;
+        const option: AxisBaseOptionCommon = this.option;
         return !option.scale;
     }
 

--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -27,7 +27,7 @@ import GridModel from './GridModel';
 import { AxisBaseModel } from '../AxisBaseModel';
 import {OrdinalSortInfo} from '../../util/types';
 import { SINGLE_REFERRING } from '../../util/model';
-
+import axisDefault from '../axisDefault';
 
 export type CartesianAxisPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -56,6 +56,16 @@ export class CartesianAxisModel extends ComponentModel<CartesianAxisOption>
 
     getCoordSysModel(): GridModel {
         return this.getReferringComponents('grid', SINGLE_REFERRING).models[0] as GridModel;
+    }
+
+    getNeedCrossZero(): boolean {
+        const option = this.option;
+
+        if (option.type === 'value') {
+            return !option.scale;
+        }
+
+        return !axisDefault[option.type].scale;
     }
 }
 

--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -27,7 +27,6 @@ import GridModel from './GridModel';
 import { AxisBaseModel } from '../AxisBaseModel';
 import {OrdinalSortInfo} from '../../util/types';
 import { SINGLE_REFERRING } from '../../util/model';
-import axisDefault from '../axisDefault';
 
 export type CartesianAxisPosition = 'top' | 'bottom' | 'left' | 'right';
 

--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -58,15 +58,6 @@ export class CartesianAxisModel extends ComponentModel<CartesianAxisOption>
         return this.getReferringComponents('grid', SINGLE_REFERRING).models[0] as GridModel;
     }
 
-    getNeedCrossZero(): boolean {
-        const option = this.option;
-
-        if (option.type === 'value') {
-            return !option.scale;
-        }
-
-        return !axisDefault[option.type].scale;
-    }
 }
 
 export interface CartesianAxisModel extends AxisModelCommonMixin<CartesianAxisOption>,

--- a/src/coord/scaleRawExtentInfo.ts
+++ b/src/coord/scaleRawExtentInfo.ts
@@ -96,7 +96,7 @@ export class ScaleRawExtentInfo {
         this._dataMax = dataExtent[1];
 
         const isOrdinal = this._isOrdinal = scale.type === 'ordinal';
-        this._needCrossZero = model.getNeedCrossZero && model.getNeedCrossZero();
+        this._needCrossZero = scale.type === 'interval' && model.getNeedCrossZero && model.getNeedCrossZero();
 
         const modelMinRaw = this._modelMinRaw = model.get('min', true);
         if (isFunction(modelMinRaw)) {

--- a/test/logScale.html
+++ b/test/logScale.html
@@ -59,7 +59,8 @@ under the License.
                     }],
                     yAxis: [{
                         type: 'log',
-                        name: 'y'
+                        name: 'y',
+                        scale: false
                     }],
                     series: [
                     {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

According to [doc](https://echarts.apache.org/en/option.html#yAxis.scale)
In `catersain`, only `value` axis can have `scale`.



### Fixed issues

- Close #10174


## Details

### Before: What was the problem?

<img width="655" alt="Screen Shot 2021-11-02 at 11 19 24 PM" src="https://user-images.githubusercontent.com/20318608/139876208-8029952a-8529-4f96-8510-fe543af251b1.png">




### After: How is it fixed in this PR?

<img width="667" alt="Screen Shot 2021-11-02 at 11 19 13 PM" src="https://user-images.githubusercontent.com/20318608/139876254-4f9b8783-ca48-4bfa-8c87-981036298a2d.png">



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [x] Please squash the commits into a single one when merge.

### Other information
