### PR TITLE
fix(sunburst) set the position of label in center when angle is 2π. c…

### DIFF
--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -1,4 +1,5 @@
 /*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
@@ -219,7 +220,13 @@ class SunburstPiece extends graphic.Sector {
             }
             else {
                 if (!textAlign || textAlign === 'center') {
-                    r = (layout.r + layout.r0) / 2;
+                    // set the position of label in center when angle is 2π & r0 is 0
+                    if (angle === 2 * Math.PI && layout.r0 === 0) {
+                        r = 0;
+                    }
+                    else {
+                        r = (layout.r + layout.r0) / 2;
+                    }
                     textAlign = 'center';
                 }
                 else if (textAlign === 'left') {
@@ -239,15 +246,8 @@ class SunburstPiece extends graphic.Sector {
             state.style.align = textAlign;
             state.style.verticalAlign = getLabelAttr(labelStateModel, 'verticalAlign') || 'middle';
 
-            // set the position of label in center when angle is 2π & r0 is 0
-            if (textAlign === 'center' && angle === 2 * Math.PI && layout.r0 === 0) {
-                state.x = layout.cx;
-                state.y = layout.cy;
-            }
-            else {
-                state.x = r * dx + layout.cx;
-                state.y = r * dy + layout.cy;
-            }
+            state.x = r * dx + layout.cx;
+            state.y = r * dy + layout.cy;
 
             const rotateType = getLabelAttr(labelStateModel, 'rotate');
             let rotate = 0;

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -1,5 +1,4 @@
 /*
-/*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -239,8 +239,8 @@ class SunburstPiece extends graphic.Sector {
             state.style.align = textAlign;
             state.style.verticalAlign = getLabelAttr(labelStateModel, 'verticalAlign') || 'middle';
 
-            // set the position of label in center when angle is 2π
-            if (textAlign === 'center' && angle === 2 * Math.PI) {
+            // set the position of label in center when angle is 2π & r0 is 0
+            if (textAlign === 'center' && angle === 2 * Math.PI && layout.r0 === 0) {
                 state.x = layout.cx;
                 state.y = layout.cy;
             }

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -239,8 +239,15 @@ class SunburstPiece extends graphic.Sector {
             state.style.align = textAlign;
             state.style.verticalAlign = getLabelAttr(labelStateModel, 'verticalAlign') || 'middle';
 
-            state.x = r * dx + layout.cx;
-            state.y = r * dy + layout.cy;
+            // set the position of label in center when angle is 2π
+            if (textAlign === 'center' && angle === 2 * Math.PI) {
+                state.x = layout.cx;
+                state.y = layout.cy;
+            }
+            else {
+                state.x = r * dx + layout.cx;
+                state.y = r * dy + layout.cy;
+            }
 
             const rotateType = getLabelAttr(labelStateModel, 'rotate');
             let rotate = 0;

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -219,7 +219,7 @@ class SunburstPiece extends graphic.Sector {
             }
             else {
                 if (!textAlign || textAlign === 'center') {
-                    // set the position of label in center when angle is 2π & r0 is 0
+                    // Put label in the center if it's a circle
                     if (angle === 2 * Math.PI && layout.r0 === 0) {
                         r = 0;
                     }

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            var data = [{
+                name: 'sum',
+                children: [{
+                    name:'text1',
+                    value: 42,
+                    itemStyle: {
+                        color: 'blue'
+                    },
+                    children: [{
+                        name:'other',
+                        value: 42,
+                        itemStyle: {
+                            color: 'red'
+                        }
+                    }]
+                }, {
+                    name:'text2',
+                    value: 91,
+                    itemStyle: {
+                        color: 'green'
+                    },
+                    children: [{
+                        name:'other',
+                        value: 91,
+                        itemStyle: {
+                            color: 'orange'
+                        }
+                    }]
+                }]
+            }];
+
+            option = {
+                series: {
+                    radius: ['0%', '80%'],
+                    type: 'sunburst',
+                    sort: null,
+                    highlightPolicy: 'ancestor',
+                    nodeClick: 'false',
+                    data: data,
+                    levels: [
+                        {},
+                        {
+                            label: {align: 'center', rotate: 0}
+                        }
+                    ]
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Set the position of label in center when angle is 2π'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -102,7 +102,7 @@ under the License.
 
             var chart = testHelper.create(echarts, 'main0', {
                 title: [
-                    'Set the position of label in center when angle is 2π'
+                    'Put label in the center if it\'s a circle'
                 ],
                 option: option
                 // height: 300,


### PR DESCRIPTION
…lose #16296

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fix a bug that the Sunburst center text cannot be centered vertically.
<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->
https://github.com/apache/echarts/issues/16296

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
when the sector's angle is 2π, and inner radius is 0(which means at the first level). the position of label cannot be the center of the circle, which lead to the text of label cannot be centered vertically in Sunburst.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/17442959/150936933-a4642d18-a6cf-4654-bb96-ba8596b38864.png)


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
set the position of label in center when angle is 2π and inner radius is 0 so that the text of label can be centered vertically in Sunburst.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/17442959/150938306-fb6c9f44-6364-462d-814f-c1e7c5a4cd9b.png)



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
