### PR TITLE
fix(line): fix bezier points calculated wrong when monotone smooth is used.

### DIFF
--- a/src/chart/line/poly.ts
+++ b/src/chart/line/poly.ts
@@ -136,18 +136,20 @@ function drawSegment(
                     if (smoothMonotone === 'x') {
                         lenPrevSeg = Math.abs(dx0);
                         lenNextSeg = Math.abs(dx1);
-                        cpx1 = x - lenPrevSeg * smooth;
+                        const dir = vx > 0 ? 1 : -1;
+                        cpx1 = x - dir * lenPrevSeg * smooth;
                         cpy1 = y;
-                        nextCpx0 = x + lenPrevSeg * smooth;
+                        nextCpx0 = x + dir * lenNextSeg * smooth;
                         nextCpy0 = y;
                     }
                     else if (smoothMonotone === 'y') {
                         lenPrevSeg = Math.abs(dy0);
                         lenNextSeg = Math.abs(dy1);
+                        const dir = vy > 0 ? 1 : -1;
                         cpx1 = x;
-                        cpy1 = y - lenPrevSeg * smooth;
+                        cpy1 = y - dir * lenPrevSeg * smooth;
                         nextCpx0 = x;
-                        nextCpy0 = y + lenPrevSeg * smooth;
+                        nextCpy0 = y + dir * lenNextSeg * smooth;
                     }
                     else {
                         lenPrevSeg = Math.sqrt(dx0 * dx0 + dy0 * dy0);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix a wrong factor in the algorithm because of typo.

### Fixed issues

#15323 


## Details

### Before: What was the problem?

![image](https://user-images.githubusercontent.com/841551/141880649-b1e7bede-d504-4a33-9ed5-3039af8a603e.png)

### After: How is it fixed in this PR?

![image](https://user-images.githubusercontent.com/841551/141880607-bec1ea2f-3bad-4659-a3b4-b009f919bf10.png)

