### PR TITLE
fix(toolbox): fix toolbox title may be outside of the chart

### DIFF
--- a/src/component/toolbox/ToolboxView.ts
+++ b/src/component/toolbox/ToolboxView.ts
@@ -259,11 +259,11 @@ class ToolboxView extends ComponentView {
 
                     // Use enterEmphasis and leaveEmphasis provide by ec.
                     // There are flags managed by the echarts.
-                    enterEmphasis(this);
+                    api.enterEmphasis(this);
                 })
                 .on('mouseout', function () {
                     if (featureModel.get(['iconStatus', iconName]) !== 'emphasis') {
-                        leaveEmphasis(this);
+                        api.leaveEmphasis(this);
                     }
                     textContent.hide();
                 });

--- a/test/toolbox-title.html
+++ b/test/toolbox-title.html
@@ -150,7 +150,7 @@ under the License.
 
             var chart = testHelper.create(echarts, 'main2', {
                 title: [
-                    'orient: horizontal; bottom left side',
+                    'orient: vertical; top left side',
                     'Text when hover on toolbox icon should not be outside of the canvas'
                 ],
                 option: option
@@ -186,7 +186,7 @@ under the License.
 
             var chart = testHelper.create(echarts, 'main3', {
                 title: [
-                    'orient: horizontal; bottom right side',
+                    'orient: vertical; top right side',
                     'Text when hover on toolbox icon should not be outside of the canvas'
                 ],
                 option: option


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the toolbox title may be outside of the chart. This PR relies on #16702.

### Fixed issues

- https://github.com/apache/echarts/issues/16673#issuecomment-1068775607
- #16472
- #14833

## Details

### Before: What was the problem?

Toolbox title may be outside of the chart so that it can't be fully displayed.

| 1 | 2 |
| :----: | :----: |
| ![bug1](https://user-images.githubusercontent.com/26999792/159122929-fcac6b02-7f6e-4426-97b0-83efcc6b2ebe.png) | ![bug2](https://user-images.githubusercontent.com/26999792/159122933-65ca13b9-567d-40bd-ab49-9c6ae2e5c7c8.png) |

### After: How is it fixed in this PR?

| 1 | 2 | 3 |
| :----: | :----: | :----: |
| ![h-tl](https://user-images.githubusercontent.com/26999792/159123009-ddfffcbc-6fc4-4f3c-b8b0-fa9ffeb96b9d.png) | ![h-tl1](https://user-images.githubusercontent.com/26999792/159123010-d4c5a346-4120-462b-b896-00a7bbfafcd2.png) | ![h-tr](https://user-images.githubusercontent.com/26999792/159123012-85f2d45c-55f7-4412-876c-63e127ac4eb3.png) |
 | ![h-tr1](https://user-images.githubusercontent.com/26999792/159123014-86730bbe-cbc4-4c3c-ad43-d585de5c9253.png) | ![v-br](https://user-images.githubusercontent.com/26999792/159123017-5eba40a1-f70c-491e-914d-908c8b4a268a.png) | ![v-tl](https://user-images.githubusercontent.com/26999792/159123018-4df21985-bc0f-4d99-ab4e-20080b87f889.png) |


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

See `test/toolbox-title.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
