### PR TITLE
fix(toolbox): toolbox doesn't enter emphasis state when hovering on the icon.

### DIFF
--- a/src/component/toolbox/ToolboxView.ts
+++ b/src/component/toolbox/ToolboxView.ts
@@ -259,11 +259,11 @@ class ToolboxView extends ComponentView {
 
                     // Use enterEmphasis and leaveEmphasis provide by ec.
                     // There are flags managed by the echarts.
-                    enterEmphasis(this);
+                    api.enterEmphasis(this);
                 })
                 .on('mouseout', function () {
                     if (featureModel.get(['iconStatus', iconName]) !== 'emphasis') {
-                        leaveEmphasis(this);
+                        api.leaveEmphasis(this);
                     }
                     textContent.hide();
                 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix toolbox doesn't enter emphasis state when hovering on the icon.

### Fixed issues

- #13777


## Details

Please refer to #13777 for details.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Any test cases that enable the toolbox.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
