### PR TITLE
Support using dataType param to specify edge highlighting

### DIFF
--- a/src/data/helper/linkSeriesData.ts
+++ b/src/data/helper/linkSeriesData.ts
@@ -133,17 +133,10 @@ function cloneShallowInjection(opt: LinkSeriesDataOpt, res: SeriesData): SeriesD
  * @param [dataType] If not specified, return mainData.
  */
 function getLinkedData(this: SeriesData, dataType?: SeriesDataType): SeriesData {
-    const seriesDataTypeList = ["main" , "node" , "edge"]
     const mainData = inner(this).mainData;
-    if (dataType == null || mainData == null){
-        return mainData
-    }
-    if (!seriesDataTypeList.includes(dataType)){
-        warn(`${dataType} is not a valid type,please check spelling or consult the documentation`)
-        return mainData
-    }
-
-    return inner(mainData).datas[dataType]
+    return (dataType == null || mainData == null)
+        ? mainData
+        : inner(mainData).datas[dataType];
 }
 
 /**

--- a/src/data/helper/linkSeriesData.ts
+++ b/src/data/helper/linkSeriesData.ts
@@ -26,7 +26,6 @@ import { curry, each, assert, extend, map, keys } from 'zrender/src/core/util';
 import SeriesData from '../SeriesData';
 import { makeInner } from '../../util/model';
 import { SeriesDataType } from '../../util/types';
-import {warn} from "../../util/log";
 
 // That is: { dataType: data },
 // like: { node: nodeList, edge: edgeList }.

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -525,6 +525,12 @@ export function blurSeriesFromHighlightPayload(
 ) {
     const seriesIndex = seriesModel.seriesIndex;
     const data = seriesModel.getData(payload.dataType);
+    if (!data) {
+        if (__DEV__) {
+            error(`Unknown dataType ${payload.dataType}`);
+        }
+        return;
+    }
     let dataIndex = queryDataIndex(data, payload);
     // Pick the first one if there is multiple/none exists.
     dataIndex = (isArray(dataIndex) ? dataIndex[0] : dataIndex) || 0;

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -160,7 +160,7 @@ class ChartView {
             }
             return;
         }
-        toggleHighlight(seriesModel.getData(payload && payload.dataType), payload, 'emphasis');
+        toggleHighlight(data, payload, 'emphasis');
     }
 
     /**

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -35,6 +35,7 @@ import {
 } from '../util/types';
 import { SeriesTaskContext, SeriesTask } from '../core/Scheduler';
 import SeriesData from '../data/SeriesData';
+import { error } from '../util/log';
 
 const inner = modelUtil.makeInner<{
     updateMethod: keyof ChartView
@@ -152,6 +153,13 @@ class ChartView {
      * Highlight series or specified data item.
      */
     highlight(seriesModel: SeriesModel, ecModel: GlobalModel, api: ExtensionAPI, payload: Payload): void {
+        const data = seriesModel.getData(payload && payload.dataType);
+        if (!data) {
+            if (__DEV__) {
+                error(`Unknown dataType ${payload.dataType}`);
+            }
+            return;
+        }
         toggleHighlight(seriesModel.getData(payload && payload.dataType), payload, 'emphasis');
     }
 
