### PR TITLE
fix(visual): fix legend modify alpha on transparent color

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -46,8 +46,7 @@ import {
     SymbolOptionMixin
 } from '../../util/types';
 import Model from '../../model/Model';
-import {LineStyleProps, LINE_STYLE_KEY_MAP} from '../../model/mixin/lineStyle';
-import {ITEM_STYLE_KEY_MAP} from '../../model/mixin/itemStyle';
+import {LineStyleProps} from '../../model/mixin/lineStyle';
 import {createSymbol, ECSymbol} from '../../util/symbol';
 import SeriesModel from '../../model/Series';
 
@@ -244,7 +243,7 @@ class LegendView extends ComponentView {
 
                         const idx = provider.indexOfName(name);
 
-                        const style = provider.getItemVisual(idx, 'style') as PathStyleProps;
+                        let style = provider.getItemVisual(idx, 'style') as PathStyleProps;
                         const legendIcon = provider.getItemVisual(idx, 'legendIcon');
 
                         const colorArr = parse(style.fill as ColorString);
@@ -253,7 +252,7 @@ class LegendView extends ComponentView {
                         if (colorArr && colorArr[3] === 0) {
                             colorArr[3] = 0.2;
                             // TODO color is set to 0, 0, 0, 0. Should show correct RGBA
-                            style.fill = stringify(colorArr, 'rgba');
+                            style = zrUtil.extend(zrUtil.extend({}, style), { fill: stringify(colorArr, 'rgba') });
                         }
 
                         const itemGroup = this._createItem(

--- a/test/pie-case.html
+++ b/test/pie-case.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                title: {
+                    text: 'Referer of a Website',
+                    subtext: 'Fake Data',
+                    left: 'center'
+                },
+                tooltip: {
+                    trigger: 'item'
+                },
+                legend: {
+                    orient: 'vertical',
+                    left: 'left'
+                },
+                series: [
+                    {
+                        name: 'Access From',
+                        type: 'pie',
+                        radius: '50%',
+                        data: [
+                            {
+                                value: 1048, name: 'Search Engine'
+                            },
+                            {
+                                value: 300, name: 'Direct'
+                            },
+                            {
+                                value: 1348,
+                                name: 'Placeholder',
+                                itemStyle: {
+                                    color: 'rgba(135,206,250,0)'
+                                }
+                            }
+                        ]
+                    }
+                ]
+            };
+
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Placeholder with color(with alpha 0) should be totally hidden',
+                    'From https://github.com/apache/echarts/issues/16064'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

In the PR https://github.com/apache/echarts/pull/14497/files#diff-57be669601679875d9b233c7dc218568caae93a25cf1585ee5df4129dcfd82a2L248. The `style` object is modified unexpectedly if color is transparent. It will cause the chart can't be totally transparent. This PR cloned a new style to instead of modifying the original to fix this issue.

### Fixed issues

https://github.com/apache/echarts/issues/16064

## Details

### Before: What was the problem?

![image](https://user-images.githubusercontent.com/841551/148505170-7fbd8985-1e46-4061-85eb-ce61b2af5d08.png)

### After: How is it fixed in this PR?

![image](https://user-images.githubusercontent.com/841551/148505185-29283f9f-fdec-41e8-ac77-232eed038023.png)

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
