### PR TITLE
fix: add an option to ensure the markPoint always show (close: #16591)

### DIFF
--- a/src/component/marker/MarkerModel.ts
+++ b/src/component/marker/MarkerModel.ts
@@ -79,6 +79,11 @@ export interface MarkerPositionOption {
      * Value to be displayed as label. Totally optional
      */
     value?: string | number
+
+    /**
+     * always show the point even out of the range
+     */
+    isAlwaysShow?: boolean
 }
 
 export interface MarkerOption extends ComponentOption, AnimationOptionMixin {

--- a/test/markPointAlwaysShow.html
+++ b/test/markPointAlwaysShow.html
@@ -1,0 +1,68 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body, #main {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+        <div id="chart1" style="position: relative; overflow: hidden; width: 380px; height: 200px; cursor: default;"></div> <div id="chart2" style="position: relative; overflow: hidden; width: 380px; height: 200px; cursor: default;"></div>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                function makeChartBars(chartDom) {
+                    const volumes = [];
+
+                    const option = {
+                        xAxis: {
+                            type: "category",
+                            data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+                        },
+                        yAxis: {},
+                        series: [{
+                            data: [820, 932, 901, 934, 1290, 1330, 1320],
+                            type: "line",
+                            markPoint: {
+                                data: [{
+                                    value: 3000,
+                                    xAxis: 3,
+                                    yAxis: 3000,
+                                    isAlwaysShow: true // set this option to show the point constantly.
+                                }]
+                            }
+                        }]
+                    };
+                    const barChart = echarts.init(chartDom, null)
+                    barChart.setOption(option)
+                }
+                makeChartBars(document.getElementById('chart1'));
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information
fix: add an option to ensure the markPoint always show (close: #16591)
This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

When we calculate the extent of the scale. We alse need to consider the mark points.

Through adding `isAlwaysShow` option, we can optional consider mark point. If this option is setted to true, these mark points will always in the range of scale.extent.

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

```
{
      xAxis: {
          type: "category",
          data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
      },
      yAxis: {},
      series: [{
          data: [820, 932, 901, 934, 1290, 1330, 1320],
          type: "line",
          markPoint: {
              data: [{
                  value: 3000,
                  xAxis: 3,
                  yAxis: 3000,
                  isAlwaysShow: true // set this option to show the point constantly.
              }]
          }
      }]
  }
```

consider above option.
The mark point is obviously out of the extent rang.
before:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/33452468/156143332-77732038-8c74-468a-ab81-1a06de7760e9.png">

after:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/33452468/156142945-df4d9e68-fe66-4d69-9153-951841742a03.png">



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
