### PR TITLE
perf(lines): fix potential memory leak in the effect line when setOption with notMerge

### DIFF
--- a/src/chart/helper/EffectLine.ts
+++ b/src/chart/helper/EffectLine.ts
@@ -117,8 +117,6 @@ class EffectLine extends graphic.Group {
             return;
         }
 
-        const self = this;
-
         const points = lineData.getItemLayout(idx);
 
         let period = effectModel.get('period') * 1000;
@@ -138,40 +136,46 @@ class EffectLine extends graphic.Group {
         }
 
         if (period !== this._period || loop !== this._loop) {
-
             symbol.stopAnimation();
-
-            if (period > 0) {
-                let delayNum: number;
-                if (zrUtil.isFunction(delayExpr)) {
-                    delayNum = delayExpr(idx);
-                }
-                else {
-                    delayNum = delayExpr;
-                }
-                if (symbol.__t > 0) {
-                    delayNum = -period * symbol.__t;
-                }
-                symbol.__t = 0;
-                const animator = symbol.animate('', loop)
-                    .when(period, {
-                        __t: 1
-                    })
-                    .delay(delayNum)
-                    .during(function () {
-                        self._updateSymbolPosition(symbol);
-                    });
-                if (!loop) {
-                    animator.done(function () {
-                        self.remove(symbol);
-                    });
-                }
-                animator.start();
+            let delayNum: number;
+            if (zrUtil.isFunction(delayExpr)) {
+                delayNum = delayExpr(idx);
             }
+            else {
+                delayNum = delayExpr;
+            }
+            if (symbol.__t > 0) {
+                delayNum = -period * symbol.__t;
+            }
+
+            this._animateSymbol(
+                symbol, period, delayNum, loop
+            );
         }
 
         this._period = period;
         this._loop = loop;
+    }
+
+    private _animateSymbol(symbol: ECSymbolOnEffectLine, period: number, delayNum: number, loop: boolean) {
+        if (period > 0) {
+            symbol.__t = 0;
+            const self = this;
+            const animator = symbol.animate('', loop)
+                .when(period, {
+                    __t: 1
+                })
+                .delay(delayNum)
+                .during(function () {
+                    self._updateSymbolPosition(symbol);
+                });
+            if (!loop) {
+                animator.done(function () {
+                    self.remove(symbol);
+                });
+            }
+            animator.start();
+        }
     }
 
     protected _getLineLength(symbol: ECSymbolOnEffectLine) {

--- a/src/chart/helper/Symbol.ts
+++ b/src/chart/helper/Symbol.ts
@@ -23,7 +23,7 @@ import {getECData} from '../../util/innerStore';
 import { enterEmphasis, leaveEmphasis, toggleHoverEmphasis } from '../../util/states';
 import {getDefaultLabel} from './labelHelper';
 import SeriesData from '../../data/SeriesData';
-import { ColorString, BlurScope, AnimationOption, ZRColor } from '../../util/types';
+import { ColorString, BlurScope, AnimationOption, ZRColor, AnimationOptionMixin } from '../../util/types';
 import SeriesModel from '../../model/Series';
 import { PathProps } from 'zrender/src/graphic/Path';
 import { SymbolDrawSeriesScope, SymbolDrawItemModelOption } from './SymbolDraw';
@@ -31,6 +31,7 @@ import { extend } from 'zrender/src/core/util';
 import { setLabelStyle, getLabelStatesModels } from '../../label/labelStyle';
 import ZRImage from 'zrender/src/graphic/Image';
 import { saveOldStyle } from '../../animation/basicTrasition';
+import Model from '../../model/Model';
 
 type ECSymbol = ReturnType<typeof createSymbol>;
 
@@ -42,8 +43,6 @@ interface SymbolOpts {
 }
 
 class Symbol extends graphic.Group {
-
-    private _seriesModel: SeriesModel;
 
     private _symbolType: string;
 
@@ -201,8 +200,6 @@ class Symbol extends graphic.Group {
             // Must stop leave transition manually if don't call initProps or updateProps.
             this.childAt(0).stopAnimation('leave');
         }
-
-        this._seriesModel = seriesModel;
     }
 
     _updateCommon(
@@ -353,12 +350,11 @@ class Symbol extends graphic.Group {
         this.scaleX = this.scaleY = scale;
     }
 
-    fadeOut(cb: () => void, opt?: {
+    fadeOut(cb: () => void, seriesModel: Model<AnimationOptionMixin>, opt?: {
         fadeLabel: boolean,
         animation?: AnimationOption
     }) {
         const symbolPath = this.childAt(0) as ECSymbol;
-        const seriesModel = this._seriesModel;
         const dataIndex = getECData(this).dataIndex;
         const animationOpt = opt && opt.animation;
         // Avoid mistaken hover when fading out

--- a/src/chart/helper/SymbolDraw.ts
+++ b/src/chart/helper/SymbolDraw.ts
@@ -40,6 +40,7 @@ import Model from '../../model/Model';
 import { ScatterSeriesOption } from '../scatter/ScatterSeries';
 import { getLabelStatesModels } from '../../label/labelStyle';
 import Element from 'zrender/src/Element';
+import SeriesModel from '../../model/Series';
 
 interface UpdateOpt {
     isIgnore?(idx: number): boolean
@@ -51,7 +52,7 @@ interface UpdateOpt {
 
 interface SymbolLike extends graphic.Group {
     updateData(data: SeriesData, idx: number, scope?: SymbolDrawSeriesScope, opt?: UpdateOpt): void
-    fadeOut?(cb: () => void): void
+    fadeOut?(cb: () => void, seriesModel: SeriesModel): void
 }
 
 interface SymbolLikeCtor {
@@ -252,7 +253,7 @@ class SymbolDraw {
                 const el = oldData.getItemGraphicEl(oldIdx) as SymbolLike;
                 el && el.fadeOut(function () {
                     group.remove(el);
-                });
+                }, seriesModel as SeriesModel);
             })
             .execute();
 
@@ -319,7 +320,7 @@ class SymbolDraw {
             data.eachItemGraphicEl(function (el: SymbolLike) {
                 el.fadeOut(function () {
                     group.remove(el);
-                });
+                }, data.hostModel as SeriesModel);
             });
         }
         else {

--- a/src/chart/tree/TreeView.ts
+++ b/src/chart/tree/TreeView.ts
@@ -706,7 +706,7 @@ function removeNode(
         removeOpt: removeAnimationOpt
     });
 
-    symbolEl.fadeOut(null, {
+    symbolEl.fadeOut(null, data.hostModel as TreeSeriesModel, {
         fadeLabel: true,
         animation: removeAnimationOpt
     });

--- a/test/lib/testHelper.js
+++ b/test/lib/testHelper.js
@@ -174,7 +174,7 @@
         initRecordCanvas(opt, chart, recordCanvasContainer);
 
         if (opt.recordVideo) {
-testHelper.createRecordVideo(chart, recordVideoContainer);
+            testHelper.createRecordVideo(chart, recordVideoContainer);
         }
 
         chart.__testHelper = {

--- a/test/lib/testHelper.js
+++ b/test/lib/testHelper.js
@@ -174,7 +174,7 @@
         initRecordCanvas(opt, chart, recordCanvasContainer);
 
         if (opt.recordVideo) {
-            initRecordVideo(chart, recordVideoContainer);
+testHelper.createRecordVideo(chart, recordVideoContainer);
         }
 
         chart.__testHelper = {
@@ -238,7 +238,7 @@
         }
     }
 
-    function initRecordVideo(chart, recordVideoContainer) {
+    testHelper.createRecordVideo = function (chart, recordVideoContainer) {
         var button = document.createElement('button');
         button.innerHTML = 'Start Recording';
         recordVideoContainer.appendChild(button);

--- a/test/node/ssr.js
+++ b/test/node/ssr.js
@@ -29,7 +29,7 @@ chart.setOption({
         {
             name: 'Nightingale Chart',
             type: 'pie',
-            radius: [25, 250],
+            radius: [50, 250],
             center: ['50%', '50%'],
             roseType: 'radius',
             label: {
@@ -49,18 +49,18 @@ chart.setOption({
                 return (1 - idx / 8) * 500;
             },
             data: [
-                { value: 40, name: 'rose 1', itemStyle: { borderRadius: [0, 20] } },
-                { value: 32, name: 'rose 2', itemStyle: { borderRadius: [0, 18] } },
-                { value: 28, name: 'rose 3', itemStyle: { borderRadius: [0, 16] } },
-                { value: 24, name: 'rose 4', itemStyle: { borderRadius: [0, 14] } },
-                { value: 19, name: 'rose 5', itemStyle: { borderRadius: [0, 12] } },
-                { value: 15, name: 'rose 6', itemStyle: { borderRadius: [0, 10] } },
-                { value: 12, name: 'rose 7', itemStyle: { borderRadius: [0, 8] } },
-                { value: 10, name: 'rose 8', itemStyle: { borderRadius: [0, 6] } },
+                { value: 40, name: 'rose 1', itemStyle: { borderRadius: [5, 20] } },
+                { value: 32, name: 'rose 2', itemStyle: { borderRadius: [5, 18] } },
+                { value: 28, name: 'rose 3', itemStyle: { borderRadius: [5, 16] } },
+                { value: 24, name: 'rose 4', itemStyle: { borderRadius: [5, 14] } },
+                { value: 19, name: 'rose 5', itemStyle: { borderRadius: [5, 12] } },
+                { value: 15, name: 'rose 6', itemStyle: { borderRadius: [5, 10] } },
+                { value: 12, name: 'rose 7', itemStyle: { borderRadius: [5, 8] } },
+                { value: 10, name: 'rose 8', itemStyle: { borderRadius: [5, 6] } },
             ],
         },
     ],
 });
-const str = chart.renderToString();
+const str = chart.renderToSVGString();
 console.log(str);
 chart.dispose();


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [] others



### What does this PR do?

Reproduce demo of memory leak demo: https://uzedc5.csb.app/map-random.html

When we using setOption with notMerge. The model will be recreated but view will be reused. And the graphic elements in the view are also reused so we can apply transition animations easily.

In this case memory leaks happens in https://github.com/apache/echarts/blob/e4bdd30ea1a751fdb583367ff29fa122ba27be7d/src/chart/helper/EffectLine.ts#L162. The looped animation of graphic elements will be keeped when updating. It also keeps the closure of during callback. Which includes the old `lineData`:

<img width="210" alt="image" src="https://user-images.githubusercontent.com/841551/154411133-34b2339b-dc77-4aed-a623-cc0ef0cf901a.png">

I still can't figure out why this `lineData` will be kept in the closure because there is no code using it in the during callback.  Current workaroud is move the code of updating animation to a new function.

Another improvement is removing the unnecessary hold of `SeriesModel` instance in the graphic elements in https://github.com/apache/echarts/blob/e4bdd30ea1a751fdb583367ff29fa122ba27be7d/src/chart/helper/Symbol.ts#L46 It won't cause memory leak now, but this change can optimize the memory a bit.


## Details

### Before: What was the problem?

The instances of `SeriesData` and `SeriesModel` in memory will increase each time `setOption` in the above case.


### After: How is it fixed in this PR?

The  instance numbers of `SeriesData` and `SeriesModel` is stable.

