### PR TITLE
fix(polar): fix edge symbols are clipped unexpectedly for the tiny offset.

### DIFF
--- a/src/coord/polar/Polar.ts
+++ b/src/coord/polar/Polar.ts
@@ -228,7 +228,8 @@ class Polar implements CoordinateSystem, CoordinateSystemMaster {
                 // Start angle and end angle don't matter
                 const dx = x - this.cx;
                 const dy = y - this.cy;
-                const d2 = dx * dx + dy * dy;
+                // minus a tiny value 1e-4 to avoid being clipped unexpectedly
+                const d2 = dx * dx + dy * dy - 1e-4;
                 const r = this.r;
                 const r0 = this.r0;
 

--- a/test/clip.html
+++ b/test/clip.html
@@ -150,7 +150,7 @@ under the License.
                     }]
                 };
                 var chart = testHelper.create(echarts, 'scatter-clip-polar', {
-                    title: 'Scatter Clip on Polar',
+                    title: ['Scatter Clip on Polar', 'Shrink the page, this red point shouldn\'t be clipped'],
                     option: option,
                     height: 400,
                     buttons: makeToggleChartButtons(function (clip) {

--- a/test/clip.html
+++ b/test/clip.html
@@ -116,6 +116,19 @@ under the License.
                     data1.push([Math.random() * 10, Math.random() * 360]);
                 }
 
+                data1.push({
+                    value: [5, 82],
+                    name: 'This point shouldn\'t be clipped',
+                    itemStyle: {
+                        color: 'red'
+                    },
+                    label: {
+                        show: true,
+                        formatter: '👆{b}👆',
+                        position: 'bottom'
+                    }
+                });
+
                 var option = {
                     polar: {},
                     angleAxis: {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the bug that symbols will be unexpectedly clipped in some scenarios.

### Fixed issues

- #15292
- #16328


## Details

### Comparison

|  Before   | After |
|  :----:  | :----: |
| <img src="https://user-images.githubusercontent.com/26999792/148210620-0ed93113-661d-411b-b9b3-aee922840804.png" height="300"> | <img src="https://user-images.githubusercontent.com/26999792/148210960-2ec93174-3d6f-4b52-86b9-dea519757f95.png" height="300"> |
| <img src="https://user-images.githubusercontent.com/26999792/148211235-edb2cd45-dcb8-4de4-ba8d-8e386860fc35.png" height="300">  | <img src="https://user-images.githubusercontent.com/26999792/148211097-368dece4-db83-448e-9146-e1b79c548bcb.png" height="300"> |
| <img src="https://user-images.githubusercontent.com/26999792/148211305-906ed372-c75d-494c-b7f1-2bd2f656ad1e.png" height="300">  | <img src="https://user-images.githubusercontent.com/26999792/148211311-7105a64b-ee1e-4ac3-8906-c052a3c8adca.png" height="300"> |


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the second test case in `test/clip.html`.

- https://www.makeapie.com/editor.html?c=xNWkC5gbUM&v=1 (#16328)
- https://jsfiddle.net/tks007/hsufw179/11/ (#15292)



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
