### PR TITLE
fix(core): avoid error in render breaks following update

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1214,7 +1214,7 @@ class ECharts extends Eventful<ECEventDefinition> {
     resize(opts?: ResizeOpts): void {
         if (this[IN_MAIN_PROCESS_KEY]) {
             if (__DEV__) {
-                error('`setOption` should not be called during main process.');
+                error('`resize` should not be called during main process.');
             }
             return;
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

We use a flag to check if there are unexpected update during another update, which may cause chaos like infinite loop. But currently if there are exceptions during update, the flag will not be cleared and this check keeps fail in the following update. For example if error happens in the callback. 

This PR handles exceptions during update to avoid following setOption or resize fails.



### Fixed issues

https://github.com/apache/echarts/issues/15280