### PR TITLE
fix(gauge): fix progress bar may become unexpectedly circle when value is `0` and `progress.roundCap` is enabled.

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -33,6 +33,7 @@ import {createSymbol} from '../../util/symbol';
 import ZRImage from 'zrender/src/graphic/Image';
 import {extend, isFunction, isString} from 'zrender/src/core/util';
 import {setCommonECData} from '../../util/innerStore';
+import { normalizeArcAngles } from 'zrender/src/core/PathProxy';
 
 type ECSymbol = ReturnType<typeof createSymbol>;
 
@@ -71,8 +72,6 @@ function formatLabel(value: number, labelFormatter: string | ((value: number) =>
 
     return label;
 }
-
-const PI2 = Math.PI * 2;
 
 class GaugeView extends ChartView {
     static type = 'gauge' as const;
@@ -119,8 +118,12 @@ class GaugeView extends ChartView {
         const showAxis = axisLineModel.get('show');
         const lineStyleModel = axisLineModel.getModel('lineStyle');
         const axisLineWidth = lineStyleModel.get('width');
-        const angleRangeSpan = !((endAngle - startAngle) % PI2) && endAngle !== startAngle
-            ? PI2 : (endAngle - startAngle) % PI2;
+
+        const angles = [startAngle, endAngle];
+        normalizeArcAngles(angles, !clockwise);
+        startAngle = angles[0];
+        endAngle = angles[1];
+        const angleRangeSpan = endAngle - startAngle;
 
         let prevEndAngle = startAngle;
 
@@ -172,12 +175,6 @@ class GaugeView extends ChartView {
             // More than 1
             return colorList[i - 1][1];
         };
-
-        if (!clockwise) {
-            const tmp = startAngle;
-            startAngle = endAngle;
-            endAngle = tmp;
-        }
 
         this._renderTicks(
             seriesModel, ecModel, api, getColor, posInfo,

--- a/test/gauge-case.html
+++ b/test/gauge-case.html
@@ -37,8 +37,8 @@ under the License.
 
 
         <div id="main0"></div>
-
-
+        <div id="main1"></div>
+        <div id="main2"></div>
 
 
         <script>
@@ -85,6 +85,67 @@ under the License.
             });
 
         });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    series: [{
+                        type: 'gauge',
+                        startAngle: 200,
+                        endAngle: -20,
+                        clockwise: true,
+                        data: [
+                            {
+                                value: 0,
+                                name: 'SCORE'
+                                }
+                        ],
+                        progress: {
+                            show: true,
+                            roundCap: true
+                        }
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Should not display a circle',
+                        'Test case from #16640 (simplified)'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    series: [{
+                        type: 'gauge',
+                        startAngle: 200,
+                        endAngle: -20,
+                        clockwise: false,
+                        data: [
+                            {
+                                value: 0,
+                                name: 'SCORE'
+                            }
+                        ],
+                        progress: {
+                            show: true,
+                            roundCap: true
+                        }
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Ticks should follow the axis (clockwise: false)'
+                    ],
+                    option: option
+                });
+            });
         </script>
 
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

1. Fix progress bar may become unexpectedly circle when value is `0` and `progress.roundCap` is enabled.
2. Fix ticks don't follow the axis direction when the chart is anticlockwise.

### Fixed issues

- #16640

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<img src="https://user-images.githubusercontent.com/26999792/157372321-80fd08a5-956f-4e99-b131-63dd2739fcd5.png" width="300">

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img src="https://user-images.githubusercontent.com/26999792/157372264-62bff20d-cd13-4ee3-a007-a573bc37c8db.png" width="300">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/gauge-case.html`.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
