### PR TITLE
fix(graphic): fix `cursor` doesn't work in `graphic` component.

### DIFF
--- a/src/component/graphic/GraphicView.ts
+++ b/src/component/graphic/GraphicView.ts
@@ -441,7 +441,10 @@ function updateCommonAttrs(
 ) {
     if (!el.isGroup) {
         const elDisplayable = el as Displayable;
-        elDisplayable.cursor = (elOption as GraphicComponentDisplayableOption).cursor;
+        elDisplayable.cursor = zrUtil.retrieve2(
+            (elOption as GraphicComponentDisplayableOption).cursor,
+            Displayable.prototype.cursor
+        );
         // We should not support configure z and zlevel in the element level.
         // But seems we didn't limit it previously. So here still use it to avoid breaking.
         elDisplayable.z = zrUtil.retrieve2(

--- a/src/component/graphic/GraphicView.ts
+++ b/src/component/graphic/GraphicView.ts
@@ -441,10 +441,17 @@ function updateCommonAttrs(
 ) {
     if (!el.isGroup) {
         const elDisplayable = el as Displayable;
+        elDisplayable.cursor = (elOption as GraphicComponentDisplayableOption).cursor;
         // We should not support configure z and zlevel in the element level.
         // But seems we didn't limit it previously. So here still use it to avoid breaking.
-        elDisplayable.z = zrUtil.retrieve2((elOption as any).z, defaultZ || 0);
-        elDisplayable.zlevel = zrUtil.retrieve2((elOption as any).zlevel, defaultZlevel || 0);
+        elDisplayable.z = zrUtil.retrieve2(
+            (elOption as GraphicComponentDisplayableOption).z,
+            defaultZ || 0
+        );
+        elDisplayable.zlevel = zrUtil.retrieve2(
+            (elOption as GraphicComponentDisplayableOption).zlevel,
+            defaultZlevel || 0
+        );
         // z2 must not be null/undefined, otherwise sort error may occur.
         const optZ2 = (elOption as GraphicComponentDisplayableOption).z2;
         optZ2 != null && (elDisplayable.z2 = optZ2 || 0);

--- a/test/graphic-cases.html
+++ b/test/graphic-cases.html
@@ -40,7 +40,7 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
-
+        <div id="main3"></div>
 
 
 
@@ -220,6 +220,61 @@ under the License.
             });
             </script>
 
+        <script>
+             require(['echarts'], function (echarts) {
+                var option = {
+                    graphic:{
+                        elements: [{
+                            type: 'group',
+                            left: '10%',
+                            top: 'center',
+                            draggable: true,
+                            children: [{
+                                type: 'rect',
+                                z: 100,
+                                left: 'center',
+                                top: 'middle',
+                                shape: {
+                                    width: 240,
+                                    height: 90
+                                },
+                                style: {
+                                    fill: 'gray',
+                                    stroke: '#555',
+                                    lineWidth: 1,
+                                    shadowBlur: 8,
+                                    shadowOffsetX: 3,
+                                    shadowOffsetY: 3,
+                                    shadowColor: 'rgba(0,0,0,0.2)'
+                                },
+                                cursor: 'move',
+                            }, {
+                                type: 'text',
+                                z: 100,
+                                left: 'center',
+                                top: 'middle',
+                                style: {
+                                    fill: '#000',
+                                    width: 220,
+                                    overflow: 'break',
+                                    text: 'the value of cursor prop is "default", it looks well on version 5.1.1. Replace echarts version with 5.3.0, the mouse will still be a pointer',
+                                    font: '14px Microsoft YaHei'
+                                },
+                                cursor: 'help',
+                            }]
+                        }]
+                    }
+                };
+                var chart = testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Cursor should be **move** when hovering on the rect',
+                        'Cursor should be **help** when hovering on the text',
+                        'See https://github.com/apache/echarts/issues/16511'
+                    ],
+                    option: option
+                });
+             });
+        </script>
     </body>
 </html>
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the bug that `cursor` doesn't work in `graphic` component.

### Fixed issues

- #16511


## Details

### Before: What was the problem?

<img src="https://user-images.githubusercontent.com/26999792/154065718-c8afc7a8-3032-423d-8869-6cb1d4255a0a.gif" width="300">


### After: How is it fixed in this PR?

<img src="https://user-images.githubusercontent.com/26999792/154065746-c8da5ded-afd0-4d91-8de4-bb73d10dcd26.gif" width="300">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last case in `test/graphic-cases.html`.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

`Group` doesn't support `cursor`/`invisible`/`progressive` as they are only for a single element. We should remove these options from our documentation.

