### PR TITLE
add .js extension in the import statement

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -26,7 +26,6 @@ const chalk = require('chalk');
 const rollup = require('rollup');
 const prePublish = require('./pre-publish');
 const transformDEV = require('./transform-dev');
-const preamble = require('./preamble');
 
 async function run() {
 

--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -39,6 +39,7 @@ const transformDEVUtil = require('./transform-dev');
 const preamble = require('./preamble');
 const dts = require('@lang/rollup-plugin-dts').default;
 const rollup = require('rollup');
+const { transformImport } = require('zrender/build/transformImport');
 
 const ecDir = nodePath.resolve(__dirname, '..');
 const tmpDir = nodePath.resolve(ecDir, 'pre-publish-tmp');
@@ -109,8 +110,8 @@ const compileWorkList = [
             transformRootFolderInEntry(nodePath.resolve(ecDir, 'index.common.js'), esmDir);
             transformRootFolderInEntry(nodePath.resolve(ecDir, 'index.simple.js'), esmDir);
 
-            await transformDistributionFiles(nodePath.resolve(ecDir, esmDir), esmDir);
-            await transformDistributionFiles(nodePath.resolve(ecDir, 'types'), esmDir);
+            await transformLibFiles(nodePath.resolve(ecDir, esmDir), esmDir);
+            await transformLibFiles(nodePath.resolve(ecDir, 'types'), esmDir);
             fsExtra.removeSync(tmpDir);
         }
     },
@@ -131,7 +132,7 @@ const compileWorkList = [
             fsExtra.removeSync(extensionESMDir);
         },
         after: async function () {
-            await transformDistributionFiles(extensionESMDir, 'lib');
+            await transformLibFiles(extensionESMDir, 'lib');
         }
     }
 ];
@@ -245,15 +246,15 @@ function transformRootFolderInEntry(entryFile, replacement) {
     fs.writeFileSync(
         entryFile,
         // Also transform zrender.
-        singleTransformZRRootFolder(code, replacement),
+        singleTransformImport(code, replacement),
         'utf-8'
     );
 }
 
 /**
- * Transform `zrender/src` to `zrender/esm` in all files
+ * Transform `zrender/src` to `zrender/lib` in all files
  */
