### PR TITLE
fix(bar): avoid creating subpaths in the sausage shape

### DIFF
--- a/src/util/shape/sausage.ts
+++ b/src/util/shape/sausage.ts
@@ -51,50 +51,54 @@ class SausagePath extends Path<SausagePathProps> {
     }
 
     buildPath(ctx: CanvasRenderingContext2D, shape: SausageShape) {
-        const x = shape.cx;
-        const y = shape.cy;
+        const cx = shape.cx;
+        const cy = shape.cy;
         const r0 = Math.max(shape.r0 || 0, 0);
         const r = Math.max(shape.r, 0);
         const dr = (r - r0) * 0.5;
         const rCenter = r0 + dr;
-        const startAngle = shape.startAngle;
+        let startAngle = shape.startAngle;
         const endAngle = shape.endAngle;
         const clockwise = shape.clockwise;
+
+        const PI2 = Math.PI * 2;
+        const lessThanCircle = clockwise
+            ? endAngle - startAngle < PI2
+            : startAngle - endAngle < PI2;
+
+        if (!lessThanCircle) {
+            // Normalize angles
+            startAngle = endAngle - (clockwise ? PI2 : -PI2);
+        }
 
         const unitStartX = Math.cos(startAngle);
         const unitStartY = Math.sin(startAngle);
         const unitEndX = Math.cos(endAngle);
         const unitEndY = Math.sin(endAngle);
 
-        const lessThanCircle = clockwise
-            ? endAngle - startAngle < Math.PI * 2
-            : startAngle - endAngle < Math.PI * 2;
-
         if (lessThanCircle) {
-            ctx.moveTo(unitStartX * r0 + x, unitStartY * r0 + y);
-
+            ctx.moveTo(unitStartX * r0 + cx, unitStartY * r0 + cy);
             ctx.arc(
-                unitStartX * rCenter + x, unitStartY * rCenter + y, dr,
+                unitStartX * rCenter + cx, unitStartY * rCenter + cy, dr,
                 -Math.PI + startAngle, startAngle, !clockwise
             );
         }
+        else {
+            ctx.moveTo(unitStartX * r + cx, unitStartY * r + cy);
+        }
 
-        ctx.arc(x, y, r, startAngle, endAngle, !clockwise);
-
-        ctx.moveTo(unitEndX * r + x, unitEndY * r + y);
+        ctx.arc(cx, cy, r, startAngle, endAngle, !clockwise);
 
         ctx.arc(
-            unitEndX * rCenter + x, unitEndY * rCenter + y, dr,
+            unitEndX * rCenter + cx, unitEndY * rCenter + cy, dr,
             endAngle - Math.PI * 2, endAngle - Math.PI, !clockwise
         );
 
         if (r0 !== 0) {
-            ctx.arc(x, y, r0, endAngle, startAngle, clockwise);
-
-            ctx.moveTo(unitStartX * r0 + x, unitEndY * r0 + y);
+            ctx.arc(cx, cy, r0, endAngle, startAngle, clockwise);
         }
 
-        ctx.closePath();
+        // ctx.closePath();
     }
 }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This PR optimize the sausage shape by avoiding creating subpaths with `moveTo` command. It can improve the visual effect of morphing significantly.


## Details

### Before: What was the problem?

Vertices are not matched when doing one-one morphing.

![before](https://user-images.githubusercontent.com/841551/146720092-50686a69-5860-4b7d-b6ae-232ef6f63f24.gif)

### After: How is it fixed in this PR?

Vertices are matched perfectly.

![morph](https://user-images.githubusercontent.com/841551/146720248-f67421e0-db5c-4aea-b7d4-36207fa423b1.gif)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
