### PR TITLE
[fix] dataZoom: optimize shadow render performance when roaming.

### DIFF
--- a/src/component/axisPointer/BaseAxisPointer.ts
+++ b/src/component/axisPointer/BaseAxisPointer.ts
@@ -493,6 +493,8 @@ class BaseAxisPointer implements AxisPointer {
             this._handle = null;
             this._payloadInfo = null;
         }
+
+        throttleUtil.clear(this, '_doDispatchAxisPointer');
     }
 
     /**

--- a/src/component/dataZoom/roams.ts
+++ b/src/component/dataZoom/roams.ts
@@ -158,14 +158,16 @@ function createCoordSysRecord(api: ExtensionAPI, coordSysModel: CoordinateSystem
  * This action will be throttled.
  */
 function dispatchAction(api: ExtensionAPI, batch: DataZoomPayloadBatchItem[]) {
-    api.dispatchAction({
-        type: 'dataZoom',
-        animation: {
-            easing: 'cubicOut',
-            duration: 100
-        },
-        batch: batch
-    });
+    if (!api.isDisposed()) {
+        api.dispatchAction({
+            type: 'dataZoom',
+            animation: {
+                easing: 'cubicOut',
+                duration: 100
+            },
+            batch: batch
+        });
+    }
 }
 
 function containsPoint(

--- a/src/component/parallel/ParallelView.ts
+++ b/src/component/parallel/ParallelView.ts
@@ -25,7 +25,7 @@ import { ElementEventName } from 'zrender/src/core/types';
 import { ElementEvent } from 'zrender/src/Element';
 import { ParallelAxisExpandPayload } from '../axis/parallelAxisAction';
 import { each, bind, extend } from 'zrender/src/core/util';
-import { ThrottleController, createOrUpdate } from '../../util/throttle';
+import { ThrottleController, createOrUpdate, clear } from '../../util/throttle';
 
 const CLICK_THRESHOLD = 5; // > 4
 
@@ -50,6 +50,7 @@ class ParallelView extends ComponentView {
         createOrUpdate(this, '_throttledDispatchExpand', parallelModel.get('axisExpandRate'), 'fixRate');
     }
     dispose(ecModel: GlobalModel, api: ExtensionAPI): void {
+        clear(this, '_throttledDispatchExpand');
         each(this._handlers, function (handler: ElementEventHandler, eventName) {
             api.getZr().off(eventName, handler);
         });

--- a/src/util/throttle.ts
+++ b/src/util/throttle.ts
@@ -176,6 +176,8 @@ export function createOrUpdate<T, S extends keyof T, P = T[S]>(
 export function clear<T, S extends keyof T>(obj: T, fnAttr: S): void {
     const fn = obj[fnAttr];
     if (fn && (fn as any)[ORIGIN_METHOD]) {
+        // Clear throttle
+        (fn as any).clear && (fn as any).clear();
         obj[fnAttr] = (fn as any)[ORIGIN_METHOD];
     }
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

1. Avoid shadow re-render in slider dataZoom when roaming on the chart.
2. Clear throttle timeouts when disposing.


### Fixed issues

https://github.com/apache/echarts/issues/15409
