### PR TITLE
fix(boxplot): fix invalid logic that causes incorrect band width when axis type is not `category`.

### DIFF
--- a/src/chart/boxplot/boxplotLayout.ts
+++ b/src/chart/boxplot/boxplotLayout.ts
@@ -90,7 +90,6 @@ function groupSeriesByAxis(ecModel: GlobalModel) {
  * Calculate offset and box width for each series.
  */
 function calculateBase(groupItem: GroupItem) {
-    let extent;
     const baseAxis = groupItem.axis;
     const seriesModels = groupItem.seriesModels;
     const seriesCount = seriesModels.length;
@@ -108,8 +107,8 @@ function calculateBase(groupItem: GroupItem) {
         each(seriesModels, function (seriesModel) {
             maxDataCount = Math.max(maxDataCount, seriesModel.getData().count());
         });
-        extent = baseAxis.getExtent(),
-        Math.abs(extent[1] - extent[0]) / maxDataCount;
+        const extent = baseAxis.getExtent();
+        bandWidth = Math.abs(extent[1] - extent[0]) / maxDataCount;
     }
 
     each(seriesModels, function (seriesModel) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

The current logic makes no sense.

I don't know which commit made this unexpected change. But I think it should be like this previous commit.

https://github.com/apache/echarts/blob/fd771524a0d3b8913745a7ad26d5d5cf98859578/src/chart/candlestick/candlestickLayout.js#L84-L89


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
