### PR TITLE
fix(lines): use echarts log instead of zrender log.

### DIFF
--- a/src/chart/lines/linesLayout.ts
+++ b/src/chart/lines/linesLayout.ts
@@ -22,7 +22,7 @@
 import createRenderPlanner from '../helper/createRenderPlanner';
 import { StageHandler } from '../../util/types';
 import LinesSeriesModel, {LinesDataItemOption} from './LinesSeries';
-import { logError } from 'zrender/src/core/util';
+import { error } from '../../util/log';
 
 const linesLayout: StageHandler = {
     seriesType: 'lines',
@@ -33,7 +33,7 @@ const linesLayout: StageHandler = {
         const coordSys = seriesModel.coordinateSystem;
         if (!coordSys) {
             if (__DEV__) {
-                logError('The lines series must have a coordinate system.');
+                error('The lines series must have a coordinate system.');
             }
             return;
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Tweak #16184. Use echarts log instead of zrender log.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
