### PR TITLE
chore: reuse noop function from zrender util to reduce redundant code.

### DIFF
--- a/src/chart/graph/install.ts
+++ b/src/chart/graph/install.ts
@@ -31,6 +31,7 @@ import GraphView from './GraphView';
 import GraphSeriesModel from './GraphSeries';
 import { RoamPaylod, updateCenterAndZoom } from '../../action/roamHelper';
 import GlobalModel from '../../model/Global';
+import { noop } from 'zrender/src/core/util';
 
 const actionInfo = {
     type: 'graphRoam',
@@ -62,13 +63,13 @@ export function install(registers: EChartsExtensionInstallRegisters) {
         type: 'focusNodeAdjacency',
         event: 'focusNodeAdjacency',
         update: 'series:focusNodeAdjacency'
-    }, function () {});
+    }, noop);
 
     registers.registerAction({
         type: 'unfocusNodeAdjacency',
         event: 'unfocusNodeAdjacency',
         update: 'series:unfocusNodeAdjacency'
-    }, function () {});
+    }, noop);
 
     // Register roam action.
     registers.registerAction(actionInfo, function (payload: RoamPaylod, ecModel: GlobalModel) {

--- a/src/chart/treemap/treemapAction.ts
+++ b/src/chart/treemap/treemapAction.ts
@@ -23,8 +23,7 @@ import TreemapSeriesModel from './TreemapSeries';
 import { TreeNode } from '../../data/Tree';
 import { RectLike } from 'zrender/src/core/BoundingRect';
 import { EChartsExtensionInstallRegisters } from '../../extension';
-
-const noop = function () {};
+import { noop } from 'zrender/src/core/util';
 
 const actionTypes = [
     'treemapZoomToNode',

--- a/src/component/brush/install.ts
+++ b/src/component/brush/install.ts
@@ -29,6 +29,8 @@ import GlobalModel from '../../model/Global';
 import BrushFeature from '../toolbox/feature/Brush';
 import { registerFeature } from '../toolbox/featureManager';
 
+import { noop } from 'zrender/src/core/util';
+
 interface BrushPayload extends Payload {
     // If "areas" is empty, all of the select-boxes will be deleted
     areas?: BrushAreaParam[];
@@ -78,12 +80,12 @@ export function install(registers: EChartsExtensionInstallRegisters) {
      */
     registers.registerAction(
         {type: 'brushSelect', event: 'brushSelected', update: 'none'},
-        function () {}
+        noop
     );
 
     registers.registerAction(
         {type: 'brushEnd', event: 'brushEnd', update: 'none'},
-        function () {}
+        noop
     );
 
     registerFeature('brush', BrushFeature);

--- a/src/component/helper/interactionMutex.ts
+++ b/src/component/helper/interactionMutex.ts
@@ -19,6 +19,7 @@
 
 // @ts-nocheck
 import * as echarts from '../../core/echarts';
+import { noop } from 'zrender/src/core/util';
 
 const ATTR = '\0_ec_interaction_mutex';
 
@@ -54,5 +55,5 @@ function getStore(zr) {
 // TODO: SELF REGISTERED.
 echarts.registerAction(
     {type: 'takeGlobalCursor', event: 'globalCursorTaken', update: 'update'},
-    function () {}
+    noop
 );

--- a/src/component/tooltip/install.ts
+++ b/src/component/tooltip/install.ts
@@ -17,10 +17,11 @@
 * under the License.
 */
 
-import {install as installAxisPointer} from '../axisPointer/install';
+import { install as installAxisPointer } from '../axisPointer/install';
 import { EChartsExtensionInstallRegisters, use } from '../../extension';
 import TooltipModel from './TooltipModel';
 import TooltipView from './TooltipView';
+import { noop } from 'zrender/src/core/util';
 
 export function install(registers: EChartsExtensionInstallRegisters) {
     use(installAxisPointer);
@@ -41,8 +42,7 @@ export function install(registers: EChartsExtensionInstallRegisters) {
             event: 'showTip',
             update: 'tooltip:manuallyShowTip'
         },
-        // noop
-        function () {}
+        noop
     );
 
     registers.registerAction(
@@ -51,7 +51,6 @@ export function install(registers: EChartsExtensionInstallRegisters) {
             event: 'hideTip',
             update: 'tooltip:manuallyHideTip'
         },
-        // noop
-        function () {}
+        noop
     );
 }


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Some places are defining the same `noop` function, that's unnecessary. This PR is to reuse the `noop` function from `zrender` util to reduce redundant code.