@@ -159,7 +167,14 @@ class ChartView {
      * Downplay series or specified data item.
      */
     downplay(seriesModel: SeriesModel, ecModel: GlobalModel, api: ExtensionAPI, payload: Payload): void {
-        toggleHighlight(seriesModel.getData(), payload, 'normal');
+        const data = seriesModel.getData(payload && payload.dataType);
+        if (!data) {
+            if (__DEV__) {
+                error(`Unknown dataType ${payload.dataType}`);
+            }
+            return;
+        }
+        toggleHighlight(data, payload, 'normal');
     }
 
     /**

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -152,7 +152,7 @@ class ChartView {
      * Highlight series or specified data item.
      */
     highlight(seriesModel: SeriesModel, ecModel: GlobalModel, api: ExtensionAPI, payload: Payload): void {
-        toggleHighlight(seriesModel.getData(), payload, 'emphasis');
+        toggleHighlight(seriesModel.getData(payload?.dataType), payload, 'emphasis');
     }
 
     /**

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -152,7 +152,7 @@ class ChartView {
      * Highlight series or specified data item.
      */
     highlight(seriesModel: SeriesModel, ecModel: GlobalModel, api: ExtensionAPI, payload: Payload): void {
-        toggleHighlight(seriesModel.getData(payload?.dataType), payload, 'emphasis');
+        toggleHighlight(seriesModel.getData(payload && payload.dataType), payload, 'emphasis');
     }
 
     /**

--- a/test/graph-edge-highlight.html
+++ b/test/graph-edge-highlight.html
@@ -1,0 +1,196 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/dat.gui.min.js"></script>
+</head>
+<body>
+<style>
+    html, body, #main {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+    }
+</style>
+<div id="main"></div>
+<script>
+
+    require([
+        'echarts',
+        'extension/dataTool',
+        './data/les-miserables.gexf',
+        'theme/vintage'
+    ], function (echarts, dataTool, xml) {
+        var gexf = dataTool.gexf;
+        var chart = echarts.init(document.getElementById('main'), 'vintage');
+
+        var graph = gexf.parse(xml);
+        var categories = [];
+        for (var i = 0; i < 9; i++) {
+            categories[i] = {
+                name: '类目' + i
+            };
+        }
+        graph.nodes.forEach(function (node) {
+            delete node.itemStyle;
+            node.value = node.symbolSize;
+            node.label = {
+                normal: {
+                    show: node.symbolSize > 30
+                },
+                emphasis: {
+                    show: true
+                }
+            };
+            node.category = node.attributes['modularity_class'];
+        });
+        graph.links.forEach(function (link) {
+            delete link.lineStyle;
+        });
+        var option = {
+            aria: {
+                show: true,
+                description: 'Les Miserables 的关系主要分为六个区域，这张图描述了他们之间的相互关联。'
+            },
+            tooltip: {},
+            legend: [{
+                // selectedMode: 'single',
+                data: categories.map(function (a) {
+                    return a.name;
+                })
+            }],
+            animationDurationUpdate: 1500,
+            animationEasingUpdate: 'quinticInOut',
+            series : [
+                {
+                    name: 'Les Miserables',
+                    type: 'graph',
+                    layout: 'none',
+                    data: graph.nodes,
+                    links: graph.links,
+                    categories: categories,
+                    cursor: 'crosshair',
+                    roam: true,
+                    draggable: true,
+                    itemStyle: {
+                        normal: {
+                            borderColor: '#fff',
+                            borderWidth: 2,
+                            shadowBlur: 10,
+                            shadowColor: 'rgba(0, 0, 0, 0.3)'
+                        }
+                    },
+                    emphasis: {
+                        focus: 'adjacency'
+                    },
+                    // edgeSymbol: ['none', 'arrow'],
+                    // scaleLimit: {
+                    //     min: 1.5,
+                    //     max: 2
+                    // },
+                    label: {
+                        normal: {
+                            position: 'right',
+                            formatter: '{b}'
+                        }
+                    },
+                    lineStyle: {
+                        normal: {
+                            color: 'source',
+                            curveness: 0.3
+                        },
+                        emphasis: {
+                            width: 10
+                        }
+                    }
+                }
+            ]
+        };
+
+        chart.setOption(option);
+
+        var config = {
+            layout: 'none',
+            focusNodeAdjacency: true,
+            manualFocusNodeAdjacency: function () {
+                chart.dispatchAction({
+                    type: 'highlight',
+                    seriesName: 'Les Miserables',
+                    dataIndex: 2
+                });
+            },
+            manualUnfocusNodeAdjacency: function () {
+                chart.dispatchAction({
+                    type: 'downplay',
+                    seriesName: 'Les Miserables'
+                });
+            },
+            'circular.rotateLabel': false
+        };
+
+        // set edge or node highlight width dataIndex
+        chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3], dataType: 'edge'})
+        // chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3], dataType: 'node'})
+
+        chart.on('click', function (params) {
+            console.log(params, params.data);
+        });
+
+        var gui = new dat.GUI();
+        gui.add(config, 'layout', ['none', 'circular'])
+            .onChange(function (value) {
+                chart.setOption({
+                    series: [{
+                        name: 'Les Miserables',
+                        layout: value
+                    }]
+                });
+            });
+        gui.add(config, 'focusNodeAdjacency')
+            .onChange(function (value) {
+                chart.setOption({
+                    series: [{
+                        name: 'Les Miserables',
+                        emphasis: {
+                            focus: config.focusNodeAdjacency ? 'adjacency' : null
+                        }
+                    }]
+                });
+            });
+        gui.add(config, 'manualFocusNodeAdjacency');
+        gui.add(config, 'manualUnfocusNodeAdjacency');
+        gui.add(config, 'circular.rotateLabel')
+            .onChange(function (value) {
+                chart.setOption({
+                    series: [{
+                        name: 'Les Miserables',
+                        circular: {rotateLabel: !!value}
+                    }]
+                });
+            });
+    });
+</script>
+</body>
+</html>

--- a/test/graph-edge-highlight.html
+++ b/test/graph-edge-highlight.html
@@ -150,10 +150,17 @@ under the License.
             'circular.rotateLabel': false
         };
 
-        // set edge or node highlight width dataIndex
-        chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3], dataType: 'edge'})
+        // set edge or node highlight with dataIndex
+        //chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3],dataType:'edge'})
+
+        // wrong dataType test case
+        chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3],dataType:'edges'})
+
         // chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3], dataType: 'node'})
 
+        // chart.on('mouseover', function (params) {
+        //     chart.dispatchAction({type: 'highlight',dataIndex: [0,1,2,3],dataType:'edge'})
+        // });
         chart.on('click', function (params) {
             console.log(params, params.data);
         });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Added property configuration to specify edge highlighting

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
Source from this issue: https://github.com/apache/echarts/issues/16134#issuecomment-997340280, need to solve the problem of highlighting on the specified side

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?
According to the original method "highlight" of the highlighted node, pass in the dataType property in the payload

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

```js
echartInstance.dispatchAction({ type: 'highlight', dataType: 'edge | node', dataIndex: number | number[] })
```


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
