### PR TITLE
fix(tooltip): fix the page will be frozen if multiple tooltips are provided.

### DIFF
--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -390,6 +390,7 @@ class GlobalModel extends Model<ECUnitOption> {
             let cmptsCountByMainType = 0;
 
             let tooltipExists: boolean;
+            let tooltipWarningLogged: boolean;
 
             each(mappingResult, function (resultItem, index) {
                 let componentModel = resultItem.existing;
@@ -437,7 +438,10 @@ echarts.use([${seriesImportName}]);`);
                     if (mainType === 'tooltip') {
                         if (tooltipExists) {
                             if (__DEV__) {
-                                warn('Currently only one tooltip component is allowed.', !oldCmptList);
+                                if (!tooltipWarningLogged) {
+                                    warn('Currently only one tooltip component is allowed.');
+                                    tooltipWarningLogged = true;
+                                }
                             }
                             return;
                         }

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -61,7 +61,7 @@ import Scheduler from '../core/Scheduler';
 import { concatInternalOptions } from './internalComponentCreator';
 import { LocaleOption } from '../core/locale';
 import {PaletteMixin} from './mixin/palette';
-import { error } from '../util/log';
+import { error, warn } from '../util/log';
 
 export interface GlobalModelSetOptionOpts {
     replaceMerge: ComponentMainType | ComponentMainType[];
@@ -389,6 +389,8 @@ class GlobalModel extends Model<ECUnitOption> {
             const cmptsByMainType = [] as ComponentModel[];
             let cmptsCountByMainType = 0;
 
+            let tooltipExists: boolean;
+
             each(mappingResult, function (resultItem, index) {
                 let componentModel = resultItem.existing;
                 const newCmptOption = resultItem.newOption;
@@ -429,6 +431,18 @@ echarts.use([${seriesImportName}]);`);
                             }
                         }
                         return;
+                    }
+
+                    // Before multiple tooltips get supported,
+                    // we do this check to avoid unexpected exception.
+                    if (mainType === 'tooltip') {
+                        if (tooltipExists) {
+                            if (__DEV__) {
+                                warn('Currently only one tooltip component is allowed.');
+                            }
+                            return;
+                        }
+                        tooltipExists = true;
                     }
 
                     if (componentModel && componentModel.constructor === ComponentModelClass) {

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -433,12 +433,11 @@ echarts.use([${seriesImportName}]);`);
                         return;
                     }
 
-                    // Before multiple tooltips get supported,
-                    // we do this check to avoid unexpected exception.
+                    // TODO Before multiple tooltips get supported, we do this check to avoid unexpected exception.
                     if (mainType === 'tooltip') {
                         if (tooltipExists) {
                             if (__DEV__) {
-                                warn('Currently only one tooltip component is allowed.');
+                                warn('Currently only one tooltip component is allowed.', !oldCmptList);
                             }
                             return;
                         }

--- a/test/tooltip-multiple.html
+++ b/test/tooltip-multiple.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                title: {
+                    text: '折线图堆叠'
+                },
+                tooltip: [{
+                    trigger: 'axis'
+                }, {
+                    trigger: 'item'
+                }],
+                legend: {
+                    data: ['邮件营销', '联盟广告', '视频广告', '直接访问', '搜索引擎']
+                },
+                grid: {
+                    left: '3%',
+                    right: '4%',
+                    bottom: '3%',
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: '邮件营销',
+                        type: 'line',
+                        stack: '总量',
+                        data: [120, 132, 101, 134, 90, 230, 210]
+                    },
+                    {
+                        name: '联盟广告',
+                        type: 'line',
+                        stack: '总量',
+                        data: [220, 182, 191, 234, 290, 330, 310]
+                    },
+                    {
+                        name: '视频广告',
+                        type: 'line',
+                        stack: '总量',
+                        data: [150, 232, 201, 154, 190, 330, 410]
+                    },
+                    {
+                        name: '直接访问',
+                        type: 'line',
+                        stack: '总量',
+                        data: [320, 332, 301, 334, 390, 330, 320]
+                    },
+                    {
+                        name: '搜索引擎',
+                        type: 'line',
+                        stack: '总量',
+                        data: [820, 932, 901, 934, 1290, 1330, 1320]
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'The page shouldn\'t be freezed because of multiple tooltip configurations in the option'
+                ],
+                option: option,
+                buttons: [
+                    {
+                        text: 'Set 1 tooltip',
+                        onclick: function () {
+                            chart.setOption({
+                                tooltip: [
+                                    {
+                                        trigger: 'axis'
+                                    }
+                                ]
+                            });
+                        }
+                    },
+                    {
+                        text: 'Set 2 tooltips',
+                        onclick: function () {
+                            chart.setOption({
+                                tooltip: [{
+                                    trigger: 'axis'
+                                }, {
+                                    trigger: 'item'
+                                }]
+                            });
+                        }
+                    }
+                ]
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/tooltip-multiple.html
+++ b/test/tooltip-multiple.html
@@ -139,6 +139,20 @@ under the License.
                                 }]
                             });
                         }
+                    },
+                    {
+                        text: 'Set 3 tooltips',
+                        onclick: function () {
+                            chart.setOption({
+                                tooltip: [{
+                                    trigger: 'axis'
+                                }, {
+                                    trigger: 'item'
+                                }, {
+
+                                }]
+                            });
+                        }
                     }
                 ]
             });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

- Fix the bug that the page will be frozen if multiple tooltips are provided.
- Give a warning if it's in the development environment.

### Fixed issues

- #6722
- #9152
- #14850
- #16236

## Details

### Before: What was the problem?

As the _**Multiple Tooltip**_ doesn't get supported yet, the page will get frozen if more than one tooltip is provided.


### After: How is it fixed in this PR?

Check if there already exists a tooltip component and avoid creating another one to prevent the tooltip component from falling into an infinite loop that freezes the page.

## Misc

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/tooltip-multiple.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
