### PR TITLE
fix(scale): fix rounding error when increase interval in align ticks calculation

### DIFF
--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -92,7 +92,7 @@ export function increaseInterval(interval: number) {
     else { // f is 1 or 5
         f *= 2;
     }
-    return f * exp10;
+    return round(f * exp10);
 }
 
 /**


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

The interval will have rounding error when increase interval by multiplying 3. It may happen when `alignTicks` is set true.

## Details

### Before: What was the problem?

![before](https://user-images.githubusercontent.com/841551/150454170-5955e677-9eef-49ae-9abd-4afed9123e54.png)

### After: How is it fixed in this PR?

![after](https://user-images.githubusercontent.com/841551/150454195-b85b3586-9742-4c22-8b9c-ce162b44f16f.png)
