### PR TITLE
fix(sanky):fallback to black if color were illegal

### DIFF
--- a/src/visual/VisualMapping.ts
+++ b/src/visual/VisualMapping.ts
@@ -698,7 +698,7 @@ function setVisualToOption(thisOption: VisualMappingInnerOption, visualArr: Visu
             if (!color && __DEV__) {
                 warn(`'${item}' is an illegal color, fallback to '#000000'`, true);
             }
-            return zrColor.parse(item) || [0, 0, 0, 1];
+            return color || [0, 0, 0, 1];
         });
     }
     return visualArr;

--- a/src/visual/VisualMapping.ts
+++ b/src/visual/VisualMapping.ts
@@ -28,6 +28,7 @@ import {
     VisualOptionUnit,
     ParsedValue
 } from '../util/types';
+import { warn } from '../util/log';
 
 const each = zrUtil.each;
 const isObject = zrUtil.isObject;
@@ -693,7 +694,11 @@ function setVisualToOption(thisOption: VisualMappingInnerOption, visualArr: Visu
     thisOption.visual = visualArr;
     if (thisOption.type === 'color') {
         thisOption.parsedVisual = zrUtil.map(visualArr, function (item: string) {
-            return zrColor.parse(item);
+            const color = zrColor.parse(item);
+            if (!color && __DEV__) {
+                warn(`'${item}' is an illegal color, fallback to '#000000'`, true);
+            }
+            return zrColor.parse(item) || [0, 0, 0, 1];
         });
     }
     return visualArr;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

if `zrColor.parse` returns `undefiend`, use `#000` as default color



### Fixed issues

- Close #16574

## Details

### Before: What was the problem?

<img width="626" alt="Screen Shot 2022-03-02 at 10 31 52 PM" src="https://user-images.githubusercontent.com/20318608/156381658-48d7f96a-edb0-47dd-b4ff-c62826a1f9c2.png">




### After: How is it fixed in this PR?

<img width="1413" alt="Screen Shot 2022-03-02 at 10 31 19 PM" src="https://user-images.githubusercontent.com/20318608/156381586-d2a5f199-ff97-4967-913c-773e50de210c.png">




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
