### PR TITLE
fix: set sourceHeader=false not work, will auto find sourceHeader(#16…

### DIFF
--- a/src/data/helper/sourceManager.ts
+++ b/src/data/helper/sourceManager.ts
@@ -229,7 +229,7 @@ export class SourceManager {
             const newMetaRawOption = this._getSourceMetaRawOption() || {} as SourceMetaRawOption;
             const upMetaRawOption = upSource && upSource.metaRawOption || {} as SourceMetaRawOption;
             const seriesLayoutBy = retrieve2(newMetaRawOption.seriesLayoutBy, upMetaRawOption.seriesLayoutBy) || null;
-            const sourceHeader = retrieve2(newMetaRawOption.sourceHeader, upMetaRawOption.sourceHeader) || null;
+            const sourceHeader = retrieve2(newMetaRawOption.sourceHeader, upMetaRawOption.sourceHeader);
             // Note here we should not use `upSource.dimensionsDefine`. Consider the case:
             // `upSource.dimensionsDefine` is detected by `seriesLayoutBy: 'column'`,
             // but series need `seriesLayoutBy: 'row'`.


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
if sourceHeader=false
```js
const sourceHeader = retrieve2(newMetaRawOption.sourceHeader, upMetaRawOption.sourceHeader) || null;
```
the sourceHeader will set null. If sourceHeader is null, echarts will find sourceHeader auto.

```js
if (sourceHeader === 'auto' || sourceHeader == null) {
    arrayRowsTravelFirst(function (val) {
        // '-' is regarded as null/undefined.
        if (val != null && val !== '-') {
            if (isString(val)) {
                startIndex == null && (startIndex = 1);
            }
            else {
                startIndex = 0;
            }
        }
    // 10 is an experience number, avoid long loop.
    }, seriesLayoutBy, dataArrayRows, 10);
}
else {
    startIndex = isNumber(sourceHeader) ? sourceHeader : sourceHeader ? 1 : 0;
}
```

### Fixed issues

版本从5.1.2升到5.2.2之后柱状图第一项数据被吞掉 #16343


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/8437666/149616767-a9bc7d1c-7911-4cbf-8e72-e1bb4d884520.png)



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/8437666/149616787-c603ce91-f694-45c4-bc40-462a04866ff4.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
