### PR TITLE
feat(ssr): add useViewBox opts in renderToSVGString

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -710,14 +710,19 @@ class ECharts extends Eventful<ECEventDefinition> {
         });
     }
 
-    renderToSVGString(): string {
+    renderToSVGString(opts?: {
+        useViewBox?: boolean
+    }): string {
+        opts = opts || {};
         const painter = this._zr.painter;
         if (__DEV__) {
             if (painter.type !== 'svg') {
                 throw new Error('renderToSVGString can only be used in the svg renderer.');
             }
         }
-        return painter.renderToString();
+        return (painter as SVGPainter).renderToString({
+            useViewBox: opts.useViewBox
+        });
     }
 
     /**

--- a/test/ssr-animaiton-wave.html
+++ b/test/ssr-animaiton-wave.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <script src="lib/perlin.js"></script>
+        <script src="lib/dat.gui.min.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            body, #main, svg {
+                margin: 0;
+                width: 100%;
+                height: 100%;
+            }
+            img {
+                position: absolute;
+                left: 0;
+                top: 0;
+            }
+        </style>
+
+
+        <div id="main"></div>
+
+        <script>
+            require(['echarts'/*, 'map/js/china' */], function (echarts) {
+                // During transition
+                var chart = echarts.init(null, null, {
+                    width: 500,
+                    height: 500,
+                    renderer: 'svg',
+                    ssr: true
+                })
+
+                const width = chart.getWidth();
+                const height = chart.getHeight();
+
+                const config = {
+                    minSize: 3,
+                    maxSize: 30,
+
+                    color0: '#ffa500',
+                    color1: '#800080',
+
+                    backgroundColor: '#8e2ed2',
+
+                    duration: 4000,
+
+                    frequency: 500,
+                    offsetX: 0,
+                    offsetY: 100
+                }
+
+                function createElements() {
+                    const elements = [];
+                    for (let x = 20; x < width; x += 40) {
+                        for (let y = 20; y < height; y += 40) {
+                            const rand = noise.perlin2(
+                                x / config.frequency + config.offsetX,
+                                y / config.frequency + config.offsetY
+                            );
+                            elements.push({
+                                type: 'circle',
+                                x, y,
+                                style: {
+                                    fill: config.color1
+                                },
+                                shape: {
+                                    r: config.maxSize
+                                },
+                                keyframeAnimation: {
+                                    duration: config.duration,
+                                    loop: true,
+                                    delay: (rand - 1) * 4000,
+                                    keyframes: [{
+                                        percent: 0.5,
+                                        easing: 'sinusoidalInOut',
+                                        style: {
+                                            fill: config.color0
+                                        },
+                                        scaleX: config.minSize / config.maxSize,
+                                        scaleY: config.minSize / config.maxSize
+                                    }, {
+                                        percent: 1,
+                                        easing: 'sinusoidalInOut',
+                                        style: {
+                                            fill: config.color1
+                                        },
+                                        scaleX: 1,
+                                        scaleY: 1
+                                    }]
+                                }
+                            });
+                        }
+                    }
+                    return elements;
+                }
+
+                function update() {
+                    chart.setOption({
+                        backgroundColor: config.backgroundColor,
+                        graphic: {
+                            elements: createElements()
+                        }
+                    });
+
+                    document.getElementById('main').innerHTML = chart.renderToSVGString();
+                }
+
+                update();
+
+
+                var gui = new dat.GUI();
+
+                gui.add(config, 'frequency', 10, 1000).onChange(update);
+                gui.add(config, 'offsetX', 0, 1000).onChange(update);
+                gui.add(config, 'offsetY', 0, 1000).onChange(update);
+
+                gui.add(config, 'minSize', 0, 100).onChange(update);
+                gui.add(config, 'maxSize', 0, 100).onChange(update);
+                gui.add(config, 'duration', 100, 100000).onChange(update);
+
+                gui.addColor(config, 'backgroundColor').onChange(update);
+                gui.addColor(config, 'color0').onChange(update);
+                gui.addColor(config, 'color1').onChange(update);
+            });
+        </script>
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add `useViewBox` opt in `renderToSVGString` method to make the generated SVG responsive.

Related PR: https://github.com/apache/echarts/pull/15880#issue-1026012150


### Fixed issues

https://github.com/apache/echarts/issues/16127#issuecomment-983514232

## Details

### Before: What was the problem?

The generated SVG has no [viewBox](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox) attribute and is not responsive.


### After: How is it fixed in this PR?

Use a `useViewBox` opt (default to be true) to add [viewBox](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/viewBox) attribute. It's responsive now when `width` and `height` are changed.

This allows use to configure `width` and `height` in the CSS.

```css
.chart svg {
  width: 100%;
  height: 100%;
}
```


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [x] This PR depends on ZRender changes (ecomfe/zrender#861).