-async function transformDistributionFiles(rooltFolder, replacement) {
+async function transformLibFiles(rooltFolder, replacement) {
     const files = await readFilePaths({
         patterns: ['**/*.js', '**/*.d.ts'],
         cwd: rooltFolder
@@ -262,7 +263,7 @@ async function transformDistributionFiles(rooltFolder, replacement) {
     // TODO More robust way?
     for (let fileName of files) {
         let code = fs.readFileSync(fileName, 'utf-8');
-        code = singleTransformZRRootFolder(code, replacement);
+        code = singleTransformImport(code, replacement);
         // For lower ts version, not use import type
         // TODO Use https://github.com/sandersn/downlevel-dts ?
         // if (fileName.endsWith('.d.ts')) {
@@ -272,8 +273,40 @@ async function transformDistributionFiles(rooltFolder, replacement) {
     }
 }
 
-function singleTransformZRRootFolder(code, replacement) {
-    return code.replace(/([\"\'])zrender\/src\//g, `$1zrender/${replacement}/`);
+/**
+ * 1. Transform zrender/src to zrender/lib
+ * 2. Add .js extensions
+ *
+ * FIXME. Comment in the named import statement is not supported.
+ *
+ * import {
+ *   AAAA,
+ *   // BBB
+ * } from 'foo';
+ */
+function singleTransformImport(code, replacement) {
+    return transformImport(
+        code.replace(/([\"\'])zrender\/src\//g, `$1zrender/${replacement}/`),
+        (moduleName) => {
+            // Ignore 'tslib'
+            if (moduleName === 'tslib') {
+                return moduleName;
+            }
+            else if (moduleName === 'zrender' || moduleName === 'zrender/lib/export') {
+                throw new Error('Should not import the whole zrender library.');
+            }
+            else if (moduleName.endsWith('.ts')) {
+                // Replace ts with js
+                return moduleName.replace(/\.ts$/, '.js');
+            }
+            else if (moduleName.endsWith('.js')) {
+                return moduleName;
+            }
+            else {
+                return moduleName + '.js'
+            }
+        }
+    );
 }
 
 // function singleTransformImportType(code) {

--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -276,13 +276,6 @@ async function transformLibFiles(rooltFolder, replacement) {
 /**
  * 1. Transform zrender/src to zrender/lib
  * 2. Add .js extensions
- *
- * FIXME. Comment in the named import statement is not supported.
- *
- * import {
- *   AAAA,
- *   // BBB
- * } from 'foo';
  */
 function singleTransformImport(code, replacement) {
     return transformImport(

--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -288,11 +288,11 @@ function singleTransformImport(code, replacement) {
     return transformImport(
         code.replace(/([\"\'])zrender\/src\//g, `$1zrender/${replacement}/`),
         (moduleName) => {
-            // Ignore 'tslib'
-            if (moduleName === 'tslib') {
+            // Ignore 'tslib' and 'echarts' in the extensions.
+            if (moduleName === 'tslib' || moduleName === 'echarts') {
                 return moduleName;
             }
-            else if (moduleName === 'zrender' || moduleName === 'zrender/lib/export') {
+            else if (moduleName === 'zrender/lib/export') {
                 throw new Error('Should not import the whole zrender library.');
             }
             else if (moduleName.endsWith('.ts')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11122,9 +11122,9 @@
       }
     },
     "zrender": {
-      "version": "npm:zrender-nightly@5.3.0-dev.20211222",
-      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.3.0-dev.20211222.tgz",
-      "integrity": "sha512-pwfuY4PVOfGV/RJ0BE3oJv2PXNvRR8E7HfjbPn6/HQ20DqT+We23fI39EhEFNUWKP5dLHKl+EGb+qpnxQQDVJg==",
+      "version": "npm:zrender-nightly@5.3.0-dev.20211224",
+      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.3.0-dev.20211224.tgz",
+      "integrity": "sha512-xpGRPACeiHz8F+wKgLs+WZrIsRietAuLCvNXgvMPkax1Hv1u+Gu+yVRSYkmCP3vjLHt93slax66FJteazeOeDg==",
       "requires": {
         "tslib": "2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "tslib": "2.3.0",
-    "zrender": "npm:zrender-nightly@^5.3.0-dev.20211222"
+    "zrender": "npm:zrender-nightly@^5.3.0-dev.20211224"
   },
   "devDependencies": {
     "@babel/code-frame": "7.10.4",

--- a/test/browser-esm-partial.html
+++ b/test/browser-esm-partial.html
@@ -23,7 +23,6 @@ under the License.
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="data/basicChartsOptions.js"></script>
         <script src="lib/dat.gui.min.js"></script>
         <link rel="stylesheet" href="lib/reset.css" />
     </head>
@@ -53,46 +52,51 @@ under the License.
 
 
         <div id="main">
-            <h1>Tests ESM bundle importing in browser</h1>
+            <h1>Tests ESM lib files importing in browser partially</h1>
         </div>
 
+        <script type="importmap">
+            {
+                "imports": {
+                    "echarts/": "../",
+                    "zrender/": "../node_modules/zrender/",
+                    "tslib": "../node_modules/tslib/tslib.es6.js"
+                }
+            }
+        </script>
+        <script>
+            if (typeof process === 'undefined' || !process.env) {
+                window.process = {
+                    env: {
+                        NODE_ENV: 'development'
+                    }
+                };
+            }
+        </script>
+
         <script type="module">
-            import * as echarts from '../dist/echarts.esm.min.js';
+            import * as echarts from 'echarts/core.js';
+            import { PieChart } from 'echarts/charts.js';
+            import { CanvasRenderer } from 'echarts/renderers.js';
+            echarts.use([PieChart, CanvasRenderer])
+
+            const chartsOptions = [{
+                series: [{
+                    type: 'pie',
+                    data: [{
+                        name: 'A',
+                        value: 5
+                    }, {
+                        name: 'B',
+                        value: 3
+                    }, {
+                        name: 'C',
+                        value: 1
+                    }]
+                }]
+            }]
             const charts = [];
-            allChartsOptions.forEach(function (chartOption) {
-                chartOption.series.forEach(function (series) {
-                    series.selectedMode = 'single';
-                    series.select = {
-                        itemStyle: {
-                            borderWidth: 3
-                        }
-                    }
-
-                    if (series.renderItem) {
-                        const oldRenderItem = series.renderItem;
-                        series.renderItem = function () {
-                            const ret = oldRenderItem.apply(this, arguments);
-                            ret.focus = 'self';
-                            return ret;
-                        }
-                    }
-
-                    if (series.type === 'treemap') {
-                        series.itemStyle = {
-                            borderColor: 'rgba(100, 100, 200, 0.1)',
-                        };
-                        series.nodeClick = null;
-                        series.select = {
-                            itemStyle: {
-                                strokeColor: '#000',
-                                strokeWidth: 1
-                            }
-                        }
-                    }
-                    else if (series.type === 'pie') {
-                        series.data[0].selected = true;
-                    }
-                });
+            chartsOptions.forEach(function (chartOption) {
                 const dom = document.createElement('div');
                 dom.className = 'chart';
                 document.querySelector('#main').appendChild(dom);

--- a/test/browser-esm-partial2.html
+++ b/test/browser-esm-partial2.html
@@ -23,7 +23,6 @@ under the License.
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="data/basicChartsOptions.js"></script>
         <script src="lib/dat.gui.min.js"></script>
         <link rel="stylesheet" href="lib/reset.css" />
     </head>
@@ -53,46 +52,49 @@ under the License.
 
 
         <div id="main">
-            <h1>Tests ESM bundle importing in browser</h1>
+            <h1>Tests ESM lib files importing in browser partially</h1>
         </div>
 
+        <script type="importmap">
+            {
+                "imports": {
+                    "echarts/": "../",
+                    "zrender/": "../node_modules/zrender/",
+                    "tslib": "../node_modules/tslib/tslib.es6.js"
+                }
+            }
+        </script>
+        <script>
+            if (typeof process === 'undefined' || !process.env) {
+                window.process = {
+                    env: {
+                        NODE_ENV: 'development'
+                    }
+                };
+            }
+        </script>
+
         <script type="module">
-            import * as echarts from '../dist/echarts.esm.min.js';
+            import * as echarts from 'echarts/lib/echarts';
+            import 'echarts/lib/chart/pie.js';
+
+            const chartsOptions = [{
+                series: [{
+                    type: 'pie',
+                    data: [{
+                        name: 'A',
+                        value: 5
+                    }, {
+                        name: 'B',
+                        value: 3
+                    }, {
+                        name: 'C',
+                        value: 1
+                    }]
+                }]
+            }]
             const charts = [];
-            allChartsOptions.forEach(function (chartOption) {
-                chartOption.series.forEach(function (series) {
-                    series.selectedMode = 'single';
-                    series.select = {
-                        itemStyle: {
-                            borderWidth: 3
-                        }
-                    }
-
-                    if (series.renderItem) {
-                        const oldRenderItem = series.renderItem;
-                        series.renderItem = function () {
-                            const ret = oldRenderItem.apply(this, arguments);
-                            ret.focus = 'self';
-                            return ret;
-                        }
-                    }
-
-                    if (series.type === 'treemap') {
-                        series.itemStyle = {
-                            borderColor: 'rgba(100, 100, 200, 0.1)',
-                        };
-                        series.nodeClick = null;
-                        series.select = {
-                            itemStyle: {
-                                strokeColor: '#000',
-                                strokeWidth: 1
-                            }
-                        }
-                    }
-                    else if (series.type === 'pie') {
-                        series.data[0].selected = true;
-                    }
-                });
+            chartsOptions.forEach(function (chartOption) {
                 const dom = document.createElement('div');
                 dom.className = 'chart';
                 document.querySelector('#main').appendChild(dom);

--- a/test/browser-esm2.html
+++ b/test/browser-esm2.html
@@ -53,11 +53,30 @@ under the License.
 
 
         <div id="main">
-            <h1>Tests ESM bundle importing in browser</h1>
+            <h1>Tests ESM lib files importing in browser</h1>
         </div>
 
+        <script type="importmap">
+            {
+                "imports": {
+                    "echarts/": "../",
+                    "zrender/": "../node_modules/zrender/",
+                    "tslib": "../node_modules/tslib/tslib.es6.js"
+                }
+            }
+        </script>
+        <script>
+            if (typeof process === 'undefined' || !process.env) {
+                window.process = {
+                    env: {
+                        NODE_ENV: 'development'
+                    }
+                };
+            }
+        </script>
+
         <script type="module">
-            import * as echarts from '../dist/echarts.esm.min.js';
+            import * as echarts from '../index.js';
             const charts = [];
             allChartsOptions.forEach(function (chartOption) {
                 chartOption.series.forEach(function (series) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

As discussed in https://github.com/apache/echarts/issues/16054. This PR trys to add an extra transform step to add `.js` extension to the import statement after `lib` is generated. 

So before the statement is:

```ts
import * as zrender from 'zrender/lib/zrender';
```
Now it becomes:
```ts
import * as zrender from 'zrender/lib/zrender.js';
```

So specific modules in the `lib` can be imported in the browsers more conveniently.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [x] This PR depends on ZRender changes (ecomfe/zrender#862).

### Related test cases or examples to use the new APIs

Still there some required steps needs to be done before we actually importing the modules:

1. For the modules from dependencies. Import map need to be configured.
```html
<script type="importmap">
{
  "imports": {
    "echarts/": "https://unpkg.com/echarts@latest/",
    "zrender/": "https://unpkg.com/zrender@latest/",
    "tslib": "https://unpkg.com/tslib@2.3.1/tslib.es6.js"
  }
}
</script>
```

2. Because the generated code use `process.env.NODE_ENV` on the dev only code. We need to define it in the browsers environment
```js
if (typeof process === "undefined" || !process.env) {
  window.process = {
    env: {
      NODE_ENV: "development",
    },
  };
}
```

Then we can importing modules just like in the bundling environment.

```js
import * as echarts from "echarts/core.js";
import { PieChart } from "echarts/charts.js";
import { CanvasRenderer } from "echarts/renderers.js";
echarts.use([PieChart, CanvasRenderer]);
```

But still there are limitations. Because this API design heavliy depends on dead code removal to do the tree-shaking, which seems to be not supported by the browsers yet. So it will still import all the charts from `echarts/charts.js`, not only the pie chart we needed.

This problem not exists if we use our legacy partially importing API:

```js
import * as echarts from "echarts/lib/echarts";
import "echarts/lib/chart/pie.js";
```

It will only import the pie chart and all the modules it depends on.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
