### PR TITLE
fix(dataZoom): fix the dataZoom was unexpectedly displayed at the top when data contains null values

### DIFF
--- a/src/data/DataStore.ts
+++ b/src/data/DataStore.ts
@@ -290,8 +290,10 @@ class DataStore {
         // Parse from previous data offset. len may be changed after appendData
         for (let i = offset; i < len; i++) {
             const val = (chunk as any)[i] = ordinalMeta.parseAndCollect(chunk[i]);
-            dimRawExtent[0] = Math.min(val, dimRawExtent[0]);
-            dimRawExtent[1] = Math.max(val, dimRawExtent[1]);
+            if (!isNaN(val)) {
+                dimRawExtent[0] = Math.min(val, dimRawExtent[0]);
+                dimRawExtent[1] = Math.max(val, dimRawExtent[1]);
+            }
         }
 
         dim.ordinalMeta = ordinalMeta;

--- a/test/dataZoom-feature.html
+++ b/test/dataZoom-feature.html
@@ -43,7 +43,7 @@ under the License.
         <div id="specified_axis_second_setOption_normal_dz"></div>
         <div id="remove_dz"></div>
         <div id="duplicated_dataZoom_ref"></div>
-
+        <div id="main0"></div>
 
 
 
@@ -745,6 +745,116 @@ under the License.
             });
         });
         </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    dataZoom: [{
+                        id: 'dataZoomX',
+                        type: 'slider',
+                        xAxisIndex: 0,
+                        filterMode: 'filter'
+                    }],
+                    legend: {
+                        data: ['语文'],
+                        top: '0'
+                    },
+                    tooltip: {
+                        trigger: 'axis',
+                        formatter: '{b0}<br />',
+                        axisPointer: {
+                            animation: true,
+                            type: 'line',
+                            lineStyle: {
+                                type: 'dashed'
+                            }
+                        }
+                    },
+                    grid: {
+                        left: 20,
+                        top: 38,
+                        right: 20,
+                        bottom: 65
+                    },
+                    xAxis: {
+                        type: 'category',
+                        data: [
+                        '第1周',
+                        '第2周',
+                        '第3周',
+                        '第4周',
+                        '第5周',
+                        '第6周',
+                        '第7周',
+                        '第8周',
+                        '第9周',
+                        '第10周',
+                        '第11周',
+                        '第12周',
+                        '第13周',
+                        '第14周',
+                        '第15周',
+                        '第16周',
+                        '第17周',
+                        '第18周',
+                        '第19周',
+                        '第20周',
+                        '第21周',
+                        '第22周'
+                        ],
+                        boundaryGap: false
+                    },
+                    yAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        name: '等级',
+                        data: ['0', 'D', 'C', 'B', 'A'],
+                        splitLine: {
+                            show: true
+                        }
+                    },
+                    series: [{
+                        labelLine: { show: true },
+                        symbolSize: 16,
+                        type: 'line',
+                        smooth: true,
+                        name: '语文',
+                        data: [
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            'D',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-',
+                            '-'
+                        ]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'The dataZoom should be displayed at bottom',
+                    ],
+                    option: option,
+                    height: 350
+                });
+            });
+            </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the `dataZoom` was unexpectedly displayed at the top when data contains null values. Fixes #16476.


### Fixed issues

- #16476


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/46208943/159678113-759d9df7-1f74-43cd-ad8f-b47edfc2e3eb.png)


### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/46208943/159677187-9df9f39c-cfed-45d8-afb9-dc5a937d2ae0.png)

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Refer to the last case in `test/dataZoom-feature.html`.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
