### PR TITLE
fix:<gauge>#15930 gauge's detail option can't setting the padding-top…

### DIFF
--- a/src/chart/gauge/GaugeSeries.ts
+++ b/src/chart/gauge/GaugeSeries.ts
@@ -305,7 +305,7 @@ class GaugeSeriesModel extends SeriesModel<GaugeSeriesOption> {
             borderWidth: 0,
             borderColor: '#ccc',
             width: 100,
-            height: null, // self-adaption
+            height: 40, // self-adaption
             padding: [5, 10],
             // x, y，单位px
             offsetCenter: [0, '40%'],

--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -641,7 +641,6 @@ class GaugeView extends ChartView {
                         width: isNaN(width) ? null : width,
                         height: isNaN(height) ? null : height,
                         align: 'center',
-                        verticalAlign: 'middle'
                     }, {inheritColor: detailColor})
                 });
                 setLabelValueAnimation(


### PR DESCRIPTION
…/padding-bottom individually

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [✔️ ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
+ 删除默认detail文本垂直居中
+ 添加默认detail的height，文档显示默认高度是40


### Fixed issues

#15930


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
gauge's detail option can't setting the padding-top/padding-bottom individually

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
去掉默认的垂直居中属性

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
