### PR TITLE
fix: the histogram cannot be displayed normally due to the problem of NaN data

### DIFF
--- a/test/bar.html
+++ b/test/bar.html
@@ -61,7 +61,7 @@ under the License.
 
                 for (var i = 0; i < 10; i++) {
                     xAxisData.push('类目' + i);
-                    data1.push(i === 0 ? '-' : (Math.random() * 5).toFixed(2));
+                    data1.push((Math.random() * 5).toFixed(2));
                     data2.push(-Math.random().toFixed(2));
                     data3.push((Math.random() + 0.5).toFixed(2));
                     data4.push((Math.random() + 0.3).toFixed(2));


### PR DESCRIPTION
In the bar example, the histogram cannot be displayed normally due to the problem of Nan data

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Due to the data like '-' in the test code, it becomes NaN when converted to numerical value, so that the histogram cannot be displayed

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<img width="411" alt="截屏2022-02-22 下午7 38 38" src="https://user-images.githubusercontent.com/36806217/155127929-eca9d39f-9700-4fbb-a5e0-fa61ce43a026.png">
<img width="623" alt="截屏2022-02-22 下午7 54 23" src="https://user-images.githubusercontent.com/36806217/155127990-e76730a1-1990-4d74-8cc6-065d21a4be16.png">



### After: How is it fixed in this PR?

modify code `data1.push(i === 0 ? '-' : (Math.random() * 5).toFixed(2));` to `data1.push((Math.random() * 5).toFixed(2));`
<img width="523" alt="截屏2022-02-22 下午8 02 30" src="https://user-images.githubusercontent.com/36806217/155128485-b0d12ed5-e1ab-44cd-9a6b-1fe15389a4a1.png">

<img width="608" alt="截屏2022-02-22 下午7 53 58" src="https://user-images.githubusercontent.com/36806217/155128017-bacf84df-b94a-439a-a03f-b1fa32dc8acb.png">
### Fixed issues



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
