### PR TITLE
fix: should check data item in `dataset`

### DIFF
--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -35,7 +35,8 @@ import {
     ModelOption, SeriesDataType, OptionSourceData, SOURCE_FORMAT_TYPED_ARRAY, SOURCE_FORMAT_ORIGINAL,
     DecalObject,
     OrdinalNumber,
-    OrdinalRawValue
+    OrdinalRawValue,
+    SOURCE_FORMAT_OBJECT_ROWS
 } from '../util/types';
 import {convertOptionIdName, isDataItemOption} from '../util/model';
 import { setCommonECData } from '../util/innerStore';
@@ -631,6 +632,7 @@ class SeriesData<
         const idList = this._idList;
         const sourceFormat = provider.getSource().sourceFormat;
         const isFormatOriginal = sourceFormat === SOURCE_FORMAT_ORIGINAL;
+        const isFormatDataset = sourceFormat === SOURCE_FORMAT_OBJECT_ROWS;
 
         // Each data item is value
         // [1, 2]
@@ -640,6 +642,17 @@ class SeriesData<
         // Use a tempValue to normalize the value to be a (x, y) value
         // If dataItem is {name: ...} or {id: ...}, it has highest priority.
         // This kind of ids and names are always stored `_nameList` and `_idList`.
+        if (isFormatDataset) {
+            const sharedDataItem: OptionDataItem = [];
+            for (let idx = start; idx < end; idx++) {
+                // NOTICE: Try not to write things into dataItem
+                const dataItem = provider.getItem(idx, sharedDataItem);
+                if (!this.hasItemOption && isDataItemOption(dataItem)) {
+                    this.hasItemOption = true;
+                }
+            }
+        }
+
         if (isFormatOriginal && !provider.pure) {
             const sharedDataItem = [] as OptionDataItem;
             for (let idx = start; idx < end; idx++) {

--- a/test/pie.html
+++ b/test/pie.html
@@ -326,12 +326,12 @@ under the License.
                         source: [
                             {name: 'a', value: 123},
                             {name: 'b', value: 456},
-                            {name: 'should be selected', value: 789, selected: true}
+                            {name: 'c should be selected', value: 789, selected: true}
                         ]
                     },
                     series: {
                         type: 'pie',
-                        selectedMode: 'multiply'
+                        selectedMode: 'multiple'
                     }
                 };
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

When using `dataset`, it should check data item in value.
https://github.com/apache/echarts/blob/master/src/data/SeriesData.ts#L643
https://github.com/apache/echarts/blob/master/src/model/Series.ts#L618


### Fixed issues

`test/pie.html`


## Details

### Before: What was the problem?

<img width="674" alt="Screen Shot 2022-01-09 at 11 17 31 PM" src="https://user-images.githubusercontent.com/20318608/148688661-f812b531-5024-490f-a0ed-579c730efa0d.png">



### After: How is it fixed in this PR?

<img width="670" alt="Screen Shot 2022-01-09 at 11 16 40 PM" src="https://user-images.githubusercontent.com/20318608/148688674-83f8f23d-2a53-4a2f-9085-8821946fe10e.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/pie.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
