### PR TITLE
fix(dataview): fix unexpected scrollbar and outline when using default textview

### DIFF
--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -29,6 +29,7 @@ import ExtensionAPI from '../../../core/ExtensionAPI';
 import { addEventListener } from 'zrender/src/core/event';
 import Axis from '../../../coord/Axis';
 import Cartesian2D from '../../../coord/cartesian/Cartesian2D';
+import { warn } from '../../../util/log';
 
 /* global document */
 
@@ -363,7 +364,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
             textarea.readOnly = model.get('readOnly');
             const style = textarea.style;
             // eslint-disable-next-line max-len
-            style.cssText = 'width:100%;height:100%;font-family:monospace;font-size:14px;line-height:1.6rem;resize:none';
+            style.cssText = 'width:100%;height:100%;font-family:monospace;font-size:14px;line-height:1.6rem;resize:none;vertical-align:middle;box-sizing:border-box;outline:none';
             style.color = model.get('textColor');
             style.borderColor = model.get('textareaBorderColor');
             style.backgroundColor = model.get('textareaColor');
@@ -397,7 +398,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
                 || (contentToOption != null && optionToContent == null)) {
                 if (__DEV__) {
                     // eslint-disable-next-line
-                    console.warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
+                    warn('It seems you have just provided one of `contentToOption` and `optionToContent` functions but missed the other one. Data change is ignored.')
                 }
                 close();
                 return;

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -364,7 +364,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
             textarea.readOnly = model.get('readOnly');
             const style = textarea.style;
             // eslint-disable-next-line max-len
-            style.cssText = 'width:100%;height:100%;font-family:monospace;font-size:14px;line-height:1.6rem;resize:none;vertical-align:middle;box-sizing:border-box;outline:none';
+            style.cssText = 'display:block;width:100%;height:100%;font-family:monospace;font-size:14px;line-height:1.6rem;resize:none;box-sizing:border-box;outline:none';
             style.color = model.get('textColor');
             style.borderColor = model.get('textareaBorderColor');
             style.backgroundColor = model.get('textareaColor');


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Optimize the default textview style to fix unexpected scrollbar and outline.

## Comparison

| Before | After |
| :----: | :----: |
| <img width="400" alt="mac" src="https://user-images.githubusercontent.com/26999792/158779494-6a7182e0-e747-4061-83f3-b7d3f4ef0f9b.png"> | <img width="400"  alt="mac" src="https://user-images.githubusercontent.com/26999792/158779509-28f31d8f-7c84-4627-a726-b720334be728.png"> |
| <img width="400" alt="windows" src="https://user-images.githubusercontent.com/26999792/158780002-0a7471e3-6775-4e0b-8fd6-4dedd9504ca5.png"> | <img width="400" alt="windows" src="https://user-images.githubusercontent.com/26999792/158779674-fb513d60-62b7-4d49-81f3-5d82d7d61f90.png"> |

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/dataZoom-toolbox.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
