### PR TITLE
feat(chart): support negative values in logarithmic axes

### DIFF
--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -36,8 +36,27 @@ const roundingErrorFix = numberUtil.round;
 const mathFloor = Math.floor;
 const mathCeil = Math.ceil;
 const mathPow = Math.pow;
-
 const mathLog = Math.log;
+
+/**
+ * symmetric log, allowing negative values for logarithmic scales
+ */
+function symMathLog(x: number): number {
+    if (x >= 0) {
+        return mathLog(x);
+    }
+    return -mathLog(-x);
+}
+
+/**
+ * symmetric pow, allowing negative values for logarithmic scales
+ */
+function symMathPow(x: number, y: number): number {
+    if (y >= 0) {
+        return mathPow(x, y);
+    }
+    return -mathPow(x, -y);
+}
 
 class LogScale extends Scale {
     static type = 'log';
@@ -68,7 +87,7 @@ class LogScale extends Scale {
 
         return zrUtil.map(ticks, function (tick) {
             const val = tick.value;
-            let powVal = numberUtil.round(mathPow(this.base, val));
+            let powVal = numberUtil.round(symMathPow(this.base, val));
 
             // Fix #4158
             powVal = (val === extent[0] && this._fixMin)
@@ -86,8 +105,8 @@ class LogScale extends Scale {
 
     setExtent(start: number, end: number): void {
         const base = this.base;
-        start = mathLog(start) / mathLog(base);
-        end = mathLog(end) / mathLog(base);
+        start = symMathLog(start) / mathLog(base);
+        end = symMathLog(end) / mathLog(base);
         intervalScaleProto.setExtent.call(this, start, end);
     }
 
@@ -97,8 +116,8 @@ class LogScale extends Scale {
     getExtent() {
         const base = this.base;
         const extent = scaleProto.getExtent.call(this);
-        extent[0] = mathPow(base, extent[0]);
-        extent[1] = mathPow(base, extent[1]);
+        extent[0] = symMathPow(base, extent[0]);
+        extent[1] = symMathPow(base, extent[1]);
 
         // Fix #4158
         const originalScale = this._originalScale;
@@ -113,8 +132,8 @@ class LogScale extends Scale {
         this._originalScale.unionExtent(extent);
 
         const base = this.base;
-        extent[0] = mathLog(extent[0]) / mathLog(base);
-        extent[1] = mathLog(extent[1]) / mathLog(base);
+        extent[0] = symMathLog(extent[0]) / mathLog(base);
+        extent[1] = symMathLog(extent[1]) / mathLog(base);
         scaleProto.unionExtent.call(this, extent);
     }
 
@@ -176,18 +195,18 @@ class LogScale extends Scale {
     }
 
     contain(val: number): boolean {
-        val = mathLog(val) / mathLog(this.base);
+        val = symMathLog(val) / mathLog(this.base);
         return scaleHelper.contain(val, this._extent);
     }
 
     normalize(val: number): number {
-        val = mathLog(val) / mathLog(this.base);
+        val = symMathLog(val) / mathLog(this.base);
         return scaleHelper.normalize(val, this._extent);
     }
 
     scale(val: number): number {
         val = scaleHelper.scale(val, this._extent);
-        return mathPow(this.base, val);
+        return symMathPow(this.base, val);
     }
 
     getMinorTicks: IntervalScale['getMinorTicks'];

--- a/test/bar-log-negative.html
+++ b/test/bar-log-negative.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            .test-title {
+                background: #146402;
+                color: #fff;
+            }
+        </style>
+
+
+        <div id="main0"></div>
+
+        <script>
+
+            // See <https://github.com/ecomfe/echarts/issues/7412>
+            // Thanks to <https://github.com/CrazyShipOne>
+
+            var chart;
+            var myChart;
+            var option;
+
+            require([
+                'echarts'/*, 'map/js/china' */
+            ], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'log'
+                    },
+                    series: [{
+                        data: [820, 932, 901, -934, 1290, 1330, 1320],
+                        type: 'bar'
+                    },{
+                        data: [820, 932, 901, -934, 1290, 1330, 1320],
+                        type: 'line'
+                    }]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main0', {
+                    title: 'bar with negative log axis',
+                    option: option,
+                    info: option
+                });
+            });
+
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
The logarithm of negative values is not defined.
However, in the case of a logarithmic chart axis, it makes sense to
define log(-x) as -log(x), to support logarithmic axes with negative
values.

Cf. 'symlog' in matplotlib

Resolves: #15558

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [X] new feature
- [ ] others



### What does this PR do?

Supports negative values in logarithmic axes.



### Fixed issues

- #15558


## Details

### Before: What was the problem?

Axes with logarithmic scales didn't support negative values, because `Math.log()` of a negative number is undefined (`NaN`). Therefore the ticks on the yAxis disappeared entirely.



### After: How is it fixed in this PR?

Negative values for logarithmic scales work by defining `log(-x) = -log(x)` and negative values are shown on logarithmic axes.



## Misc

### Related test cases or examples to use the new APIs

`test/bar-log-negative.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
