### PR TITLE
fix(visualmap): add textShadowColor, make text shadow work on visualMap. close #14440

### DIFF
--- a/src/component/visualMap/ContinuousView.ts
+++ b/src/component/visualMap/ContinuousView.ts
@@ -182,6 +182,7 @@ class ContinuousView extends VisualMapView {
         );
         const orient = this._orient;
         const textStyleModel = this.visualMapModel.textStyleModel;
+        const textShadow = textStyleModel.getTextShadow();
 
         this.group.add(new graphic.Text({
             style: {
@@ -191,7 +192,8 @@ class ContinuousView extends VisualMapView {
                 align: orient === 'horizontal' ? align as TextAlign : 'center',
                 text: text,
                 font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor()
+                fill: textStyleModel.getTextColor(),
+                ...textShadow
             }
         }));
     }

--- a/src/component/visualMap/ContinuousView.ts
+++ b/src/component/visualMap/ContinuousView.ts
@@ -38,6 +38,7 @@ import { setAsHighDownDispatcher } from '../../util/states';
 import { createSymbol } from '../../util/symbol';
 import ZRImage from 'zrender/src/graphic/Image';
 import { getECData } from '../../util/innerStore';
+import { createTextStyle } from '../../label/labelStyle';
 
 const linearMap = numberUtil.linearMap;
 const each = zrUtil.each;
@@ -185,16 +186,16 @@ class ContinuousView extends VisualMapView {
         const textShadow = textStyleModel.getTextShadow();
 
         this.group.add(new graphic.Text({
-            style: {
+            style: createTextStyle(textStyleModel, {
                 x: position[0],
                 y: position[1],
                 verticalAlign: orient === 'horizontal' ? 'middle' : align as TextVerticalAlign,
                 align: orient === 'horizontal' ? align as TextAlign : 'center',
-                text: text,
+                text,
                 font: textStyleModel.getFont(),
                 fill: textStyleModel.getTextColor(),
                 ...textShadow
-            }
+            })
         }));
     }
 

--- a/src/component/visualMap/ContinuousView.ts
+++ b/src/component/visualMap/ContinuousView.ts
@@ -183,7 +183,6 @@ class ContinuousView extends VisualMapView {
         );
         const orient = this._orient;
         const textStyleModel = this.visualMapModel.textStyleModel;
-        const textShadow = textStyleModel.getTextShadow();
 
         this.group.add(new graphic.Text({
             style: createTextStyle(textStyleModel, {
@@ -191,10 +190,7 @@ class ContinuousView extends VisualMapView {
                 y: position[1],
                 verticalAlign: orient === 'horizontal' ? 'middle' : align as TextVerticalAlign,
                 align: orient === 'horizontal' ? align as TextAlign : 'center',
-                text,
-                font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor(),
-                ...textShadow
+                text
             })
         }));
     }

--- a/src/component/visualMap/ContinuousView.ts
+++ b/src/component/visualMap/ContinuousView.ts
@@ -299,11 +299,11 @@ class ContinuousView extends VisualMapView {
                 eventTool.stop(e.event);
             },
             ondragend: onDragEnd,
