### PR TITLE
fix(map): some labels won't be shown when legend is enabled and no label formatter specified.

### DIFF
--- a/src/chart/map/MapView.ts
+++ b/src/chart/map/MapView.ts
@@ -173,7 +173,8 @@ class MapView extends ChartView {
                         getFormattedLabel(idx: number, state: DisplayState) {
                             return mapModel.getFormattedLabel(fullIndex, state);
                         }
-                    }
+                    },
+                    defaultText: name
                 });
                 (circle as ECElement).disableLabelAnimation = true;
                 if (!labelModel.get('position')) {

--- a/test/map-china.html
+++ b/test/map-china.html
@@ -39,6 +39,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
 
 
 
@@ -119,7 +120,52 @@ under the License.
         });
         </script>
 
+        <script>
+            require([
+                'echarts',
+                'map/json/china-new.json'
+            ], function (echarts, chinaJson) {
+                var option;
+                echarts.registerMap('china', chinaJson)
 
+                option = {
+                    legend: {
+                        show: true,
+                        data: ['销售额']
+                    },
+                    series: {
+                        name: '销售额',
+                        type: 'map',
+                        map: 'china',
+                        label: {
+                            show: true,
+                            // formatter: '{b}'
+                        },
+                        data: [
+                            {
+                                name: '上海',
+                                value: 506772
+                            },
+                            {
+                                name: '内蒙古',
+                                value: 79776
+                            },
+                            {
+                                name: '台湾',
+                                value: 68885
+                            }
+                        ]
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Should show all labels when legend is enabled and no label formatter specified',
+                    ],
+                    option: option
+                });
+            });
+            </script>
     </body>
 </html>
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

For `map` series, some labels won't be shown when `legend` is enabled and no label formatter specified.

### Fixed issues

- #15649


## Details

### Before: What was the problem?

<img src="https://user-images.githubusercontent.com/26999792/148096351-61df3d79-43bb-4c60-bdc0-dfdf10ad3092.png" width="400">


### After: How is it fixed in this PR?

<img src="https://user-images.githubusercontent.com/26999792/148096281-b8d7d0e2-e160-4697-ac5f-7f1735ba7c6d.png" width="400">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last test case in `test/map-china.html`.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
