### PR TITLE
fix(tooltip): fix tooltip lag issue when transition is disabled. (#16101)

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -18,7 +18,6 @@
 */
 
 import { isString, indexOf, each, bind, isArray, isDom } from 'zrender/src/core/util';
-import { toHex } from 'zrender/src/tool/color';
 import { normalizeEvent } from 'zrender/src/core/event';
 import { transformLocalCoord } from 'zrender/src/core/dom';
 import env from 'zrender/src/core/env';

--- a/test/tooltip-lag-glitch.html
+++ b/test/tooltip-lag-glitch.html
@@ -40,6 +40,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
 
 
         <script>
@@ -97,7 +98,7 @@ under the License.
 
                 var chart1 = testHelper.create(echarts, 'main0', {
                     title: [
-                        'Tooltip shouldn\'t shake or lag',
+                        'Tooltip shouldn\'t shake or be laggy',
                         '1) Chrome with the devtools open',
                         '2) Firefox'
                     ],
@@ -106,11 +107,32 @@ under the License.
 
                 var chart2 = testHelper.create(echarts, 'main1', {
                     title: [
-                        'Tooltip shouldn\'t shake or lag',
+                        'Tooltip shouldn\'t shake or be laggy',
                         '1) Chrome with the devtools open',
                         '2) Firefox'
                     ],
                     option: option
+                });
+
+                var chart3 = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Tooltip shouldn\'t be laggy when transition is disabled',
+                        'https://github.com/apache/echarts/issues/16101'
+                    ],
+                    option: option,
+                    buttons: [{
+                        text: 'Disable transition',
+                        onclick: function () {
+                            var enabled = chart3._transitionEnabled;
+                            chart3.setOption({
+                                tooltip: {
+                                    transitionDuration: enabled && .4
+                                }
+                            });
+                            chart3._transitionEnabled = !enabled;
+                            this.innerText = (enabled ? 'Disable' : 'Enable') + ' transition';
+                        }
+                    }]
                 });
 
                 echarts.connect([chart1, chart2]);


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix tooltip lag issue when transition is disabled, resolves #16101.

### Fixed issues

- #16101


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

We throttled the `updatePosition` function of tooltip in #15683 to solve the **_shake_** and **_lag_** issue(raised by #14965) in Chrome(with DevTools open) and Firefox. But as #16101 described,  the tooltip will be laggy because of the `50ms` interval when `transitionDuration` is `0`.

Refer to #16101, #16091 for more details.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Throttle it only when `transition` is enabled.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/tooltip-lag-glitch.html`.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
