### PR TITLE
fix(heatmap): avoid the unexpected gaps when dpr is not an integer

### DIFF
--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -175,12 +175,13 @@ class HeatmapView extends ChartView {
     ) {
 
         const coordSys = seriesModel.coordinateSystem as Cartesian2D | Calendar;
+        const isCartesian2d = isCoordinateSystemType<Cartesian2D>(coordSys, 'cartesian2d');
         let width;
         let height;
         let xAxisExtent;
         let yAxisExtent;
 
-        if (isCoordinateSystemType<Cartesian2D>(coordSys, 'cartesian2d')) {
+        if (isCartesian2d) {
             const xAxis = coordSys.getAxis('x');
             const yAxis = coordSys.getAxis('y');
 
@@ -193,8 +194,9 @@ class HeatmapView extends ChartView {
                 }
             }
 
-            width = xAxis.getBandWidth();
-            height = yAxis.getBandWidth();
+            // add 0.5px to avoid the gaps
+            width = xAxis.getBandWidth() + .5;
+            height = yAxis.getBandWidth() + .5;
             xAxisExtent = xAxis.scale.getExtent();
             yAxisExtent = yAxis.scale.getExtent();
         }
@@ -211,7 +213,7 @@ class HeatmapView extends ChartView {
         let blurScope = emphasisModel.get('blurScope');
         let emphasisDisabled = emphasisModel.get('disabled');
 
-        const dataDims = isCoordinateSystemType<Cartesian2D>(coordSys, 'cartesian2d')
+        const dataDims = isCartesian2d
             ? [
                 data.mapDimension('x'),
                 data.mapDimension('y'),
@@ -226,7 +228,7 @@ class HeatmapView extends ChartView {
             let rect;
             const style = data.getItemVisual(idx, 'style');
 
-            if (isCoordinateSystemType<Cartesian2D>(coordSys, 'cartesian2d')) {
+            if (isCartesian2d) {
                 const dataDimX = data.get(dataDims[0], idx);
                 const dataDimY = data.get(dataDims[1], idx);
 
@@ -247,10 +249,10 @@ class HeatmapView extends ChartView {
 
                 rect = new graphic.Rect({
                     shape: {
-                        x: Math.floor(Math.round(point[0]) - width / 2),
-                        y: Math.floor(Math.round(point[1]) - height / 2),
-                        width: Math.ceil(width),
-                        height: Math.ceil(height)
+                        x: point[0] - width / 2,
+                        y: point[1] - height / 2,
+                        width,
+                        height
                     },
                     style
                 });

--- a/test/heatmap-gap-bug.html
+++ b/test/heatmap-gap-bug.html
@@ -97,7 +97,11 @@ under the License.
             </div>
         </div>
         <script>
-
+            // gap usually appears when dpr is not an integer
+            Object.defineProperty(window, 'devicePixelRatio', {
+                value: 2.5,
+                writable: false
+            });
             require([
                 'echarts'
             ], function (echarts) {

--- a/test/heatmap-large.html
+++ b/test/heatmap-large.html
@@ -36,7 +36,11 @@ under the License.
         </style>
         <div id="main"></div>
         <script>
-
+            // gap usually appears when dpr is not an integer
+            Object.defineProperty(window, 'devicePixelRatio', {
+                value: 2.5,
+                writable: false
+            });
             require([
                 'echarts'
             ], function (echarts) {

--- a/test/runTest/actions/__meta__.json
+++ b/test/runTest/actions/__meta__.json
@@ -103,6 +103,7 @@
   "graphic-draggable": 1,
   "graphic-transition": 3,
   "heatmap": 1,
+  "heatmap-gap-bug": 1,
   "heatmap-map": 1,
   "homepage3": 1,
   "hoverFocus": 12,

--- a/test/runTest/actions/heatmap-gap-bug.json
+++ b/test/runTest/actions/heatmap-gap-bug.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"mousedown","time":482,"x":413,"y":595},{"type":"mouseup","time":1742,"x":454,"y":595},{"time":1743,"delay":400,"type":"screenshot-auto"},{"type":"mousemove","time":1772,"x":454,"y":595}],"scrollY":0,"scrollX":0,"timestamp":1642876188713}]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix some gaps will occur in the heatmap when dpr is not an integer.

### Fixed issues

- #6011
- #12519
- #11975


## Details

### Before: What was the problem?

There are unexpected obvious gaps when dpr is not an integer.

### After: How is it fixed in this PR?

Add extra 0.5px for each cell.

### Comparison

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26999792/159249225-07242875-db03-4ccb-b1fb-c1f4a67cb453.png) | ![image](https://user-images.githubusercontent.com/26999792/159249211-253daafe-51b0-43c7-a5f4-235080af29c3.png) |
| ![image](https://user-images.githubusercontent.com/26999792/159250220-5e285041-4c4a-4b81-be08-552e02cf2117.png) | ![image](https://user-images.githubusercontent.com/26999792/159250320-fcd4c11c-9c72-4b5e-9d04-02b1967cffde.png) |

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/heatmap-gap-bug.html`
- `test/heatmap-large.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