-            style: {
-                x: 0, y: 0, text: '',
-                font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor()
-            }
+            style: createTextStyle(textStyleModel, {
+                x: 0,
+                y: 0,
+                text: ''
+            })
         });
         handleLabel.ensureState('blur').style = {
             opacity: 0.1
@@ -359,11 +359,11 @@ class ContinuousView extends VisualMapView {
         const indicatorLabel = new graphic.Text({
             silent: true,
             invisible: true,
-            style: {
-                x: 0, y: 0, text: '',
-                font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor()
-            }
+            style: createTextStyle(textStyleModel, {
+                x: 0,
+                y: 0,
+                text: ''
+            })
         });
         this.group.add(indicatorLabel);
 

--- a/src/component/visualMap/PiecewiseView.ts
+++ b/src/component/visualMap/PiecewiseView.ts
@@ -154,7 +154,6 @@ class PiecewiseVisualMapView extends VisualMapView {
 
         const itemGroup = new graphic.Group();
         const textStyleModel = this.visualMapModel.textStyleModel;
-        const textShadow = textStyleModel.getTextShadow();
 
         itemGroup.add(new graphic.Text({
             style: createTextStyle(textStyleModel, {
@@ -162,10 +161,7 @@ class PiecewiseVisualMapView extends VisualMapView {
                 y: itemSize[1] / 2,
                 verticalAlign: 'middle',
                 align: showLabel ? (itemAlign as TextAlign) : 'center',
-                text: text,
-                font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor(),
-                ...textShadow
+                text
             })
         }));
 

--- a/src/component/visualMap/PiecewiseView.ts
+++ b/src/component/visualMap/PiecewiseView.ts
@@ -101,8 +101,6 @@ class PiecewiseVisualMapView extends VisualMapView {
         this.renderBackground(thisGroup);
 
         this.positionGroup(thisGroup);
-
-
     }
 
     private _enableHoverLink(itemGroup: graphic.Group, pieceIndex: number) {
@@ -155,6 +153,7 @@ class PiecewiseVisualMapView extends VisualMapView {
 
         const itemGroup = new graphic.Group();
         const textStyleModel = this.visualMapModel.textStyleModel;
+        const textShadow = textStyleModel.getTextShadow();
 
         itemGroup.add(new graphic.Text({
             style: {
@@ -164,7 +163,8 @@ class PiecewiseVisualMapView extends VisualMapView {
                 align: showLabel ? (itemAlign as TextAlign) : 'center',
                 text: text,
                 font: textStyleModel.getFont(),
-                fill: textStyleModel.getTextColor()
+                fill: textStyleModel.getTextColor(),
+                ...textShadow
             }
         }));
 

--- a/src/component/visualMap/PiecewiseView.ts
+++ b/src/component/visualMap/PiecewiseView.ts
@@ -26,6 +26,7 @@ import * as helper from './helper';
 import PiecewiseModel from './PiecewiseModel';
 import { TextAlign } from 'zrender/src/core/types';
 import { VisualMappingOption } from '../../visual/VisualMapping';
+import { createTextStyle } from '../../label/labelStyle';
 
 class PiecewiseVisualMapView extends VisualMapView {
 
@@ -156,7 +157,7 @@ class PiecewiseVisualMapView extends VisualMapView {
         const textShadow = textStyleModel.getTextShadow();
 
         itemGroup.add(new graphic.Text({
-            style: {
+            style: createTextStyle(textStyleModel, {
                 x: showLabel ? (itemAlign === 'right' ? itemSize[0] : 0) : itemSize[0] / 2,
                 y: itemSize[1] / 2,
                 verticalAlign: 'middle',
@@ -165,7 +166,7 @@ class PiecewiseVisualMapView extends VisualMapView {
                 font: textStyleModel.getFont(),
                 fill: textStyleModel.getTextColor(),
                 ...textShadow
-            }
+            })
         }));
 
         group.add(itemGroup);

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -35,6 +35,8 @@ const textStyleParams = [
     'fontStyle', 'fontWeight', 'fontSize', 'fontFamily', 'padding',
     'lineHeight', 'rich', 'width', 'height', 'overflow'
 ] as const;
+type LabelTextShadowOption = Pick<LabelOption,
+    'textShadowBlur' | 'textShadowColor' | 'textShadowOffsetX' | 'textShadowOffsetY'>;
 
 // TODO Performance improvement?
 const tmpText = new ZRText();
@@ -76,6 +78,15 @@ class TextStyleMixin {
         tmpText.useStyle(style);
         tmpText.update();
         return tmpText.getBoundingRect();
+    }
+
+    getTextShadow(this: Model<LabelTextShadowOption>) {
+        return {
+            textShadowBlur: this.getShallow('textShadowBlur'),
+            textShadowColor: this.getShallow('textShadowColor'),
+            textShadowOffsetX: this.getShallow('textShadowOffsetX'),
+            textShadowOffsetY: this.getShallow('textShadowOffsetY')
+        };
     }
 };
 

--- a/src/model/mixin/textStyle.ts
+++ b/src/model/mixin/textStyle.ts
@@ -35,8 +35,6 @@ const textStyleParams = [
     'fontStyle', 'fontWeight', 'fontSize', 'fontFamily', 'padding',
     'lineHeight', 'rich', 'width', 'height', 'overflow'
 ] as const;
-type LabelTextShadowOption = Pick<LabelOption,
-    'textShadowBlur' | 'textShadowColor' | 'textShadowOffsetX' | 'textShadowOffsetY'>;
 
 // TODO Performance improvement?
 const tmpText = new ZRText();
@@ -78,15 +76,6 @@ class TextStyleMixin {
         tmpText.useStyle(style);
         tmpText.update();
         return tmpText.getBoundingRect();
-    }
-
-    getTextShadow(this: Model<LabelTextShadowOption>) {
-        return {
-            textShadowBlur: this.getShallow('textShadowBlur'),
-            textShadowColor: this.getShallow('textShadowColor'),
-            textShadowOffsetX: this.getShallow('textShadowOffsetX'),
-            textShadowOffsetY: this.getShallow('textShadowOffsetY')
-        };
     }
 };
 

--- a/test/visualMap-continuous.html
+++ b/test/visualMap-continuous.html
@@ -49,39 +49,30 @@ under the License.
         <div class="split">Stacked Bar (and inversed)</div>
         <div id="main4" class="main"></div>
 
-
-
-
-
-
         <script type="text/javascript">
             require([
                 'echarts'
             ], function (echarts) {
-
-                var main = document.getElementById('main1');
+                const main = document.getElementById('main1');
                 if (!main) {
                     return;
                 }
-                var chart = echarts.init(main);
+                const chart = echarts.init(main);
 
-                var data0 = [];
+                const data0 = [];
+                const MAX_DIM1 = 100;
 
-                var MAX_DIM1 = 100;
-
-                var itemStyle = {
-                    normal: {
-                        opacity: 0.8,
-                        shadowBlur: 10,
-                        shadowOffsetX: 0,
-                        shadowOffsetY: 0,
-                        shadowColor: 'rgba(0, 0, 0, 0.3)'
-                    }
+                const itemStyle = {
+                    opacity: 0.8,
+                    shadowBlur: 10,
+                    shadowOffsetX: 0,
+                    shadowOffsetY: 0,
+                    shadowColor: 'rgba(0, 0, 0, 0.3)'
                 };
 
-                var last = 60;
-                var lastDelta = 20;
-                for (var i = 0; i < MAX_DIM1; i++) {
+                let last = 60;
+                let lastDelta = 20;
+                for (let i = 0; i < MAX_DIM1; i++) {
                     lastDelta += (Math.random() - 0.5) * 15;
                     data0.push([
                         i,
@@ -126,6 +117,13 @@ under the License.
                             },
                             outOfRange: {
                                 color: '#eee'
+                            },
+                            text: ['High', 'Low'],
+                            textStyle: {
+                                textShadowColor: "rgba(255, 0, 255, 1)",
+                                textShadowBlur: 5,
+                                textShadowOffsetX: 5,
+                                textShadowOffsetY: 5
                             }
                         }
                     ],
@@ -134,7 +132,7 @@ under the License.
                             name: 'bar',
                             type: 'bar',
                             barMaxWidth: 10,
-                            itemStyle: itemStyle,
+                            itemStyle,
                             data: data0
                         }
                     ]
@@ -142,47 +140,31 @@ under the License.
             })
         </script>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
         <script type="text/javascript">
             require([
                 'echarts'
             ], function (echarts) {
-
-                var main = document.getElementById('main2');
+                const main = document.getElementById('main2');
                 if (!main) {
                     return;
                 }
-                var chart = echarts.init(main);
+                const chart = echarts.init(main);
 
-                var data0 = [];
-                var data1 = [];
+                const data0 = [];
+                const data1 = [];
 
-                var MAX_DIM2 = 300;
-                var MAX_DIM3 = 20000;
+                const MAX_DIM2 = 300;
+                const MAX_DIM3 = 20000;
 
-                var itemStyle = {
-                    normal: {
-                        opacity: 0.8,
-                        shadowBlur: 10,
-                        shadowOffsetX: 0,
-                        shadowOffsetY: 0,
-                        shadowColor: 'rgba(0, 0, 0, 0.5)'
-                    }
+                const itemStyle = {
+                    opacity: 0.8,
+                    shadowBlur: 10,
+                    shadowOffsetX: 0,
+                    shadowOffsetY: 0,
+                    shadowColor: 'rgba(0, 0, 0, 0.5)'
                 };
 
-                for (var i = 0; i < 60; i++) {
+                for (let i = 0; i < 60; i++) {
                     data0.push(genDataItem());
                     data1.push(genDataItem());
                 }
@@ -255,31 +237,20 @@ under the License.
                             name: 'scatter0',
                             type: 'scatter',
                             symbol: 'circle',
-                            itemStyle: itemStyle,
+                            itemStyle,
                             data: data0
                         },
                         {
                             name: 'scatter1',
                             type: 'scatter',
                             symbol: 'diamond',
-                            itemStyle: itemStyle,
+                            itemStyle,
                             data: data1
                         }
                     ]
                 });
             })
         </script>
-
-
-
-
-
-
-
-
-
-
-
 
         <script type="text/javascript">
             require([
@@ -290,11 +261,11 @@ under the License.
             });
 
             function renderWorldMap(echarts) {
-                var main = document.getElementById('main3');
+                const main = document.getElementById('main3');
                 if (!main) {
                     return;
                 }
-                var chart = echarts.init(main);
+                const chart = echarts.init(main);
 
                 option = {
                     title: {
@@ -307,9 +278,9 @@ under the License.
                     tooltip: {
                         trigger: 'item',
                         formatter: function (params) {
-                            var value = (params.value + '').split('.');
-                            value = value[0].replace(/(\d{1,3})(?=(?:\d{3})+(?!\d))/g, '$1,')
-                                    + '.' + value[1];
+                            const list = (params.value + '').split('.');
+                            const value = list[0].replace(/(\d{1,3})(?=(?:\d{3})+(?!\d))/g, '$1,')
+                                    + '.' + list[1];
                             return params.seriesName + '<br/>' + params.name + ' : ' + value;
                         }
                     },
@@ -340,10 +311,12 @@ under the License.
                         {
                             name: 'World Population (2010)',
                             type: 'map',
-                            mapType: 'world',
+                            map: 'world',
                             roam: true,
-                            itemStyle:{
-                                emphasis:{label:{show:true}}
+                            emphasis: {
+                                label: {
+                                    show: true
+                                }
                             },
                             data:[
                                 {name: 'Afghanistan', value: 28397.812},
@@ -532,31 +505,21 @@ under the License.
             }
         </script>
 
-
-
-
-
-
-
-
-
         <script type="text/javascript">
-
             require(['echarts'], function (echarts) {
-
-                var main = document.getElementById('main4');
+                const main = document.getElementById('main4');
                 if (!main) {
                     return;
                 }
-                var chart = echarts.init(main);
+                const chart = echarts.init(main);
 
-                var xAxisData = [];
-                var data1 = [];
-                var data2 = [];
-                var data3 = [];
-                var data4 = [];
+                const xAxisData = [];
+                const data1 = [];
+                const data2 = [];
+                const data3 = [];
+                const data4 = [];
 
-                for (var i = 0; i < 10; i++) {
+                for (let i = 0; i < 10; i++) {
                     xAxisData.push('Class' + i);
                     data1.push((Math.random() * 2).toFixed(2));
                     data2.push(-Math.random().toFixed(2));
@@ -564,18 +527,13 @@ under the License.
                     data4.push((Math.random() + 0.3).toFixed(2));
                 }
 
-                var itemStyle = {
-                    normal: {
-                        label: {
-                            show: true,
-                            position: 'outside'
-                        }
+                const emphasis = {
+                    label: {
+                        show: true,
+                        position: 'outside'
                     },
-                    emphasis: {
-                        label: {
-                            position: 'outside'
-                        },
-                        barBorderWidth: 1,
+                    itemStyle: {
+                        borderWidth: 1,
                         shadowBlur: 10,
                         shadowOffsetX: 0,
                         shadowOffsetY: 0,
@@ -630,28 +588,28 @@ under the License.
                             name: 'bar',
                             type: 'bar',
                             stack: 'one',
-                            itemStyle: itemStyle,
+                            emphasis,
                             data: data1
                         },
                         {
                             name: 'bar2',
                             type: 'bar',
                             stack: 'one',
-                            itemStyle: itemStyle,
+                            emphasis,
                             data: data2
                         },
                         {
                             name: 'bar3',
                             type: 'bar',
                             stack: 'two',
-                            itemStyle: itemStyle,
+                            emphasis,
                             data: data3
                         },
                         {
                             name: 'bar4',
                             type: 'bar',
                             stack: 'two',
-                            itemStyle: itemStyle,
+                            emphasis,
                             data: data4
                         }
                     ]
@@ -665,7 +623,6 @@ under the License.
                 });
             });
         </script>
-
 
     </body>
 </html>

--- a/test/visualMap-pieces.html
+++ b/test/visualMap-pieces.html
@@ -18,7 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-
 <html>
     <head>
         <meta charset="utf-8">
@@ -46,25 +45,15 @@ under the License.
             }
         </style>
 
-
-
-
         <div class="chart" id="map"></div>
-
         <div class="chart" id="line-symbol"></div>
-
-
-
-
-
 
         <script>
             require([
                 'echarts',
                 'map/js/china'
             ], function (echarts) {
-
-                var option = {
+                const option = {
                     title : {
                         text: '订单量',
                         subtext: '纯属虚构',
@@ -79,7 +68,6 @@ under the License.
                         data:['订单量']
                     },
                     visualMap: {
-                        // selectedMode: 'single',
                         text: ['Map Result'],
                         showLabel: true,
                         right: 20,
@@ -93,7 +81,13 @@ under the License.
                             {min: 5, max: 5, label: '5（自定义特殊颜色）', color: 'black'},
                             {max: 5}
                         ],
-                        color: ['#E0022B', '#E09107', '#A3E00B']
+                        color: ['#E0022B', '#E09107', '#A3E00B'],
+                        textStyle: {
+                            textShadowColor: "rgba(255, 0, 255, 1)",
+                            textShadowBlur: 5,
+                            textShadowOffsetX: 5,
+                            textShadowOffsetY: 5
+                        }
                     },
                     toolbox: {
                         show: true,
@@ -118,100 +112,69 @@ under the License.
                         {
                             name: '订单量',
                             type: 'map',
-                            mapType: 'china',
+                            map: 'china',
                             roam: false,
-                            itemStyle:{
-                                normal:{
-                                    label:{
-                                        show:true,
-                                        // textStyle: {
-                                            // color: "red"
-                                        // }
-                                    }
-                                },
-                                emphasis:{label:{show:true}}
+                            label: {
+                                show: true
                             },
                             data:[
-                                {name: '北京',value: 5},
-                                {name: '天津',value: Math.round(Math.random()*2000)},
-                                {name: '上海',value: Math.round(Math.random()*2000)},
-                                {name: '重庆',value: Math.round(Math.random()*2000)},
-                                {name: '河北',value: 0},
-                                {name: '河南',value: Math.round(Math.random()*2000)},
-                                {name: '云南',value: 123},
-                                {name: '辽宁',value: 305},
+                                {name: '北京', value: 5},
+                                {name: '天津', value: Math.round(Math.random()*2000)},
+                                {name: '上海', value: Math.round(Math.random()*2000)},
+                                {name: '重庆', value: Math.round(Math.random()*2000)},
+                                {name: '河北', value: 0},
+                                {name: '河南', value: Math.round(Math.random()*2000)},
+                                {name: '云南', value: 123},
+                                {name: '辽宁', value: 305},
                                 {name: '黑龙江', value: Math.round(Math.random()*2000), visualMap: false},
                                 {name: '湖南', value: 200},
-                                {name: '安徽',value: Math.round(Math.random()*2000)},
-                                {name: '山东',value: Math.round(Math.random()*2000)},
-                                {name: '新疆',value: Math.round(Math.random()*2000)},
+                                {name: '安徽', value: Math.round(Math.random()*2000)},
+                                {name: '山东', value: Math.round(Math.random()*2000)},
+                                {name: '新疆', value: Math.round(Math.random()*2000)},
                                 {name: '江苏', itemStyle: {color: 'red'}, value: Math.round(Math.random()*2000), visualMap: false},
-                                {name: '浙江',value: Math.round(Math.random()*2000)},
-                                {name: '江西',value: Math.round(Math.random()*2000)},
-                                {name: '湖北',value: Math.round(Math.random()*2000)},
-                                {name: '广西',value: Math.round(Math.random()*2000)},
-                                {name: '甘肃',value: Math.round(Math.random()*2000)},
-                                {name: '山西',value: Math.round(Math.random()*2000)},
-                                {name: '内蒙古',value: Math.round(Math.random()*2000)},
-                                {name: '陕西',value: Math.round(Math.random()*2000)},
-                                {name: '吉林',value: Math.round(Math.random()*2000)},
-                                {name: '福建',value: Math.round(Math.random()*2000)},
-                                {name: '贵州',value: Math.round(Math.random()*2000)},
-                                {name: '广东',value: Math.round(Math.random()*2000)},
-                                {name: '青海',value: Math.round(Math.random()*2000)},
-                                {name: '西藏',value: Math.round(Math.random()*2000)},
-                                {name: '四川',value: Math.round(Math.random()*2000)},
-                                {name: '宁夏',value: Math.round(Math.random()*2000)},
-                                {name: '海南',value: Math.round(Math.random()*2000)},
-                                {name: '台湾',value: Math.round(Math.random()*2000)},
-                                {name: '香港',value: Math.round(Math.random()*2000)},
-                                {name: '澳门',value: Math.round(Math.random()*2000)}
+                                {name: '浙江', value: Math.round(Math.random()*2000)},
+                                {name: '江西', value: Math.round(Math.random()*2000)},
+                                {name: '湖北', value: Math.round(Math.random()*2000)},
+                                {name: '广西', value: Math.round(Math.random()*2000)},
+                                {name: '甘肃', value: Math.round(Math.random()*2000)},
+                                {name: '山西', value: Math.round(Math.random()*2000)},
+                                {name: '内蒙古', value: Math.round(Math.random()*2000)},
+                                {name: '陕西', value: Math.round(Math.random()*2000)},
+                                {name: '吉林', value: Math.round(Math.random()*2000)},
+                                {name: '福建', value: Math.round(Math.random()*2000)},
+                                {name: '贵州', value: Math.round(Math.random()*2000)},
+                                {name: '广东', value: Math.round(Math.random()*2000)},
+                                {name: '青海', value: Math.round(Math.random()*2000)},
+                                {name: '西藏', value: Math.round(Math.random()*2000)},
+                                {name: '四川', value: Math.round(Math.random()*2000)},
+                                {name: '宁夏', value: Math.round(Math.random()*2000)},
+                                {name: '海南', value: Math.round(Math.random()*2000)},
+                                {name: '台湾', value: Math.round(Math.random()*2000)},
+                                {name: '香港', value: Math.round(Math.random()*2000)},
+                                {name: '澳门', value: Math.round(Math.random()*2000)}
                             ]
                         }
                     ]
                 };
 
-                var chart = testHelper.create(echarts, 'map', {
+                const chart = testHelper.create(echarts, 'map', {
                     title: [
                         'All provinces should be "blue", except that',
                         '北京 is "black"',
                         '黑龙江 is "grey" (visualMap: false)',
-                        '江苏 is "red" (visualMap: false)'
+                        '江苏 is "red" (visualMap: false)',
+                        'the shadowColor of visualMap text "Map Result" is magenta'
                     ],
-                    option: option
+                    option
                 });
-
             })
-
         </script>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
         <script>
-
-            var echarts;
-            var colorTool;
-            var chart;
-            var myChart;
-            var groupCategories = [];
-            var groupColors = [];
-
             require([
                 'echarts'
             ], function (echarts) {
-                var option = {
+                const option = {
                     title: {
                         text: '未来一周气温变化',
                         subtext: '纯属虚构'
@@ -220,7 +183,7 @@ under the License.
                         trigger: 'axis'
                     },
                     legend: {
-                        data:['最高气温','最低气温']
+                        data:['最高气温']
                     },
                     toolbox: {
                         show: true,
@@ -250,7 +213,7 @@ under the License.
                     xAxis:  {
                         type: 'category',
                         boundaryGap: false,
-                        data: ['周一','周二','周三','周四','周五','周六','周日']
+                        data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
                     },
                     yAxis: {
                         type: 'value',
@@ -267,31 +230,12 @@ under the License.
                     ]
                 };
 
-                var chart = testHelper.create(echarts, 'line-symbol', {
+                const chart = testHelper.create(echarts, 'line-symbol', {
                     title: 'line symbol (check toggle normally)',
-                    option: option
+                    option
                 });
             });
-
         </script>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

Fix a bug that some text styles are not working on `visualMap`. 

### Fixed issues

- #14440


## Details

### visualMap-continuous

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/29879262/158140242-0c221fe8-76e8-4721-8f89-40cfb78613fb.png) | ![image](https://user-images.githubusercontent.com/29879262/158140288-bac8e527-9ed0-488b-8480-d0f46e18e6bd.png) |

### visualMap-piecewise

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/29879262/158140853-da2e459e-223d-411b-9924-f723201b8e0f.png) | ![image](https://user-images.githubusercontent.com/29879262/158140778-816f4619-26de-404a-857c-e8598fa47ac2.png) |

## Misc
- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/visualMap-continuous.html`
- `test/visualMap-pieces.html`



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
