### PR TITLE
using utility methods for value type checking

### DIFF
--- a/src/animation/basicTrasition.ts
+++ b/src/animation/basicTrasition.ts
@@ -29,6 +29,7 @@ import { AnimationEasing } from 'zrender/src/animation/easing';
 import Element, { ElementAnimateConfig } from 'zrender/src/Element';
 import Model from '../model/Model';
 import {
+    isFunction,
     isObject,
     retrieve2
 } from 'zrender/src/core/util';
@@ -101,13 +102,13 @@ export function getAnimationConfig(
             animationPayload.easing != null && (easing = animationPayload.easing);
             animationPayload.delay != null && (delay = animationPayload.delay);
         }
-        if (typeof delay === 'function') {
+        if (isFunction(delay)) {
             delay = delay(
                 dataIndex as number,
                 extraDelayParams
             );
         }
-        if (typeof duration === 'function') {
+        if (isFunction(duration)) {
             duration = duration(dataIndex as number);
         }
         const config = {
@@ -136,7 +137,7 @@ function animateOrSetProps<Props>(
 ) {
     let isFrom = false;
     let removeOpt: AnimationOption;
-    if (typeof dataIndex === 'function') {
+    if (isFunction(dataIndex)) {
         during = cb;
         cb = dataIndex;
         dataIndex = null;

--- a/src/chart/funnel/funnelLayout.ts
+++ b/src/chart/funnel/funnelLayout.ts
@@ -23,6 +23,7 @@ import FunnelSeriesModel, { FunnelSeriesOption, FunnelDataItemOption } from './F
 import ExtensionAPI from '../../core/ExtensionAPI';
 import SeriesData from '../../data/SeriesData';
 import GlobalModel from '../../model/Global';
+import { isFunction } from 'zrender/src/core/util';
 
 function getViewRect(seriesModel: FunnelSeriesModel, api: ExtensionAPI) {
     return layout.getLayoutRect(
@@ -45,8 +46,8 @@ function getSortedIndices(data: SeriesData, sort: FunnelSeriesOption['sort']) {
     }
 
     // Add custom sortable function & none sortable opetion by "options.sort"
-    if (typeof sort === 'function') {
-        indices.sort(sort);
+    if (isFunction(sort)) {
+        indices.sort(sort as any);
     }
     else if (sort !== 'none') {
         indices.sort(function (a, b) {

--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -31,7 +31,7 @@ import SeriesData from '../../data/SeriesData';
 import Sausage from '../../util/shape/sausage';
 import {createSymbol} from '../../util/symbol';
 import ZRImage from 'zrender/src/graphic/Image';
-import {extend} from 'zrender/src/core/util';
+import {extend, isFunction, isString} from 'zrender/src/core/util';
 import {setCommonECData} from '../../util/innerStore';
 
 type ECSymbol = ReturnType<typeof createSymbol>;
@@ -61,10 +61,10 @@ function parsePosition(seriesModel: GaugeSeriesModel, api: ExtensionAPI): PosInf
 function formatLabel(value: number, labelFormatter: string | ((value: number) => string)): string {
     let label = value == null ? '' : (value + '');
     if (labelFormatter) {
-        if (typeof labelFormatter === 'string') {
+        if (isString(labelFormatter)) {
             label = labelFormatter.replace('{value}', label);
         }
-        else if (typeof labelFormatter === 'function') {
+        else if (isFunction(labelFormatter)) {
             label = labelFormatter(value);
         }
     }

--- a/src/chart/graph/categoryFilter.ts
+++ b/src/chart/graph/categoryFilter.ts
@@ -20,6 +20,7 @@
 import GlobalModel from '../../model/Global';
 import GraphSeriesModel, { GraphNodeItemOption } from './GraphSeries';
 import type LegendModel from '../../component/legend/LegendModel';
+import { isNumber } from 'zrender/src/core/util';
 
 export default function categoryFilter(ecModel: GlobalModel) {
     const legendModels = ecModel.findComponents({
@@ -39,7 +40,7 @@ export default function categoryFilter(ecModel: GlobalModel) {
             const model = data.getItemModel<GraphNodeItemOption>(idx);
             let category = model.getShallow('category');
             if (category != null) {
-                if (typeof category === 'number') {
+                if (isNumber(category)) {
                     category = categoryNames[category];
                 }
                 // If in any legend component the status is not selected.

--- a/src/chart/graph/categoryVisual.ts
+++ b/src/chart/graph/categoryVisual.ts
@@ -20,7 +20,7 @@
 import GlobalModel from '../../model/Global';
 import GraphSeriesModel, { GraphNodeItemOption } from './GraphSeries';
 import { Dictionary, ColorString } from '../../util/types';
-import { extend } from 'zrender/src/core/util';
+import { extend, isString } from 'zrender/src/core/util';
 
 export default function categoryVisual(ecModel: GlobalModel) {
 
@@ -60,7 +60,7 @@ export default function categoryVisual(ecModel: GlobalModel) {
                 const model = data.getItemModel<GraphNodeItemOption>(idx);
                 let categoryIdx = model.getShallow('category');
                 if (categoryIdx != null) {
-                    if (typeof categoryIdx === 'string') {
+                    if (isString(categoryIdx)) {
                         categoryIdx = categoryNameIdxMap['ec-' + categoryIdx];
                     }
 

--- a/src/chart/helper/EffectLine.ts
+++ b/src/chart/helper/EffectLine.ts
@@ -143,7 +143,7 @@ class EffectLine extends graphic.Group {
 
             if (period > 0) {
                 let delayNum: number;
-                if (typeof delayExpr === 'function') {
+                if (zrUtil.isFunction(delayExpr)) {
                     delayNum = delayExpr(idx);
                 }
                 else {

--- a/src/chart/helper/createClipPathFromCoordSys.ts
+++ b/src/chart/helper/createClipPathFromCoordSys.ts
@@ -24,6 +24,7 @@ import { SeriesOption } from '../../util/types';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import type Polar from '../../coord/polar/Polar';
 import { CoordinateSystem } from '../../coord/CoordinateSystem';
+import { isFunction } from 'zrender/src/core/util';
 
 type SeriesModelWithLineWidth = SeriesModel<SeriesOption & {
     lineStyle?: { width?: number }
@@ -80,7 +81,7 @@ function createGridClipPath(
             clipPath.shape.height = 0;
         }
 
-        const duringCb = typeof during === 'function'
+        const duringCb = isFunction(during)
             ? (percent: number) => {
                 during(percent, clipPath);
             }

--- a/src/chart/helper/multipleGraphEdgeHelper.ts
+++ b/src/chart/helper/multipleGraphEdgeHelper.ts
@@ -42,7 +42,7 @@ const createCurveness = function (seriesModel, appendLength) {
     let curvenessList = [];
 
     // handler the function set
-    if (typeof autoCurvenessParmas === 'number') {
+    if (zrUtil.isNumber(autoCurvenessParmas)) {
         length = autoCurvenessParmas;
     }
     else if (zrUtil.isArray(autoCurvenessParmas)) {

--- a/src/chart/helper/treeHelper.ts
+++ b/src/chart/helper/treeHelper.ts
@@ -34,7 +34,7 @@ export function retrieveTargetInfo(
         const root = seriesModel.getData().tree.root;
         let targetNode = payload.targetNode;
 
-        if (typeof targetNode === 'string') {
+        if (zrUtil.isString(targetNode)) {
             targetNode = root.getNodeById(targetNode);
         }
 

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -124,7 +124,7 @@ function getBoundingDiff(points1: ArrayLike<number>, points2: ArrayLike<number>)
 }
 
 function getSmooth(smooth: number | boolean) {
-    return typeof smooth === 'number' ? smooth : (smooth ? 0.5 : 0);
+    return zrUtil.isNumber(smooth) ? smooth : (smooth ? 0.5 : 0);
 }
 
 function getStackedOnPoints(
@@ -1064,11 +1064,11 @@ class LineView extends ChartView {
 
         const seriesModel = data.hostModel;
         let seriesDuration = seriesModel.get('animationDuration');
-        if (typeof seriesDuration === 'function') {
+        if (zrUtil.isFunction(seriesDuration)) {
             seriesDuration = seriesDuration(null);
         }
         const seriesDalay = seriesModel.get('animationDelay') || 0;
-        const seriesDalayValue = typeof seriesDalay === 'function'
+        const seriesDalayValue = zrUtil.isFunction(seriesDalay)
             ? seriesDalay(null)
             : seriesDalay;
 
@@ -1113,7 +1113,7 @@ class LineView extends ChartView {
                     ratio = 1 - ratio;
                 }
 
-                const delay = typeof seriesDalay === 'function' ? seriesDalay(idx)
+                const delay = zrUtil.isFunction(seriesDalay) ? seriesDalay(idx)
                     : (seriesDuration * ratio) + seriesDalayValue;
 
                 const symbolPath = el.getSymbolPath();

--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -21,7 +21,7 @@
 
 import SeriesModel from '../../model/Series';
 import SeriesData from '../../data/SeriesData';
-import { concatArray, mergeAll, map } from 'zrender/src/core/util';
+import { concatArray, mergeAll, map, isNumber } from 'zrender/src/core/util';
 import CoordinateSystem from '../../core/CoordinateSystem';
 import {
     SeriesOption,
@@ -259,7 +259,7 @@ class LinesSeriesModel extends SeriesModel<LinesSeriesOption> {
         }
         // Stored as a typed array. In format
         // Points Count(2) | x | y | x | y | Points Count(3) | x |  y | x | y | x | y |
-        if (typeof data[0] === 'number') {
+        if (isNumber(data[0])) {
             const len = data.length;
             // Store offset and len of each segment
             const coordsOffsetAndLenStorage = new Uint32Arr(len) as Uint32Array;

--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -25,7 +25,7 @@ import { HorizontalAlign, ZRTextAlign } from '../../util/types';
 import { Sector, Polyline, Point } from '../../util/graphic';
 import ZRText from 'zrender/src/graphic/Text';
 import BoundingRect, {RectLike} from 'zrender/src/core/BoundingRect';
-import { each } from 'zrender/src/core/util';
+import { each, isNumber } from 'zrender/src/core/util';
 import { limitTurnAngle, limitSurfaceAngle } from '../../label/labelGuideHelper';
 import { shiftLayoutOnY } from '../../label/labelLayoutHelper';
 
@@ -352,7 +352,7 @@ export default function pieLabelLayout(
 
         let labelRotate;
         const rotate = labelModel.get('rotate');
-        if (typeof rotate === 'number') {
+        if (isNumber(rotate)) {
             labelRotate = rotate * (Math.PI / 180);
         }
         else if (labelPosition === 'center') {

--- a/src/chart/sankey/SankeyView.ts
+++ b/src/chart/sankey/SankeyView.ts
@@ -29,6 +29,7 @@ import SeriesData from '../../data/SeriesData';
 import { RectLike } from 'zrender/src/core/BoundingRect';
 import { setLabelStyle, getLabelStatesModels } from '../../label/labelStyle';
 import { getECData } from '../../util/innerStore';
+import { isString } from 'zrender/src/core/util';
 
 class SankeyPathShape {
     x1 = 0;
@@ -206,14 +207,16 @@ class SankeyView extends ChartView {
                 case 'gradient':
                     const sourceColor = edge.node1.getVisual('color');
                     const targetColor = edge.node2.getVisual('color');
-                    if (typeof sourceColor === 'string' && typeof targetColor === 'string') {
-                        curve.style.fill = new graphic.LinearGradient(0, 0, +(orient === 'horizontal'), +(orient === 'vertical'), [{
-                            color: sourceColor,
-                            offset: 0
-                        }, {
-                            color: targetColor,
-                            offset: 1
-                        }]);
+                    if (isString(sourceColor) && isString(targetColor)) {
+                        curve.style.fill = new graphic.LinearGradient(
+                            0, 0, +(orient === 'horizontal'), +(orient === 'vertical'), [{
+                                color: sourceColor,
+                                offset: 0
+                            }, {
+                                color: targetColor,
+                                offset: 1
+                            }]
+                        );
                     }
             }
 

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -259,7 +259,7 @@ class SunburstPiece extends graphic.Sector {
                     rotate += Math.PI;
                 }
             }
-            else if (typeof rotateType === 'number') {
+            else if (zrUtil.isNumber(rotateType)) {
                 rotate = rotateType * Math.PI / 180;
             }
 

--- a/src/chart/sunburst/sunburstLayout.ts
+++ b/src/chart/sunburst/sunburstLayout.ts
@@ -205,7 +205,7 @@ function initChildren(node: TreeNode, sortOrder?: SunburstSeriesOption['sort']) 
  *                                   See SunburstSeries.js for details.
  */
 function sort(children: TreeNode[], sortOrder: SunburstSeriesOption['sort']) {
-    if (typeof sortOrder === 'function') {
+    if (zrUtil.isFunction(sortOrder)) {
         const sortTargets = zrUtil.map(children, (child, idx) => {
             const value = child.getValue() as number;
             return {

--- a/src/chart/sunburst/sunburstVisual.ts
+++ b/src/chart/sunburst/sunburstVisual.ts
@@ -18,17 +18,11 @@
 */
 
 import { lift } from 'zrender/src/tool/color';
-import { extend, map } from 'zrender/src/core/util';
+import { extend, isString } from 'zrender/src/core/util';
 import GlobalModel from '../../model/Global';
 import SunburstSeriesModel, { SunburstSeriesNodeItemOption } from './SunburstSeries';
-import { Dictionary, ColorString, ZRColor } from '../../util/types';
-import { setItemVisualFromData } from '../../visual/helper';
+import { Dictionary, ColorString } from '../../util/types';
 import { TreeNode } from '../../data/Tree';
-
-type ParentColorMap = {
-    node: TreeNode,
-    parentColor: ZRColor
-};
 
 export default function sunburstVisual(ecModel: GlobalModel) {
 
@@ -42,7 +36,7 @@ export default function sunburstVisual(ecModel: GlobalModel) {
             current = current.parentNode;
         }
         let color = seriesModel.getColorFromPalette((current.name || current.dataIndex + ''), paletteScope);
-        if (node.depth > 1 && typeof color === 'string') {
+        if (node.depth > 1 && isString(color)) {
             // Lighter on the deeper level.
             color = lift(color, (node.depth - 1) / (treeHeight - 1) * 0.5);
         }

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {retrieve, defaults, extend, each, isObject, map} from 'zrender/src/core/util';
+import {retrieve, defaults, extend, each, isObject, map, isString, isNumber, isFunction} from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import {getECData} from '../../util/innerStore';
 import {createTextStyle} from '../../label/labelStyle';
@@ -287,15 +287,13 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         if (arrows != null) {
             let arrowSize = axisModel.get(['axisLine', 'symbolSize']);
 
-            if (typeof arrows === 'string') {
+            if (isString(arrows)) {
                 // Use the same arrow for start and end point
                 arrows = [arrows, arrows];
             }
-            if (typeof arrowSize === 'string'
-                || typeof arrowSize === 'number'
-            ) {
+            if (isString(arrowSize) || isNumber(arrowSize)) {
                 // Use the same size for width and height
-                arrowSize = [arrowSize, arrowSize];
+                arrowSize = [arrowSize as number, arrowSize as number];
             }
 
             const arrowOffset = normalizeSymbolOffset(axisModel.get(['axisLine', 'symbolOffset']) || 0, arrowSize);
@@ -789,7 +787,7 @@ function buildAxisLabel(
                 verticalAlign: itemLabelModel.getShallow('verticalAlign', true)
                     || itemLabelModel.getShallow('baseline', true)
                     || labelLayout.textVerticalAlign,
-                fill: typeof textColor === 'function'
+                fill: isFunction(textColor)
                     ? textColor(
                         // (1) In category axis with data zoom, tick is not the original
                         // index of axis.data. So tick should not be exposed to user

--- a/src/component/calendar/CalendarView.ts
+++ b/src/component/calendar/CalendarView.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import { isString, extend, map } from 'zrender/src/core/util';
+import { isString, extend, map, isFunction } from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import {createTextStyle} from '../../label/labelStyle';
 import { formatTplSimple } from '../../util/format';
@@ -229,11 +229,11 @@ class CalendarView extends ComponentView {
         params: T
     ) {
 
-        if (typeof formatter === 'string' && formatter) {
+        if (isString(formatter) && formatter) {
             return formatTplSimple(formatter, params);
         }
 
-        if (typeof formatter === 'function') {
+        if (isFunction(formatter)) {
             return formatter(params);
         }
 

--- a/src/component/legend/LegendModel.ts
+++ b/src/component/legend/LegendModel.ts
@@ -356,9 +356,9 @@ class LegendModel<Ops extends LegendOption = LegendOption> extends ComponentMode
 
         const legendData = zrUtil.map(rawData, function (dataItem) {
             // Can be string or number
-            if (typeof dataItem === 'string' || typeof dataItem === 'number') {
+            if (zrUtil.isString(dataItem) || zrUtil.isNumber(dataItem)) {
                 dataItem = {
-                    name: dataItem
+                    name: dataItem as string
                 };
             }
             return new Model(dataItem, this, this.ecModel);

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -366,7 +366,7 @@ class LegendView extends ComponentView {
 
         const textStyleModel = legendItemModel.getModel('textStyle');
 
-        if (typeof seriesModel.getLegendIcon === 'function'
+        if (zrUtil.isFunction(seriesModel.getLegendIcon)
             && (!legendIconType || legendIconType === 'inherit')
         ) {
             // Series has specific way to define legend icon
@@ -404,10 +404,10 @@ class LegendView extends ComponentView {
 
         const formatter = legendModel.get('formatter');
         let content = name;
-        if (typeof formatter === 'string' && formatter) {
+        if (zrUtil.isString(formatter) && formatter) {
             content = formatter.replace('{name}', name != null ? name : '');
         }
-        else if (typeof formatter === 'function') {
+        else if (zrUtil.isFunction(formatter)) {
             content = formatter(name);
         }
 

--- a/src/component/marker/MarkAreaView.ts
+++ b/src/component/marker/MarkAreaView.ts
@@ -26,7 +26,7 @@ import * as graphic from '../../util/graphic';
 import { enableHoverEmphasis, setStatesStylesFromModel } from '../../util/states';
 import * as markerHelper from './markerHelper';
 import MarkerView from './MarkerView';
-import { retrieve, mergeAll, map, curry, filter, HashMap, extend } from 'zrender/src/core/util';
+import { retrieve, mergeAll, map, curry, filter, HashMap, extend, isString } from 'zrender/src/core/util';
 import { ParsedValue, ScaleDataValue, ZRColor } from '../../util/types';
 import { CoordinateSystem, isCoordinateSystemType } from '../../coord/CoordinateSystem';
 import MarkAreaModel, { MarkArea2DDataItemOption } from './MarkAreaModel';
@@ -272,7 +272,7 @@ class MarkAreaView extends MarkerView {
             const color = getVisualFromData(seriesData, 'color') as ZRColor;
             if (!style.fill) {
                 style.fill = color;
-                if (typeof style.fill === 'string') {
+                if (isString(style.fill)) {
                     style.fill = colorUtil.modifyAlpha(style.fill, 0.4);
                 }
             }
@@ -339,7 +339,7 @@ class MarkAreaView extends MarkerView {
                     labelFetcher: maModel,
                     labelDataIndex: idx,
                     defaultText: areaData.getName(idx) || '',
-                    inheritColor: typeof style.fill === 'string'
+                    inheritColor: isString(style.fill)
                         ? colorUtil.modifyAlpha(style.fill, 1) : '#000'
                 }
             );

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -43,7 +43,8 @@ import {
     map,
     curry,
     filter,
-    HashMap
+    HashMap,
+    isNumber
 } from 'zrender/src/core/util';
 import { makeInner } from '../../util/model';
 import { LineDataVisual } from '../../visual/commonVisualTypes';
@@ -112,7 +113,7 @@ const markLineTransform = function (
             mlTo.coord[baseIndex] = Infinity;
 
             const precision = mlModel.get('precision');
-            if (precision >= 0 && typeof value === 'number') {
+            if (precision >= 0 && isNumber(value)) {
                 value = +value.toFixed(Math.min(precision, 20));
             }
 

--- a/src/component/toolbox/ToolboxView.ts
+++ b/src/component/toolbox/ToolboxView.ts
@@ -185,14 +185,14 @@ class ToolboxView extends ComponentView {
             const titles = featureModel.get('title') || {};
             let iconsMap: Dictionary<string>;
             let titlesMap: Dictionary<string>;
-            if (typeof icons === 'string') {
+            if (zrUtil.isString(icons)) {
                 iconsMap = {};
                 iconsMap[featureName] = icons;
             }
             else {
                 iconsMap = icons;
             }
-            if (typeof titles === 'string') {
+            if (zrUtil.isString(titles)) {
                 titlesMap = {};
                 titlesMap[featureName] = titles as string;
             }

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -341,9 +341,9 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         const optionToContent = model.get('optionToContent');
         const contentToOption = model.get('contentToOption');
         const result = getContentFromModel(ecModel);
-        if (typeof optionToContent === 'function') {
+        if (zrUtil.isFunction(optionToContent)) {
             const htmlOrDom = optionToContent(api.getOption());
-            if (typeof htmlOrDom === 'string') {
+            if (zrUtil.isString(htmlOrDom)) {
                 viewMain.innerHTML = htmlOrDom;
             }
             else if (zrUtil.isDom(htmlOrDom)) {
@@ -395,7 +395,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
 
             let newOption;
             try {
-                if (typeof contentToOption === 'function') {
+                if (zrUtil.isFunction(contentToOption)) {
                     newOption = contentToOption(viewMain, api.getOption());
                 }
                 else {

--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -24,6 +24,7 @@ import { ToolboxFeature, ToolboxFeatureOption } from '../featureManager';
 import { ZRColor } from '../../../util/types';
 import GlobalModel from '../../../model/Global';
 import ExtensionAPI from '../../../core/ExtensionAPI';
+import { isFunction } from 'zrender/src/core/util';
 
 export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
     icon?: string
@@ -58,8 +59,9 @@ class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
             excludeComponents: model.get('excludeComponents'),
             pixelRatio: model.get('pixelRatio')
         });
+        const browser = env.browser;
         // Chrome, Firefox, New Edge
-        if (typeof MouseEvent === 'function' && (env.browser.newEdge || (!env.browser.ie && !env.browser.edge))) {
+        if (isFunction(MouseEvent) && (browser.newEdge || (!browser.ie && !browser.edge))) {
             const $a = document.createElement('a');
             $a.download = title + '.' + type;
             $a.target = '_blank';

--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -91,18 +91,9 @@ class TooltipRichContent {
                 rich: markupStyleCreator.richTextStyles,
                 text: content as string,
                 lineHeight: 22,
-                backgroundColor: tooltipModel.get('backgroundColor'),
-                borderRadius: tooltipModel.get('borderRadius'),
                 borderWidth: 1,
                 borderColor: borderColor as string,
-                shadowColor: tooltipModel.get('shadowColor'),
-                shadowBlur: tooltipModel.get('shadowBlur'),
-                shadowOffsetX: tooltipModel.get('shadowOffsetX'),
-                shadowOffsetY: tooltipModel.get('shadowOffsetY'),
                 textShadowColor: textStyleModel.get('textShadowColor'),
-                textShadowBlur: textStyleModel.get('textShadowBlur') || 0,
-                textShadowOffsetX: textStyleModel.get('textShadowOffsetX') || 0,
-                textShadowOffsetY: textStyleModel.get('textShadowOffsetY') || 0,
                 fill: tooltipModel.get(['textStyle', 'color']),
                 padding: getPaddingFromTooltipModel(tooltipModel, 'richText'),
                 verticalAlign: 'top',
@@ -110,6 +101,17 @@ class TooltipRichContent {
             },
             z: tooltipModel.get('z')
         });
+        zrUtil.each([
+            'backgroundColor', 'borderRadius', 'shadowColor', 'shadowBlur', 'shadowOffsetX', 'shadowOffsetY'
+        ] as const, propName => {
+            (this.el.style as any)[propName] = tooltipModel.get(propName);
+        });
+        zrUtil.each([
+            'textShadowBlur', 'textShadowOffsetX', 'textShadowOffsetY'
+        ] as const, propName => {
+            this.el.style[propName] = textStyleModel.get(propName) || 0;
+        });
+
         this._zr.add(this.el);
 
         const self = this;

--- a/src/coord/axisAlignTicks.ts
+++ b/src/coord/axisAlignTicks.ts
@@ -5,7 +5,9 @@ import { getScaleExtent } from './axisHelper';
 import { AxisBaseModel } from './AxisBaseModel';
 import LogScale from '../scale/Log';
 import { warn } from '../util/log';
-import { mathLog, increaseInterval, isValueNice } from '../scale/helper';
+import { increaseInterval, isValueNice } from '../scale/helper';
+
+const mathLog = Math.log;
 
 
 export function alignScaleTicks(

--- a/src/coord/axisAlignTicks.ts
+++ b/src/coord/axisAlignTicks.ts
@@ -1,0 +1,121 @@
+import { NumericAxisBaseOptionCommon } from './axisCommonTypes';
+import { getPrecisionSafe, round } from '../util/number';
+import IntervalScale from '../scale/Interval';
+import { getScaleExtent } from './axisHelper';
+import { AxisBaseModel } from './AxisBaseModel';
+import LogScale from '../scale/Log';
+import { warn } from '../util/log';
+import { mathLog, increaseInterval, isValueNice } from '../scale/helper';
+
+
+export function alignScaleTicks(
+    scale: IntervalScale | LogScale,
+    axisModel: AxisBaseModel<Pick<NumericAxisBaseOptionCommon, 'min' | 'max'>>,
+    alignToScale: IntervalScale | LogScale
+) {
+
+    const intervalScaleProto = IntervalScale.prototype;
+
+    // NOTE: There is a precondition for log scale  here:
+    // In log scale we store _interval and _extent of exponent value.
+    // So if we use the method of InternalScale to set/get these data.
+    // It process the exponent value, which is linear and what we want here.
+    const alignToTicks = intervalScaleProto.getTicks.call(alignToScale);
+    const alignToNicedTicks = intervalScaleProto.getTicks.call(alignToScale, true);
+    const alignToSplitNumber = alignToTicks.length - 1;
+    const alignToInterval = intervalScaleProto.getInterval.call(alignToScale);
+
+    const scaleExtent = getScaleExtent(scale, axisModel);
+    let rawExtent = scaleExtent.extent;
+    const isMinFixed = scaleExtent.fixMin;
+    const isMaxFixed = scaleExtent.fixMax;
+
+    if (scale.type === 'log') {
+        const logBase = mathLog((scale as LogScale).base);
+        rawExtent = [mathLog(rawExtent[0]) / logBase, mathLog(rawExtent[1]) / logBase];
+    }
+
+    scale.setExtent(rawExtent[0], rawExtent[1]);
+    scale.calcNiceExtent({
+        splitNumber: alignToSplitNumber,
+        fixMin: isMinFixed,
+        fixMax: isMaxFixed
+    });
+    const extent = intervalScaleProto.getExtent.call(scale);
+
+    // Need to update the rawExtent.
+    // Because value in rawExtent may be not parsed. e.g. 'dataMin', 'dataMax'
+    if (isMinFixed) {
+        rawExtent[0] = extent[0];
+    }
+    if (isMaxFixed) {
+        rawExtent[1] = extent[1];
+    }
+
+    let interval = intervalScaleProto.getInterval.call(scale);
+    let min: number = rawExtent[0];
+    let max: number = rawExtent[1];
+
+    if (isMinFixed && isMaxFixed) {
+        // User set min, max, divide to get new interval
+        interval = (max - min) / alignToSplitNumber;
+    }
+    else if (isMinFixed) {
+        max = rawExtent[0] + interval * alignToSplitNumber;
+        // User set min, expand extent on the other side
+        while (max < rawExtent[1] && isFinite(max) && isFinite(rawExtent[1])) {
+            interval = increaseInterval(interval);
+            max = rawExtent[0] + interval * alignToSplitNumber;
+        }
+    }
+    else if (isMaxFixed) {
+        // User set max, expand extent on the other side
+        min = rawExtent[1] - interval * alignToSplitNumber;
+        while (min > rawExtent[0] && isFinite(min) && isFinite(rawExtent[0])) {
+            interval = increaseInterval(interval);
+            min = rawExtent[1] - interval * alignToSplitNumber;
+        }
+    }
+    else {
+        const nicedSplitNumber = scale.getTicks().length - 1;
+        if (nicedSplitNumber > alignToSplitNumber) {
+            interval = increaseInterval(interval);
+        }
+
+        const range = interval * alignToSplitNumber;
+        max = Math.ceil(rawExtent[1] / interval) * interval;
+        min = round(max - range);
+        // Not change the result that crossing zero.
+        if (min < 0 && rawExtent[0] >= 0) {
+            min = 0;
+            max = round(range);
+        }
+        else if (max > 0 && rawExtent[1] <= 0) {
+            max = 0;
+            min = -round(range);
+        }
+
+    }
+
+    // Adjust min, max based on the extent of alignTo. When min or max is set in alignTo scale
+    const t0 = (alignToTicks[0].value - alignToNicedTicks[0].value) / alignToInterval;
+    const t1 = (alignToTicks[alignToSplitNumber].value - alignToNicedTicks[alignToSplitNumber].value) / alignToInterval;
+
+    // NOTE: Must in setExtent -> setInterval -> setNiceExtent order.
+    intervalScaleProto.setExtent.call(scale, min + interval * t0, max + interval * t1);
+    intervalScaleProto.setInterval.call(scale, interval);
+    if (t0 || t1) {
+        intervalScaleProto.setNiceExtent.call(scale, min + interval, max - interval);
+    }
+
+    if (__DEV__) {
+        const ticks = intervalScaleProto.getTicks.call(scale);
+        if (ticks[1]
+            && (!isValueNice(interval) || getPrecisionSafe(ticks[1].value) > getPrecisionSafe(interval))) {
+            warn(
+                // eslint-disable-next-line
+                `The ticks may be not readable when set min: ${axisModel.get('min')}, max: ${axisModel.get('max')} and alignTicks: true`
+            );
+        }
+    }
+}

--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -242,7 +242,7 @@ export function makeLabelFormatter(axis: Axis): (tick: ScaleTick, idx?: number) 
             };
         })(labelFormatter as TimeAxisLabelFormatterOption);
     }
-    else if (typeof labelFormatter === 'string') {
+    else if (zrUtil.isString(labelFormatter)) {
         return (function (tpl) {
             return function (tick: ScaleTick) {
                 // For category axis, get raw value; for numeric axis,
@@ -254,7 +254,7 @@ export function makeLabelFormatter(axis: Axis): (tick: ScaleTick, idx?: number) 
             };
         })(labelFormatter);
     }
-    else if (typeof labelFormatter === 'function') {
+    else if (zrUtil.isFunction(labelFormatter)) {
         return (function (cb) {
             return function (tick: ScaleTick, idx: number) {
                 // The original intention of `idx` is "the index of the tick in all ticks".

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -50,7 +50,7 @@ import { isCartesian2DSeries, findAxisModels } from './cartesianAxisHelper';
 import { CategoryAxisBaseOption, NumericAxisBaseOptionCommon } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
 import { isIntervalOrLogScale } from '../../scale/helper';
-import { alignScaleTicks } from "../axisAlignTicks";
+import { alignScaleTicks } from '../axisAlignTicks';
 import IntervalScale from '../../scale/Interval';
 import LogScale from '../../scale/Log';
 

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -49,7 +49,8 @@ import OrdinalScale from '../../scale/Ordinal';
 import { isCartesian2DSeries, findAxisModels } from './cartesianAxisHelper';
 import { CategoryAxisBaseOption, NumericAxisBaseOptionCommon } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
-import { alignScaleTicks, isIntervalOrLogScale } from '../../scale/helper';
+import { isIntervalOrLogScale } from '../../scale/helper';
+import { alignScaleTicks } from "../axisAlignTicks";
 import IntervalScale from '../../scale/Interval';
 import LogScale from '../../scale/Log';
 

--- a/src/coord/geo/Geo.ts
+++ b/src/coord/geo/Geo.ts
@@ -172,7 +172,7 @@ class Geo extends View {
     }
 
     dataToPoint(data: number[] | string, noRoam?: boolean, out?: number[]): number[] {
-        if (typeof data === 'string') {
+        if (zrUtil.isString(data)) {
             // Map area name to geoCoord
             data = this.getGeoCoord(data);
         }

--- a/src/coord/geo/GeoModel.ts
+++ b/src/coord/geo/GeoModel.ts
@@ -270,11 +270,11 @@ class GeoModel extends ComponentModel<GeoOption> {
         const params = {
             name: name
         } as GeoLabelFormatterDataParams;
-        if (typeof formatter === 'function') {
+        if (zrUtil.isFunction(formatter)) {
             params.status = status;
             return formatter(params);
         }
-        else if (typeof formatter === 'string') {
+        else if (zrUtil.isString(formatter)) {
             return formatter.replace('{a}', name != null ? name : '');
         }
     }

--- a/src/coord/radar/Radar.ts
+++ b/src/coord/radar/Radar.ts
@@ -29,7 +29,7 @@ import ExtensionAPI from '../../core/ExtensionAPI';
 import { ScaleDataValue } from '../../util/types';
 import { ParsedModelFinder } from '../../util/model';
 import { map, each, isString, isNumber } from 'zrender/src/core/util';
-import { alignScaleTicks } from '../../scale/helper';
+import { alignScaleTicks } from "../axisAlignTicks";
 
 
 class Radar implements CoordinateSystem, CoordinateSystemMaster {

--- a/src/coord/radar/Radar.ts
+++ b/src/coord/radar/Radar.ts
@@ -28,7 +28,7 @@ import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { ScaleDataValue } from '../../util/types';
 import { ParsedModelFinder } from '../../util/model';
-import { map, each } from 'zrender/src/core/util';
+import { map, each, isString, isNumber } from 'zrender/src/core/util';
 import { alignScaleTicks } from '../../scale/helper';
 
 
@@ -133,7 +133,7 @@ class Radar implements CoordinateSystem, CoordinateSystemMaster {
 
         // radius may be single value like `20`, `'80%'`, or array like `[10, '80%']`
         let radius = radarModel.get('radius');
-        if (typeof radius === 'string' || typeof radius === 'number') {
+        if (isString(radius) || isNumber(radius)) {
             radius = [0, radius];
         }
         this.r0 = numberUtil.parsePercent(radius[0], viewSize);

--- a/src/coord/radar/Radar.ts
+++ b/src/coord/radar/Radar.ts
@@ -29,7 +29,7 @@ import ExtensionAPI from '../../core/ExtensionAPI';
 import { ScaleDataValue } from '../../util/types';
 import { ParsedModelFinder } from '../../util/model';
 import { map, each, isString, isNumber } from 'zrender/src/core/util';
-import { alignScaleTicks } from "../axisAlignTicks";
+import { alignScaleTicks } from '../axisAlignTicks';
 
 
 class Radar implements CoordinateSystem, CoordinateSystemMaster {

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -146,11 +146,11 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
             if (!showName) {
                 innerIndicatorOpt.name = '';
             }
-            if (typeof nameFormatter === 'string') {
+            if (zrUtil.isString(nameFormatter)) {
                 const indName = innerIndicatorOpt.name;
                 innerIndicatorOpt.name = nameFormatter.replace('{value}', indName != null ? indName : '');
             }
-            else if (typeof nameFormatter === 'function') {
+            else if (zrUtil.isFunction(nameFormatter)) {
                 innerIndicatorOpt.name = nameFormatter(
                     innerIndicatorOpt.name, innerIndicatorOpt
                 );

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -33,7 +33,8 @@ import {
     defaults,
     isDom,
     isArray,
-    noop
+    noop,
+    isString
 } from 'zrender/src/core/util';
 import env from 'zrender/src/core/env';
 import timsort from 'zrender/src/core/timsort';
@@ -400,7 +401,7 @@ class ECharts extends Eventful<ECEventDefinition> {
         opts = opts || {};
 
         // Get theme by name
-        if (typeof theme === 'string') {
+        if (isString(theme)) {
             theme = themeStorage[theme] as object;
         }
 
@@ -2698,7 +2699,7 @@ export const disconnect = disConnect;
  * Dispose a chart instance
  */
 export function dispose(chart: EChartsType | HTMLElement | string): void {
-    if (typeof chart === 'string') {
+    if (isString(chart)) {
         chart = instances[chart];
     }
     else if (!(chart instanceof ECharts)) {
@@ -2788,7 +2789,7 @@ export function registerAction(
     eventName: string | ActionHandler,
     action?: ActionHandler
 ): void {
-    if (typeof eventName === 'function') {
+    if (isFunction(eventName)) {
         action = eventName;
         eventName = '';
     }

--- a/src/data/Graph.ts
+++ b/src/data/Graph.ts
@@ -110,10 +110,10 @@ class Graph {
         const edgesMap = this._edgesMap;
 
         // PNEDING
-        if (typeof n1 === 'number') {
+        if (zrUtil.isNumber(n1)) {
             n1 = this.nodes[n1];
         }
-        if (typeof n2 === 'number') {
+        if (zrUtil.isNumber(n2)) {
             n2 = this.nodes[n2];
         }
 

--- a/src/data/OrdinalMeta.ts
+++ b/src/data/OrdinalMeta.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {createHashMap, isObject, map, HashMap} from 'zrender/src/core/util';
+import {createHashMap, isObject, map, HashMap, isString} from 'zrender/src/core/util';
 import Model from '../model/Model';
 import { OrdinalNumber, OrdinalRawValue } from '../util/types';
 
@@ -77,7 +77,7 @@ class OrdinalMeta {
         // consider a common case: a value is 2017, which is a number but is
         // expected to be tread as a category. This case usually happen in dataset,
         // where it happent to be no need of the index feature.
-        if (typeof category !== 'string' && !needCollect) {
+        if (!isString(category) && !needCollect) {
             return category;
         }
 

--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -430,7 +430,7 @@ class SeriesData<
      * @return recogonized `DimensionIndex`. Otherwise return null/undefined (means that dim is `DimensionName`).
      */
     private _recognizeDimIndex(dim: DimensionLoose): DimensionIndex {
-        if (typeof dim === 'number'
+        if (zrUtil.isNumber(dim)
             // If being a number-like string but not being defined as a dimension name.
             || (
                 dim != null
@@ -907,7 +907,7 @@ class SeriesData<
     ): void {
         'use strict';
 
-        if (typeof dims === 'function') {
+        if (zrUtil.isFunction(dims)) {
             ctx = cb as Ctx;
             cb = dims;
             dims = [];
@@ -938,7 +938,7 @@ class SeriesData<
     ): SeriesData {
         'use strict';
 
-        if (typeof dims === 'function') {
+        if (zrUtil.isFunction(dims)) {
             ctx = cb as Ctx;
             cb = dims;
             dims = [];
@@ -994,7 +994,7 @@ class SeriesData<
     ): unknown[] {
         'use strict';
 
-        if (typeof dims === 'function') {
+        if (zrUtil.isFunction(dims)) {
             ctx = cb as Ctx;
             cb = dims;
             dims = [];
@@ -1368,7 +1368,7 @@ class SeriesData<
         injectFunction: (...args: any) => any
     ): void {
         const originalMethod = this[methodName];
-        if (typeof originalMethod !== 'function') {
+        if (!zrUtil.isFunction(originalMethod)) {
             return;
         }
         this.__wrappedMethods = this.__wrappedMethods || [];

--- a/src/data/Tree.ts
+++ b/src/data/Tree.ts
@@ -106,7 +106,7 @@ export class TreeNode {
         cb?: TreeTraverseCallback<Ctx> | Ctx,
         context?: Ctx
     ) {
-        if (typeof options === 'function') {
+        if (zrUtil.isFunction(options)) {
             context = cb as Ctx;
             cb = options;
             options = null;

--- a/src/data/helper/dataValueHelper.ts
+++ b/src/data/helper/dataValueHelper.ts
@@ -167,11 +167,13 @@ export class SortOrderComparator {
             rvalFloat = this._incomparable;
         }
         if (lvalNotNumeric && rvalNotNumeric) {
-            if (isString(lval)) {
-                lvalFloat = isString(rval) ? lval as unknown as number : 0;
+            const lvalIsStr = isString(lval);
+            const rvalIsStr = isString(rval);
+            if (lvalIsStr) {
+                lvalFloat = rvalIsStr ? lval as unknown as number : 0;
             }
-            if (isString(rval)) {
-                rvalFloat = isString(lval) ? rval as unknown as number : 0;
+            if (rvalIsStr) {
+                rvalFloat = lvalIsStr ? rval as unknown as number : 0;
             }
         }
 

--- a/src/data/helper/transform.ts
+++ b/src/data/helper/transform.ts
@@ -26,7 +26,7 @@ import {
 } from '../../util/types';
 import { normalizeToArray } from '../../util/model';
 import {
-    createHashMap, bind, each, hasOwn, map, clone, isObject, extend
+    createHashMap, bind, each, hasOwn, map, clone, isObject, extend, isNumber
 } from 'zrender/src/core/util';
 import {
     getRawSourceItemGetter, getRawSourceDataCounter, getRawSourceValueGetter
@@ -312,7 +312,7 @@ function getDimensionInfo(
         return;
     }
     // Keep the same logic as `List::getDimension` did.
-    if (typeof dim === 'number'
+    if (isNumber(dim)
         // If being a number-like string but not being defined a dimension name.
         || (!isNaN(dim as any) && !hasOwn(dimsByName, dim))
     ) {

--- a/src/label/LabelManager.ts
+++ b/src/label/LabelManager.ts
@@ -325,7 +325,7 @@ class LabelManager {
             const defaultLabelAttr = labelItem.defaultAttr;
             let layoutOption;
             // TODO A global layout option?
-            if (typeof labelItem.layoutOption === 'function') {
+            if (isFunction(labelItem.layoutOption)) {
                 layoutOption = labelItem.layoutOption(
                     prepareLayoutCallbackParams(labelItem, hostEl)
                 );

--- a/src/label/sectorLabel.ts
+++ b/src/label/sectorLabel.ts
@@ -21,7 +21,7 @@
 import {calculateTextPosition, TextPositionCalculationResult} from 'zrender/src/contain/text';
 import { RectLike } from 'zrender/src/core/BoundingRect';
 import {BuiltinTextPosition, TextAlign, TextVerticalAlign} from 'zrender/src/core/types';
-import {isArray} from 'zrender/src/core/util';
+import {isArray, isNumber} from 'zrender/src/core/util';
 import {ElementCalculateTextPosition, ElementTextConfig} from 'zrender/src/Element';
 import { Sector } from '../util/graphic';
 
@@ -195,7 +195,7 @@ export function setSectorTextRotation<T extends (string | (number | string)[])>(
     positionMapping: (seriesLabelPosition: T) => SectorTextPosition,
     rotateType: number | 'auto'
 ) {
-    if (typeof rotateType === 'number') {
+    if (isNumber(rotateType)) {
         // user-set rotation
         sector.setTextConfig({
             rotation: rotateType

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -168,47 +168,6 @@ class Model<Opt = ModelOption> {    // TODO: TYPE use unknown instead of any?
     }
 
     /**
-     * Squash option stack into one.
-     * parentModel will be removed after squashed.
-     *
-     * NOTE: resolveParentPath will not be applied here for simplicity. DON'T use this function
-     * if resolveParentPath is modified.
-     *
-     * @param deepMerge If do deep merge. Default to be false.
-     */
-    // squash(
-    //     deepMerge?: boolean,
-    //     handleCallback?: (func: () => object) => object
-    // ) {
-    //     const optionStack = [];
-    //     let model: Model = this;
-    //     while (model) {
-    //         if (model.option) {
-    //             optionStack.push(model.option);
-    //         }
-    //         model = model.parentModel;
-    //     }
-
-    //     const newOption = {} as Opt;
-    //     let option;
-    //     while (option = optionStack.pop()) {    // Top down merge
-    //         if (isFunction(option) && handleCallback) {
-    //             option = handleCallback(option);
-    //         }
-    //         if (deepMerge) {
-    //             merge(newOption, option);
-    //         }
-    //         else {
-    //             extend(newOption, option);
-    //         }
-    //     }
-
-    //     // Remove parentModel
-    //     this.option = newOption;
-    //     this.parentModel = null;
-    // }
-
-    /**
      * If model has option
      */
     isEmpty(): boolean {

--- a/src/model/mixin/dataFormat.ts
+++ b/src/model/mixin/dataFormat.ts
@@ -137,12 +137,12 @@ export class DataFormatMixin {
             );
         }
 
-        if (typeof formatter === 'function') {
+        if (zrUtil.isFunction(formatter)) {
             params.status = status;
             params.dimensionIndex = labelDimIndex;
             return formatter(params);
         }
-        else if (typeof formatter === 'string') {
+        else if (zrUtil.isString(formatter)) {
             const str = formatTpl(formatter, params);
 
             // Support 'aaa{@[3]}bbb{@product}ccc'.

--- a/src/processor/dataSample.ts
+++ b/src/processor/dataSample.ts
@@ -20,6 +20,7 @@
 import { StageHandler, SeriesOption, SeriesSamplingOptionMixin } from '../util/types';
 import { Dictionary } from 'zrender/src/core/types';
 import SeriesModel from '../model/Series';
+import { isFunction, isString } from 'zrender/src/core/util';
 
 
 type Sampler = (frame: ArrayLike<number>) => number;
@@ -99,10 +100,10 @@ export default function dataSample(seriesType: string): StageHandler {
                         seriesModel.setData(data.lttbDownSample(data.mapDimension(valueAxis.dim), 1 / rate));
                     }
                     let sampler;
-                    if (typeof sampling === 'string') {
+                    if (isString(sampling)) {
                         sampler = samplers[sampling];
                     }
-                    else if (typeof sampling === 'function') {
+                    else if (isFunction(sampling)) {
                         sampler = sampling;
                     }
                     if (sampler) {

--- a/src/processor/negativeDataFilter.ts
+++ b/src/processor/negativeDataFilter.ts
@@ -17,6 +17,7 @@
 * under the License.
 */
 
+import { isNumber } from 'zrender/src/core/util';
 import { StageHandler } from '../util/types';
 
 export default function negativeDataFilter(seriesType: string): StageHandler {
@@ -28,7 +29,7 @@ export default function negativeDataFilter(seriesType: string): StageHandler {
                 // handle negative value condition
                 const valueDim = data.mapDimension('value');
                 const curValue = data.get(valueDim, idx);
-                if (typeof curValue === 'number' && !isNaN(curValue) && curValue < 0) {
+                if (isNumber(curValue) && !isNaN(curValue) && curValue < 0) {
                     return false;
                 }
                 return true;

--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -37,7 +37,7 @@ import {
     ScaleTick
 } from '../util/types';
 import { CategoryAxisBaseOption } from '../coord/axisCommonTypes';
-import { isArray, map, isObject } from 'zrender/src/core/util';
+import { isArray, map, isObject, isString } from 'zrender/src/core/util';
 
 type OrdinalScaleSetting = {
     ordinalMeta?: OrdinalMeta | CategoryAxisBaseOption['data'];
@@ -130,7 +130,7 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
     }
 
     parse(val: OrdinalRawValue | OrdinalNumber): OrdinalNumber {
-        return typeof val === 'string'
+        return isString(val)
             ? this._ordinalMeta.getOrdinal(val)
             // val might be float.
             : Math.round(val);

--- a/src/scale/Time.ts
+++ b/src/scale/Time.ts
@@ -78,7 +78,7 @@ import {TimeAxisLabelFormatterOption} from '../coord/axisCommonTypes';
 import { warn } from '../util/log';
 import { LocaleOption } from '../core/locale';
 import Model from '../model/Model';
-import { filter, map } from 'zrender/src/core/util';
+import { filter, isNumber, map } from 'zrender/src/core/util';
 
 // FIXME 公用？
 const bisect = function (
@@ -234,7 +234,7 @@ class TimeScale extends IntervalScale<TimeScaleSetting> {
 
     parse(val: number | string | Date): number {
         // val might be float.
-        return typeof val === 'number' ? val : +numberUtil.parseDate(val);
+        return isNumber(val) ? val : +numberUtil.parseDate(val);
     }
 
     contain(val: number): boolean {

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -22,8 +22,6 @@ import IntervalScale from './Interval';
 import LogScale from './Log';
 import Scale from './Scale';
 
-export const mathLog = Math.log;
-
 type intervalScaleNiceTicksResult = {
     interval: number,
     intervalPrecision: number,

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -17,16 +17,12 @@
 * under the License.
 */
 
-import { NumericAxisBaseOptionCommon } from '../coord/axisCommonTypes';
-import {getPrecisionSafe, getPrecision, round, nice, quantityExponent} from '../util/number';
+import {getPrecision, round, nice, quantityExponent} from '../util/number';
 import IntervalScale from './Interval';
-import { getScaleExtent } from '../coord/axisHelper';
-import { AxisBaseModel } from '../coord/AxisBaseModel';
 import LogScale from './Log';
 import Scale from './Scale';
-import { warn } from '../util/log';
 
-const mathLog = Math.log;
+export const mathLog = Math.log;
 
 type intervalScaleNiceTicksResult = {
     interval: number,
@@ -34,7 +30,7 @@ type intervalScaleNiceTicksResult = {
     niceTickExtent: [number, number]
 };
 
-function isValueNice(val: number) {
+export function isValueNice(val: number) {
     const exp10 = Math.pow(10, quantityExponent(Math.abs(val)));
     const f = Math.abs(val / exp10);
     return f === 0
@@ -82,7 +78,7 @@ export function intervalScaleNiceTicks(
     return result;
 }
 
-function increaseInterval(interval: number) {
+export function increaseInterval(interval: number) {
     const exp10 = Math.pow(10, quantityExponent(interval));
     // Increase interval
     let f = interval / exp10;
@@ -99,119 +95,6 @@ function increaseInterval(interval: number) {
         f *= 2;
     }
     return f * exp10;
-}
-
-export function alignScaleTicks(
-    scale: IntervalScale | LogScale,
-    axisModel: AxisBaseModel<Pick<NumericAxisBaseOptionCommon, 'min' | 'max'>>,
-    alignToScale: IntervalScale | LogScale
-) {
-
-    const intervalScaleProto = IntervalScale.prototype;
-
-    // NOTE: There is a precondition for log scale  here:
-    // In log scale we store _interval and _extent of exponent value.
-    // So if we use the method of InternalScale to set/get these data.
-    // It process the exponent value, which is linear and what we want here.
-    const alignToTicks = intervalScaleProto.getTicks.call(alignToScale);
-    const alignToNicedTicks = intervalScaleProto.getTicks.call(alignToScale, true);
-    const alignToSplitNumber = alignToTicks.length - 1;
-    const alignToInterval = intervalScaleProto.getInterval.call(alignToScale);
-
-    const scaleExtent = getScaleExtent(scale, axisModel);
-    let rawExtent = scaleExtent.extent;
-    const isMinFixed = scaleExtent.fixMin;
-    const isMaxFixed = scaleExtent.fixMax;
-
-    if (scale.type === 'log') {
-        const logBase = mathLog((scale as LogScale).base);
-        rawExtent = [mathLog(rawExtent[0]) / logBase, mathLog(rawExtent[1]) / logBase];
-    }
-
-    scale.setExtent(rawExtent[0], rawExtent[1]);
-    scale.calcNiceExtent({
-        splitNumber: alignToSplitNumber,
-        fixMin: isMinFixed,
-        fixMax: isMaxFixed
-    });
-    const extent = intervalScaleProto.getExtent.call(scale);
-
-    // Need to update the rawExtent.
-    // Because value in rawExtent may be not parsed. e.g. 'dataMin', 'dataMax'
-    if (isMinFixed) {
-        rawExtent[0] = extent[0];
-    }
-    if (isMaxFixed) {
-        rawExtent[1] = extent[1];
-    }
-
-    let interval = intervalScaleProto.getInterval.call(scale);
-    let min: number = rawExtent[0];
-    let max: number = rawExtent[1];
-
-    if (isMinFixed && isMaxFixed) {
-        // User set min, max, divide to get new interval
-        interval = (max - min) / alignToSplitNumber;
-    }
-    else if (isMinFixed) {
-        max = rawExtent[0] + interval * alignToSplitNumber;
-        // User set min, expand extent on the other side
-        while (max < rawExtent[1] && isFinite(max) && isFinite(rawExtent[1])) {
-            interval = increaseInterval(interval);
-            max = rawExtent[0] + interval * alignToSplitNumber;
-        }
-    }
-    else if (isMaxFixed) {
-        // User set max, expand extent on the other side
-        min = rawExtent[1] - interval * alignToSplitNumber;
-        while (min > rawExtent[0] && isFinite(min) && isFinite(rawExtent[0])) {
-            interval = increaseInterval(interval);
-            min = rawExtent[1] - interval * alignToSplitNumber;
-        }
-    }
-    else {
-        const nicedSplitNumber = scale.getTicks().length - 1;
-        if (nicedSplitNumber > alignToSplitNumber) {
-            interval = increaseInterval(interval);
-        }
-
-        const range = interval * alignToSplitNumber;
-        max = Math.ceil(rawExtent[1] / interval) * interval;
-        min = round(max - range);
-        // Not change the result that crossing zero.
-        if (min < 0 && rawExtent[0] >= 0) {
-            min = 0;
-            max = round(range);
-        }
-        else if (max > 0 && rawExtent[1] <= 0) {
-            max = 0;
-            min = -round(range);
-        }
-
-    }
-
-    // Adjust min, max based on the extent of alignTo. When min or max is set in alignTo scale
-    const t0 = (alignToTicks[0].value - alignToNicedTicks[0].value) / alignToInterval;
-    const t1 = (alignToTicks[alignToSplitNumber].value - alignToNicedTicks[alignToSplitNumber].value) / alignToInterval;
-
-    // NOTE: Must in setExtent -> setInterval -> setNiceExtent order.
-    intervalScaleProto.setExtent.call(scale, min + interval * t0, max + interval * t1);
-    intervalScaleProto.setInterval.call(scale, interval);
-    if (t0 || t1) {
-        intervalScaleProto.setNiceExtent.call(scale, min + interval, max - interval);
-    }
-
-    if (__DEV__) {
-        const ticks = intervalScaleProto.getTicks.call(scale);
-        if (ticks[1]
-            && (!isValueNice(interval) || getPrecisionSafe(ticks[1].value) > getPrecisionSafe(interval))
-        ) {
-            warn(
-                // eslint-disable-next-line
-                `The ticks may be not readable when set min: ${axisModel.get('min')}, max: ${axisModel.get('max')} and alignTicks: true`
-            );
-        }
-    }
 }
 
 /**

--- a/src/util/clazz.ts
+++ b/src/util/clazz.ts
@@ -128,7 +128,7 @@ export function enableClassExtend(rootClz: ExtendableConstructor, mandatoryMetho
 }
 
 function isESClass(fn: unknown): boolean {
-    return typeof fn === 'function'
+    return zrUtil.isFunction(fn)
         && /^class\s/.test(Function.prototype.toString.call(fn));
 }
 

--- a/src/util/conditionalExpression.ts
+++ b/src/util/conditionalExpression.ts
@@ -19,7 +19,7 @@
 
 import { OptionDataValue, DimensionLoose, Dictionary } from './types';
 import {
-    keys, isArray, map, isObject, isString, HashMap, isRegExp, isArrayLike, hasOwn
+    keys, isArray, map, isObject, isString, HashMap, isRegExp, isArrayLike, hasOwn, isNumber
 } from 'zrender/src/core/util';
 import { throwError, makePrintable } from './log';
 import {
@@ -189,8 +189,8 @@ class RegExpEvaluator implements FilterComparator {
 
     evaluate(lVal: unknown): boolean {
         const type = typeof lVal;
-        return type === 'string' ? this._condVal.test(lVal as string)
-            : type === 'number' ? this._condVal.test(lVal + '')
+        return isString(type) ? this._condVal.test(lVal as string)
+            : isNumber(type) ? this._condVal.test(lVal + '')
             : false;
     }
 }

--- a/src/util/decal.ts
+++ b/src/util/decal.ts
@@ -21,7 +21,7 @@
 import WeakMap from 'zrender/src/core/WeakMap';
 import { ImagePatternObject, PatternObject, SVGPatternObject } from 'zrender/src/graphic/Pattern';
 import LRU from 'zrender/src/core/LRU';
-import {defaults, map, isArray} from 'zrender/src/core/util';
+import {defaults, map, isArray, isString, isNumber} from 'zrender/src/core/util';
 import {getLeastCommonMultiple} from './number';
 import {createSymbol} from './symbol';
 import ExtensionAPI from '../core/ExtensionAPI';
@@ -101,12 +101,11 @@ export function createOrUpdatePatternFromDecal(
         let isValidKey = true;
         for (let i = 0; i < decalKeys.length; ++i) {
             const value = (decalOpt as any)[decalKeys[i]];
-            const valueType = typeof value;
             if (value != null
                 && !isArray(value)
-                && valueType !== 'string'
-                && valueType !== 'number'
-                && valueType !== 'boolean'
+                && !isString(value)
+                && !isNumber(value)
+                && typeof value !== 'boolean'
             ) {
                 isValidKey = false;
                 break;
@@ -316,13 +315,13 @@ function normalizeSymbolArray(symbol: string | (string | string[])[]): string[][
     if (!symbol || (symbol as string[]).length === 0) {
         return [['rect']];
     }
-    if (typeof symbol === 'string') {
+    if (isString(symbol)) {
         return [[symbol]];
     }
 
     let isAllString = true;
     for (let i = 0; i < symbol.length; ++i) {
-        if (typeof symbol[i] !== 'string') {
+        if (!isString(symbol[i])) {
             isAllString = false;
             break;
         }
@@ -333,7 +332,7 @@ function normalizeSymbolArray(symbol: string | (string | string[])[]): string[][
 
     const result: string[][] = [];
     for (let i = 0; i < symbol.length; ++i) {
-        if (typeof symbol[i] === 'string') {
+        if (isString(symbol[i])) {
             result.push([symbol[i] as string]);
         }
         else {
@@ -353,7 +352,7 @@ function normalizeDashArrayX(dash: DecalDashArrayX): number[][] {
     if (!dash || (dash as number[]).length === 0) {
         return [[0, 0]];
     }
-    if (typeof dash === 'number') {
+    if (isNumber(dash)) {
         const dashValue = Math.ceil(dash);
         return [[dashValue, dashValue]];
     }
@@ -364,7 +363,7 @@ function normalizeDashArrayX(dash: DecalDashArrayX): number[][] {
      */
     let isAllNumber = true;
     for (let i = 0; i < dash.length; ++i) {
-        if (typeof dash[i] !== 'number') {
+        if (!isNumber(dash[i])) {
             isAllNumber = false;
             break;
         }
@@ -375,7 +374,7 @@ function normalizeDashArrayX(dash: DecalDashArrayX): number[][] {
 
     const result: number[][] = [];
     for (let i = 0; i < dash.length; ++i) {
-        if (typeof dash[i] === 'number') {
+        if (isNumber(dash[i])) {
             const dashValue = Math.ceil(dash[i] as number);
             result.push([dashValue, dashValue]);
         }
@@ -404,7 +403,7 @@ function normalizeDashArrayY(dash: DecalDashArrayY): number[] {
     if (!dash || typeof dash === 'object' && dash.length === 0) {
         return [0, 0];
     }
-    if (typeof dash === 'number') {
+    if (isNumber(dash)) {
         const dashValue = Math.ceil(dash);
         return [dashValue, dashValue];
     }

--- a/src/util/model.ts
+++ b/src/util/model.ts
@@ -27,7 +27,8 @@ import {
     assert,
     isString,
     indexOf,
-    isStringSafe
+    isStringSafe,
+    isNumber
 } from 'zrender/src/core/util';
 import env from 'zrender/src/core/env';
 import GlobalModel from '../model/Global';
@@ -543,10 +544,9 @@ export function convertOptionIdName(idOrName: unknown, defaultValue: string): st
     if (idOrName == null) {
         return defaultValue;
     }
-    const type = typeof idOrName;
-    return type === 'string'
-        ? idOrName as string
-        : (type === 'number' || isStringSafe(idOrName))
+    return isString(idOrName)
+        ? idOrName
+        : (isNumber(idOrName) || isStringSafe(idOrName))
         ? idOrName + ''
         : defaultValue;
 }
@@ -1047,7 +1047,7 @@ export function interpolateRawValues(
         return targetValue;
     }
 
-    if (typeof targetValue === 'number') {
+    if (isNumber(targetValue)) {
         const value = interpolateNumber(
             sourceValue as number || 0,
             targetValue as number,
@@ -1062,7 +1062,7 @@ export function interpolateRawValues(
             : precision as number
         );
     }
-    else if (typeof targetValue === 'string') {
+    else if (isString(targetValue)) {
         return percent < 1 ? sourceValue : targetValue;
     }
     else {

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -118,7 +118,7 @@ export function parsePercent(percent: number | string, all: number): number {
             percent = '100%';
             break;
     }
-    if (typeof percent === 'string') {
+    if (zrUtil.isString(percent)) {
         if (_trim(percent).match(/%$/)) {
             return parseFloat(percent) / 100 * all;
         }
@@ -335,7 +335,7 @@ export function parseDate(value: unknown): Date {
     if (value instanceof Date) {
         return value;
     }
-    else if (typeof value === 'string') {
+    else if (zrUtil.isString(value)) {
         // Different browsers parse date in different way, so we parse it manually.
         // Some other issues:
         // new Date('1970-01-01') is UTC,
@@ -585,7 +585,7 @@ export function numericToNumber(val: unknown): number {
     const valFloat = parseFloat(val as string);
     return (
         valFloat == val // eslint-disable-line eqeqeq
-        && (valFloat !== 0 || typeof val !== 'string' || val.indexOf('x') <= 0) // For case ' 0x0 '.
+        && (valFloat !== 0 || !zrUtil.isString(val) || val.indexOf('x') <= 0) // For case ' 0x0 '.
     ) ? valFloat : NaN;
 }
 

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -164,11 +164,11 @@ export function leveledFormat(
     isUTC: boolean
 ) {
     let template = null;
-    if (typeof formatter === 'string') {
+    if (zrUtil.isString(formatter)) {
         // Single formatter for all units at all levels
         template = formatter;
     }
-    else if (typeof formatter === 'function') {
+    else if (zrUtil.isFunction(formatter)) {
         // Callback formatter
         template = formatter(tick.value, idx, {
             level: tick.level
@@ -264,7 +264,7 @@ export function getUnitValue(
     unit: TimeUnit,
     isUTC: boolean
 ) : number {
-    const date = typeof value === 'number'
+    const date = zrUtil.isNumber(value)
         ? numberUtil.parseDate(value)
         : value;
     unit = unit || getUnitFromValue(value, isUTC);

--- a/src/visual/VisualMapping.ts
+++ b/src/visual/VisualMapping.ts
@@ -489,7 +489,7 @@ class VisualMapping<VisualOption
                     // but currently value type can exactly be string or number.
                     // Compromise for numeric-like string (like '12'), especially
                     // in the case that visualMap.categories is ['22', '33'].
-                    || (typeof pieceValue === 'string' && pieceValue === value + '')
+                    || (zrUtil.isString(pieceValue) && pieceValue === value + '')
                 ) {
                     return i;
                 }

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -83,7 +83,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
                 if (ecModel.isSeriesFiltered(seriesModel)) {
                     return;
                 }
-                if (typeof seriesModel.enableAriaDecal === 'function') {
+                if (zrUtil.isFunction(seriesModel.enableAriaDecal)) {
                     // Let series define how to use decal palette on data
                     seriesModel.enableAriaDecal();
                     return;
@@ -242,7 +242,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
     }
 
     function replace(str: string, keyValues: object) {
-        if (typeof str !== 'string') {
+        if (!zrUtil.isString(str)) {
             return str;
         }
 

--- a/src/visual/style.ts
+++ b/src/visual/style.ts
@@ -103,10 +103,10 @@ const seriesStyleTask: StageHandler = {
                 globalStyle[colorKey] = colorPalette;
                 data.setVisual('colorFromPalette', true);
             }
-            globalStyle.fill = (globalStyle.fill === 'auto' || typeof globalStyle.fill === 'function')
+            globalStyle.fill = (globalStyle.fill === 'auto' || isFunction(globalStyle.fill))
                 ? colorPalette
                 : globalStyle.fill;
-            globalStyle.stroke = (globalStyle.stroke === 'auto' || typeof globalStyle.stroke === 'function')
+            globalStyle.stroke = (globalStyle.stroke === 'auto' || isFunction(globalStyle.stroke))
                 ? colorPalette
                 : globalStyle.stroke;
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

This PR replaces all `typeof xxx === 'string'`, ``typeof xxx === 'number'``, ``typeof xxx === 'function'`` to `isString`, `isNumber`, `isFunction` utility methods to have neater codes. It reduces 1565 bytes in total after minimized.

And the related benchmark about this change: https://jsbench.me/yskxzuqb9t/1 . Changing inline code to function call won't have performance drop. The interesting thing is some optimizations we did before like caching the typeof result in https://github.com/apache/echarts/blob/master/src/data/helper/dataValueHelper.ts#L158 will lead to worse performance on the chrome. 

This PR also removes circular dependency introduced in https://github.com/apache/echarts/pull/16300
