### PR TITLE
feat(tooltip): Allow tooltips to disable transform positioning

### DIFF
--- a/src/component/tooltip/TooltipModel.ts
+++ b/src/component/tooltip/TooltipModel.ts
@@ -61,6 +61,12 @@ export interface TooltipOption extends CommonTooltipOption<TopLevelFormatterPara
     renderMode?: 'auto' | TooltipRenderMode   // TODO richText renamed canvas?
 
     /**
+     * 'transform': use css transform3d to position the tooltip
+     * 'legacy': use css left and top to position the tooltip
+     */
+    positioning?: 'transform' | 'legacy';
+
+    /**
      * If append popup dom to document.body
      * Only available when renderMode is html
      */
@@ -103,6 +109,8 @@ class TooltipModel extends ComponentModel<TooltipOption> {
         displayMode: 'single', // 'single' | 'multipleByCoordSys'
 
         renderMode: 'auto', // 'auto' | 'html' | 'richText'
+
+        positioning: 'transform', // 'transform' | 'legacy'
 
         // whether restraint content inside viewRect.
         // If renderMode: 'richText', default true.


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

In #14246 echarts v5 css transform was made the default for positioning tooltips based on if the browser is modern. We'd like to be able to switch back to the old left, top absolute positioning as we've found that transform is slower when attempting to follow the cursor. After removing the new drop-shadow, its close but still not nearly as performant when scrubbing quickly.

**echarts v4**

Layouts per second - 300

https://user-images.githubusercontent.com/1400464/142956494-d10f47fc-11fc-4f9f-82ba-e98becb893ee.mp4


**echarts v5.2.2** with tooltip dropshadow removed

Layouts per second - 170

https://user-images.githubusercontent.com/1400464/142956472-53af76f6-04b9-4c23-96e9-54610075949b.mp4




### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
