### PR TITLE
Fix opacity wrong when using clone divideShape in universalTransition

### DIFF
--- a/src/animation/universalTransition.ts
+++ b/src/animation/universalTransition.ts
@@ -20,7 +20,7 @@
 // Universal transitions that can animate between any shapes(series) and any properties in any amounts.
 
 import SeriesModel, { SERIES_UNIVERSAL_TRANSITION_PROP } from '../model/Series';
-import {createHashMap, each, map, filter, isArray} from 'zrender/src/core/util';
+import {createHashMap, each, map, filter, isArray, extend} from 'zrender/src/core/util';
 import Element, { ElementAnimateConfig } from 'zrender/src/Element';
 import { applyMorphAnimation, getPathList } from './morphTransitionHelper';
 import Path from 'zrender/src/graphic/Path';
@@ -173,7 +173,11 @@ function transitionBetween(
     ) {
         if (rawFrom || from) {
             to.animateFrom({
-                style: (rawFrom || from).style
+                style: (rawFrom && rawFrom !== from)
+                    // dividingMethod like clone may override the style(opacity)
+                    // So extend it to raw style.
+                    ? extend(extend({}, rawFrom.style), from.style)
+                    : from.style
             }, animationCfg);
         }
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix opacity wrong when using clone divideShape in universalTransition


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

![before](https://user-images.githubusercontent.com/841551/146738746-92b689af-e829-4e47-94db-3762e441ce09.gif)


### After: How is it fixed in this PR?

![after](https://user-images.githubusercontent.com/841551/146738769-43dd1f21-a45d-430f-a9d6-3f7c0047c5ad.gif)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
