### PR TITLE
fix(marker): marker state not restore after blur

### DIFF
--- a/src/component/marker/MarkerView.ts
+++ b/src/component/marker/MarkerView.ts
@@ -71,7 +71,7 @@ abstract class MarkerView extends ComponentView {
         inner(drawGroup).keep = true;
     }
 
-    blurSeries(seriesModelList: SeriesModel[]) {
+    toggleBlurSeries(seriesModelList: SeriesModel[], isBlur: boolean) {
         each(seriesModelList, seriesModel => {
             const markerModel = MarkerModel.getMarkerModelFromSeries(
                 seriesModel,
@@ -81,24 +81,7 @@ abstract class MarkerView extends ComponentView {
                 const data = markerModel.getData();
                 data.eachItemGraphicEl(function (el) {
                     if (el) {
-                        enterBlur(el);
-                    }
-                });
-            }
-        });
-    }
-
-    leaveBlurSeries(seriesModelList: SeriesModel[]) {
-        each(seriesModelList, seriesModel => {
-            const markerModel = MarkerModel.getMarkerModelFromSeries(
-                seriesModel,
-                this.type as 'markPoint' | 'markLine' | 'markArea'
-            );
-            if (markerModel) {
-                const data = markerModel.getData();
-                data.eachItemGraphicEl(function (el) {
-                    if (el) {
-                        leaveBlur(el);
+                        isBlur ? enterBlur(el) : leaveBlur(el);
                     }
                 });
             }

--- a/src/component/marker/MarkerView.ts
+++ b/src/component/marker/MarkerView.ts
@@ -25,7 +25,7 @@ import ExtensionAPI from '../../core/ExtensionAPI';
 import { makeInner } from '../../util/model';
 import SeriesModel from '../../model/Series';
 import Group from 'zrender/src/graphic/Group';
-import { enterBlur } from '../../util/states';
+import { enterBlur, leaveBlur } from '../../util/states';
 
 const inner = makeInner<{
     keep: boolean
@@ -82,6 +82,23 @@ abstract class MarkerView extends ComponentView {
                 data.eachItemGraphicEl(function (el) {
                     if (el) {
                         enterBlur(el);
+                    }
+                });
+            }
+        });
+    }
+
+    leaveBlurSeries(seriesModelList: SeriesModel[]) {
+        each(seriesModelList, seriesModel => {
+            const markerModel = MarkerModel.getMarkerModelFromSeries(
+                seriesModel,
+                this.type as 'markPoint' | 'markLine' | 'markArea'
+            );
+            if (markerModel) {
+                const data = markerModel.getData();
+                data.eachItemGraphicEl(function (el) {
+                    if (el) {
+                        leaveBlur(el);
                     }
                 });
             }

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -520,6 +520,7 @@ export function blurSeries(
         }
         const view = api.getViewOfComponentModel(componentModel);
         if (view && view.blurSeries) {
+            getComponentStates(componentModel).isBlured = true;
             view.blurSeries(blurredSeries, ecModel);
         }
     });

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -61,7 +61,6 @@ import GlobalModel from '../model/Global';
 import ExtensionAPI from '../core/ExtensionAPI';
 import ComponentModel from '../model/Component';
 import { error } from './log';
-import type ComponentView from '../view/Component';
 
 // Reserve 0 as default.
 let _highlightNextDigit = 1;
@@ -436,22 +435,19 @@ export function allLeaveBlur(api: ExtensionAPI) {
         const view = isSeries ? api.getViewOfSeriesModel(componentModel as SeriesModel)
             : api.getViewOfComponentModel(componentModel);
         !isSeries && allComponents.push(componentModel);
-        isSeries && leaveBlurredSeries.push(componentModel as SeriesModel);
         if (componentStates.isBlured) {
             // Leave blur anyway
             view.group.traverse(function (child) {
                 singleLeaveBlur(child);
             });
-        }
-        if (view && (view as ComponentView).toggleBlurSeries) {
-            (view as ComponentView).toggleBlurSeries(leaveBlurredSeries, false, model);
+            isSeries && leaveBlurredSeries.push(componentModel as SeriesModel);
         }
         componentStates.isBlured = false;
     });
     each(allComponents, function (component) {
         const view = api.getViewOfComponentModel(component);
-        if (view && (view as ComponentView).toggleBlurSeries) {
-            (view as ComponentView).toggleBlurSeries(leaveBlurredSeries, false, model);
+        if (view && view.toggleBlurSeries) {
+            view.toggleBlurSeries(leaveBlurredSeries, false, model);
         }
     });
 }

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -61,6 +61,7 @@ import GlobalModel from '../model/Global';
 import ExtensionAPI from '../core/ExtensionAPI';
 import ComponentModel from '../model/Component';
 import { error } from './log';
+import type ComponentView from '../view/Component';
 
 // Reserve 0 as default.
 let _highlightNextDigit = 1;
@@ -428,13 +429,13 @@ function shouldSilent(el: Element, e: ElementEvent) {
 export function allLeaveBlur(api: ExtensionAPI) {
     const model = api.getModel();
     const leaveBlurredSeries: SeriesModel[] = [];
-    const allComponents: ComponentModel[] = [];
+    const allComponentViews: ComponentView[] = [];
     model.eachComponent(function (componentType, componentModel) {
         const componentStates = getComponentStates(componentModel);
         const isSeries = componentType === 'series';
         const view = isSeries ? api.getViewOfSeriesModel(componentModel as SeriesModel)
             : api.getViewOfComponentModel(componentModel);
-        !isSeries && allComponents.push(componentModel);
+        !isSeries && allComponentViews.push(view as ComponentView);
         if (componentStates.isBlured) {
             // Leave blur anyway
             view.group.traverse(function (child) {
@@ -444,8 +445,7 @@ export function allLeaveBlur(api: ExtensionAPI) {
         }
         componentStates.isBlured = false;
     });
-    each(allComponents, function (component) {
-        const view = api.getViewOfComponentModel(component);
+    each(allComponentViews, function (view) {
         if (view && view.toggleBlurSeries) {
             view.toggleBlurSeries(leaveBlurredSeries, false, model);
         }

--- a/src/view/Component.ts
+++ b/src/view/Component.ts
@@ -115,6 +115,14 @@ class ComponentView {
     }
 
     /**
+     * Hook for leaving blur target series.
+     * Can be used in marker for leaving blur the markers
+     */
+    leaveBlurSeries(seriesModels: SeriesModel[], ecModel: GlobalModel): void {
+         // Do nothing;
+    }
+
+    /**
      * Traverse the new rendered elements.
      *
      * It will traverse the new added element in progressive rendering.

--- a/src/view/Component.ts
+++ b/src/view/Component.ts
@@ -107,19 +107,11 @@ class ComponentView {
     }
 
     /**
-     * Hook for blur target series.
-     * Can be used in marker for blur the markers
+     * Hook for toggle blur target series.
+     * Can be used in marker for blur or leave blur the markers
      */
-    blurSeries(seriesModels: SeriesModel[], ecModel: GlobalModel): void {
-         // Do nothing;
-    }
-
-    /**
-     * Hook for leaving blur target series.
-     * Can be used in marker for leaving blur the markers
-     */
-    leaveBlurSeries(seriesModels: SeriesModel[], ecModel: GlobalModel): void {
-         // Do nothing;
+    toggleBlurSeries(seriesModels: SeriesModel[], isBlur: boolean, ecModel: GlobalModel): void {
+        // Do nothing;
     }
 
     /**

--- a/test/markPoint.html
+++ b/test/markPoint.html
@@ -89,7 +89,9 @@ under the License.
                             symbolSize: 6,
                             areaStyle: {normal: {}},
                             data: data1,
-
+                            emphasis: {
+                                focus: 'series'
+                            },
                             markPoint: {
                                 data: [
                                     {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Set component's blur state to true when compoonent is blured



### Fixed issues

- Close #16665 


## Details

### Before: What was the problem?

![Kapture 2022-03-12 at 16 23 20](https://user-images.githubusercontent.com/20318608/158010237-d469fac0-b49b-4443-8875-485fbfe5f0c0.gif)




### After: How is it fixed in this PR?

![Kapture 2022-03-12 at 16 20 27](https://user-images.githubusercontent.com/20318608/158010245-3cb58fa8-0a9f-4ae2-97e2-95e133eb012c.gif)




## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
