### PR TITLE
fix(axis): axis label width when overflow is set

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -54,7 +54,6 @@ interface BreadcrumbItemStyleOption extends ItemStyleOption {
 }
 
 interface TreemapSeriesLabelOption extends SeriesLabelOption {
-    ellipsis?: boolean
     formatter?: string | ((params: CallbackDataParams) => string)
 }
 
@@ -305,7 +304,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
             upperLabel: {
                 show: true,
                 position: [0, '50%'],
-                ellipsis: true,
+                overflow: 'truncate',
                 verticalAlign: 'middle'
             }
         },

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -21,7 +21,7 @@ import * as graphicUtil from '../../util/graphic';
 import {getFont} from '../../label/labelStyle';
 import Model from '../Model';
 import { LabelOption, ColorString } from '../../util/types';
-import ZRText from 'zrender/src/graphic/Text';
+import ZRText, {TextStyleProps} from 'zrender/src/graphic/Text';
 
 const PATH_COLOR = ['textStyle', 'color'] as const;
 
@@ -65,13 +65,13 @@ class TextStyleMixin {
     }
 
     getTextRect(this: Model<LabelRectRelatedOption> & TextStyleMixin, text: string): graphicUtil.BoundingRect {
-        const style = {
+        const style: TextStyleProps = {
             text: text,
             verticalAlign: this.getShallow('verticalAlign')
                 || this.getShallow('baseline')
-        } as any;
+        };
         for (let i = 0; i < textStyleParams.length; i++) {
-            style[textStyleParams[i]] = this.getShallow(textStyleParams[i]);
+            (style as any)[textStyleParams[i]] = this.getShallow(textStyleParams[i]);
         }
         tmpText.useStyle(style);
         tmpText.update();

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -28,11 +28,19 @@ const PATH_COLOR = ['textStyle', 'color'] as const;
 export type LabelFontOption = Pick<LabelOption, 'fontStyle' | 'fontWeight' | 'fontSize' | 'fontFamily'>;
 type LabelRectRelatedOption = Pick<LabelOption,
     'align' | 'verticalAlign' | 'padding' | 'lineHeight' | 'baseline' | 'rich'
-    | 'width' | 'height' | 'overflow' | 'ellipsis'
-> & LabelFontOption;
+    | 'width' | 'height'
+> & LabelFontOption & {
+    overflow?: 'break' | 'breakAll' | 'truncate' | 'none',
+    ellipsis?: string
+};
+
+const textStyleParams = [
+    'fontStyle', 'fontWeight', 'fontSize', 'fontFamily', 'padding',
+    'lineHeight', 'rich', 'width', 'height', 'overflow', 'ellipsis'
+] as const;
 
 // TODO Performance improvement?
-const tmpRichText = new ZRText();
+const tmpText = new ZRText();
 class TextStyleMixin {
     /**
      * Get color property or get color from option.textStyle.color
@@ -60,23 +68,17 @@ class TextStyleMixin {
     }
 
     getTextRect(this: Model<LabelRectRelatedOption> & TextStyleMixin, text: string): graphicUtil.BoundingRect {
-        tmpRichText.useStyle({
-            text,
-            fontStyle: this.getShallow('fontStyle'),
-            fontWeight: this.getShallow('fontWeight'),
-            fontSize: this.getShallow('fontSize'),
-            fontFamily: this.getShallow('fontFamily'),
-            verticalAlign: this.getShallow('verticalAlign') || this.getShallow('baseline'),
-            padding: this.getShallow('padding') as number[],
-            lineHeight: this.getShallow('lineHeight'),
-            rich: this.getShallow('rich'),
-            width: this.getShallow('width') as number,
-            height: this.getShallow('height') as number,
-            overflow: this.getShallow('overflow'),
-            ellipsis: this.getShallow('ellipsis')
-        });
-        tmpRichText.update();
-        return tmpRichText.getBoundingRect();
+        const style = {
+            text: text,
+            verticalAlign: this.getShallow('verticalAlign')
+                || this.getShallow('baseline')
+        } as any;
+        for (let i = 0; i < textStyleParams.length; i++) {
+            style[textStyleParams[i]] = this.getShallow(textStyleParams[i]);
+        }
+        tmpText.useStyle(style);
+        tmpText.update();
+        return tmpText.getBoundingRect();
     }
 };
 

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -28,6 +28,7 @@ const PATH_COLOR = ['textStyle', 'color'] as const;
 export type LabelFontOption = Pick<LabelOption, 'fontStyle' | 'fontWeight' | 'fontSize' | 'fontFamily'>;
 type LabelRectRelatedOption = Pick<LabelOption,
     'align' | 'verticalAlign' | 'padding' | 'lineHeight' | 'baseline' | 'rich'
+    | 'width' | 'height' | 'overflow' | 'ellipsis'
 > & LabelFontOption;
 
 // TODO Performance improvement?
@@ -68,7 +69,11 @@ class TextStyleMixin {
             verticalAlign: this.getShallow('verticalAlign') || this.getShallow('baseline'),
             padding: this.getShallow('padding') as number[],
             lineHeight: this.getShallow('lineHeight'),
-            rich: this.getShallow('rich')
+            rich: this.getShallow('rich'),
+            width: this.getShallow('width') as number,
+            height: this.getShallow('height') as number,
+            overflow: this.getShallow('overflow'),
+            ellipsis: this.getShallow('ellipsis')
         });
         tmpRichText.update();
         return tmpRichText.getBoundingRect();

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -28,15 +28,12 @@ const PATH_COLOR = ['textStyle', 'color'] as const;
 export type LabelFontOption = Pick<LabelOption, 'fontStyle' | 'fontWeight' | 'fontSize' | 'fontFamily'>;
 type LabelRectRelatedOption = Pick<LabelOption,
     'align' | 'verticalAlign' | 'padding' | 'lineHeight' | 'baseline' | 'rich'
-    | 'width' | 'height'
-> & LabelFontOption & {
-    overflow?: 'break' | 'breakAll' | 'truncate' | 'none',
-    ellipsis?: string
-};
+    | 'width' | 'height' | 'overflow'
+> & LabelFontOption;
 
 const textStyleParams = [
     'fontStyle', 'fontWeight', 'fontSize', 'fontFamily', 'padding',
-    'lineHeight', 'rich', 'width', 'height', 'overflow', 'ellipsis'
+    'lineHeight', 'rich', 'width', 'height', 'overflow'
 ] as const;
 
 // TODO Performance improvement?

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1078,6 +1078,9 @@ export interface TextCommonOption extends ShadowOptionMixin {
     textShadowOffsetY?: number
 
     tag?: string
+
+    overflow?: 'break' | 'breakAll' | 'truncate' | 'none'
+    ellipsis?: string
 }
 
 export interface LabelFormatterCallback<T = CallbackDataParams> {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1078,9 +1078,6 @@ export interface TextCommonOption extends ShadowOptionMixin {
     textShadowOffsetY?: number
 
     tag?: string
-
-    overflow?: 'break' | 'breakAll' | 'truncate' | 'none'
-    ellipsis?: string
 }
 
 export interface LabelFormatterCallback<T = CallbackDataParams> {

--- a/test/bar3.html
+++ b/test/bar3.html
@@ -51,7 +51,7 @@ under the License.
                 var data4 = [];
 
                 for (var i = 0; i < 10; i++) {
-                    xAxisData.push('类目' + i);
+                    xAxisData.push(i + ' Long label should use ellipsis if width is set');
                     data0.push(-Math.random().toFixed(2));
                     data1.push((Math.random() * 5).toFixed(2));
                     data2.push(-Math.random().toFixed(2));
@@ -127,6 +127,10 @@ under the License.
                         },
                         splitArea: {
                             show: true
+                        },
+                        axisLabel: {
+                            width: 100,
+                            overflow: 'truncate',
                         }
                     },
                     xAxis: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Set width and overflow to textStyle so that text should set to be correct width when overflows.

### Fixed issues

#16189

## Details

### Before: What was the problem?

Grid position was not correct because text width is calculated wrong.

![image](https://user-images.githubusercontent.com/31105752/145193136-fb865a48-afdd-4bd2-b5aa-af013f2e9b86.png)

### After: How is it fixed in this PR?

Grid position calculated right.

![image](https://user-images.githubusercontent.com/779050/145531380-ab6dfb4c-4424-46d4-9f59-bfea72772e8c.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/bar3.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
