### PR TITLE
fix(OrdinalScale): fix line graph renders null value incorrectly. clo…

### DIFF
--- a/src/scale/Ordinal.ts
+++ b/src/scale/Ordinal.ts
@@ -130,6 +130,10 @@ class OrdinalScale extends Scale<OrdinalScaleSetting> {
     }
 
     parse(val: OrdinalRawValue | OrdinalNumber): OrdinalNumber {
+        // Caution: Math.round(null) will return `0` rather than `NaN`
+        if (val == null) {
+            return NaN;
+        }
         return isString(val)
             ? this._ordinalMeta.getOrdinal(val)
             // val might be float.


### PR DESCRIPTION
…se #16664

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of: bug fixing



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix function OrdinalScale.parse returns an unexpected value `0` with `null`.


### Fixed issues

- #16664


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
When options like this:
```javascript
options = {
        animation: false,
        xAxis: {
            type: "category",
            splitLine: { show: true },
            data: ["1:00", "2:00", "3:00", "4:00", "5:00"]
        },
        yAxis: {
            type: "category",
            axisLabel: {
            show: true
            },
            showMinLabel: true,
            showMaxLabel: true,
            data: ["A", "B", "C"]
        },
        series: [
            {
            type: "line",
            data: ["null", "A", undefined, "C", null], // with value `null`
            symbol: "circle",
            showSymbol: true,
            symbolSize: 8,
            lineStyle: {
                opacity: 0
            },
            connectNulls: false
            }
        ]
    };
```

We expect the value of `null` will not be rendered, 
but ECharts renders it like the following:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/59865992/158060140-1ab6bad8-8b95-417c-9d0f-6ee1dd4e291b.png">


When `OrdinalScale.parse` function handle the input value of `null`, 
it returns `0` rather than `NaN`,
because `Math.round(null)` will produce `0`.
We expect `null` will behave the same as `undefined`.

So I add a judgement in `OrdinalScale.parse`.

```javascript
parse(val: OrdinalRawValue | OrdinalNumber): OrdinalNumber {
        // Caution: Math.round(null) will return `0` rather than `NaN`
        if (val == null) {
            val = undefined;
        }
        return isString(val)
            ? this._ordinalMeta.getOrdinal(val)
            // val might be float.
            : Math.round(val);
    }
```

### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="465" alt="image" src="https://user-images.githubusercontent.com/59865992/158059606-8428ab69-6d7b-4673-bec9-867efd5f9352.png">

