### PR TITLE
feat(axis): support tooltip for axis label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.0"
+        "zrender": "github:ecomfe/zrender"
       },
       "devDependencies": {
         "@babel/code-frame": "7.10.4",
@@ -11298,8 +11298,8 @@
     },
     "node_modules/zrender": {
       "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "resolved": "git+ssh://git@github.com/ecomfe/zrender.git#980b0ea43e68da10f82aa9a18449357e8c40bba0",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -20322,9 +20322,8 @@
       }
     },
     "zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "version": "git+ssh://git@github.com/ecomfe/zrender.git#980b0ea43e68da10f82aa9a18449357e8c40bba0",
+      "from": "zrender@github:ecomfe/zrender",
       "requires": {
         "tslib": "2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "tslib": "2.3.0",
-    "zrender": "5.6.0"
+    "zrender": "github:ecomfe/zrender"
   },
   "devDependencies": {
     "@babel/code-frame": "7.10.4",

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -34,7 +34,6 @@ import { ZRTextVerticalAlign, ZRTextAlign, ECElement, ColorString } from '../../
 import { AxisBaseOption } from '../../coord/axisCommonTypes';
 import type Element from 'zrender/src/Element';
 import { PathStyleProps } from 'zrender/src/graphic/Path';
-import type TSpan from 'zrender/src/graphic/TSpan';
 import OrdinalScale from '../../scale/Ordinal';
 import { prepareLayoutList, hideOverlap } from '../../label/labelLayoutHelper';
 

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -32,8 +32,9 @@ import {shouldShowAllLabels} from '../../coord/axisHelper';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
 import { ZRTextVerticalAlign, ZRTextAlign, ECElement, ColorString } from '../../util/types';
 import { AxisBaseOption } from '../../coord/axisCommonTypes';
-import Element from 'zrender/src/Element';
+import type Element from 'zrender/src/Element';
 import { PathStyleProps } from 'zrender/src/graphic/Path';
+import type TSpan from 'zrender/src/graphic/TSpan';
 import OrdinalScale from '../../scale/Ordinal';
 import { prepareLayoutList, hideOverlap } from '../../label/labelLayoutHelper';
 
@@ -836,6 +837,16 @@ function buildAxisLabel(
         });
         textEl.anid = 'label_' + tickValue;
 
+        graphic.setTooltipConfig({
+            el: textEl,
+            componentModel: axisModel,
+            itemName: formattedLabel,
+            formatterParamsExtra: {
+                isTruncated: () => textEl.isTruncated,
+                value: rawLabel,
+                tickIndex: index
+            }
+        });
 
         // Pack data for mouse event
         if (triggerEvent) {

--- a/test/axisLabel.html
+++ b/test/axisLabel.html
@@ -44,7 +44,7 @@ under the License.
         <div class="chart" id="main2"></div>
         <div class="chart" id="main3"></div>
         <div class="chart" id="main4"></div>
-
+        <div class="chart" id="main5"></div>
 
 
         <script>
@@ -267,7 +267,7 @@ under the License.
                 option = {
                     backgroundColor: '#eee',
                     title: {
-                        text: 'axisLable.formatter: {value} should be correct'
+                        text: 'axisLabel.formatter: {value} should be correct'
                     },
                     grid: {
                         containLabel: true,
@@ -375,6 +375,63 @@ under the License.
 
         </script>
 
+        <script>
 
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    backgroundColor: '#eee',
+                    tooltip: {},
+                    xAxis: {
+                        type: 'category',
+                        data: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+                        axisLabel: {
+                            width: 60,
+                            overflow: 'truncate',
+                            interval: 0
+                        },
+                        // triggerEvent: true,
+                        tooltip: {
+                            show: true,
+                            position: 'top',
+                            trigger: 'item',
+                            formatter(p) {
+                                if (p.isTruncated()) {
+                                    return p.name;
+                                }
+                                if (p.tickIndex > 3) {
+                                    return `Oh, it is happy ${p.name}! 😀`;
+                                }
+                            }
+                        }
+                    },
+                    yAxis: {
+                        type: 'value',
+                        axisLabel: {
+                            width: 20,
+                            overflow: 'truncate'
+                        },
+                        // triggerEvent: true,
+                        tooltip: {
+                            show: true,
+                            position: 'left',
+                            trigger: 'item'
+                        }
+                    },
+                    series: [
+                        {
+                            data: [150, 230, 224, 218, 135, 147, 260],
+                            type: 'line'
+                        }
+                    ]
+                };
+                var chart = testHelper.create(echarts, 'main5', {
+                    title: 'Should show tooltip for axis label',
+                    option: option
+                });
+            });
+
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Support tooltip for the axis label. It's useful for the case in which the axis label is truncated for long text and hope to show the full text when hovering on the label.


### Fixed issues

- #11903
- #15299
- #16228

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

No tooltip for showing the full text of a truncated axis label. The developer has to simulate a tooltip via listening to the mouse event like https://codepen.io/plainheart/pen/jOGBrmJ.

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img src="https://user-images.githubusercontent.com/26999792/148003065-2b6d00c6-6c4e-4f56-92ab-d4c89fe4cd6e.png" width="400">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last test case in `test/axisLabel.html`.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
