### PR TITLE
tooltip中time类型的字段默认使用的12小时制展示，容易产生困惑，改成24小时制展示

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -82,7 +82,7 @@ export function makeValueReadable(
     valueType: DimensionType,
     useUTC: boolean
 ): string {
-    const USER_READABLE_DEFUALT_TIME_PATTERN = '{yyyy}-{MM}-{dd} {hh}:{mm}:{ss}';
+    const USER_READABLE_DEFUALT_TIME_PATTERN = '{yyyy}-{MM}-{dd} {HH}:{mm}:{ss}';
 
     function stringToUserReadable(str: string): string {
         return (str && zrUtil.trim(str)) ? str : '-';


### PR DESCRIPTION
## Brief Information
tooltip中time类型的字段默认使用的12小时制展示，容易产生困惑，应改成24小时制展示

### Before: What was the problem?
time类型在tooltip中以12小时制展示，实际数据是：2018-10-23 23:40:00
![企业微信截图_164307290249](https://user-images.githubusercontent.com/5416227/150892561-22e6f20a-483d-4576-ae0d-490fdabdd7f6.png)

### After: How is it fixed in this PR?
修复后，time类型在tooltip中以24小时制展示
![企业微信截图_16430729491532](https://user-images.githubusercontent.com/5416227/150892640-22489594-e2b2-4e15-b04d-a469b11173a9.png)
