### PR TITLE
fix: should show tooltip when all value are null

### DIFF
--- a/src/chart/helper/createSeriesData.ts
+++ b/src/chart/helper/createSeriesData.ts
@@ -183,8 +183,7 @@ function createSeriesData(
 function isNeedCompleteOrdinalData(source: Source) {
     if (source.sourceFormat === SOURCE_FORMAT_ORIGINAL) {
         const sampleItem = firstDataNotNull(source.data as ArrayLike<any> || []);
-        return sampleItem != null
-            && !zrUtil.isArray(getDataItemValue(sampleItem));
+        return !zrUtil.isArray(getDataItemValue(sampleItem));
     }
 }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

**Before**
![image](https://user-images.githubusercontent.com/35442047/140252622-18fa4690-e2d4-4f62-a8ff-38986c905c7b.png)

**After**
![image](https://user-images.githubusercontent.com/35442047/140252477-68fa87a1-e3fe-45a5-ac23-375518a7f95d.png)


### Fixed issues

<!--
- #xxxx: ...
-->

#15757

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

when all value are null, `isNeedCompleteOrdinalData` still should  be true.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
