### PR TITLE
fix(splitLine): fix chart throws errors when `splitLine` is enabled in radius axis.

### DIFF
--- a/src/component/axis/RadiusAxisView.ts
+++ b/src/component/axis/RadiusAxisView.ts
@@ -116,7 +116,8 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
                 shape: {
                     cx: polar.cx,
                     cy: polar.cy,
-                    r: ticksCoords[i].coord
+                    // ensure circle radius >= 0
+                    r: Math.max(ticksCoords[i].coord, 0)
                 }
             }));
         }

--- a/test/runTest/actions/__meta__.json
+++ b/test/runTest/actions/__meta__.json
@@ -163,6 +163,7 @@
   "scatter-single-axis": 2,
   "scatterMatrix": 3,
   "setOption": 1,
+  "splitLine": 1,
   "stackBar-dataZoom": 7,
   "sunburst-book": 1,
   "sunburst-canvas": 1,

--- a/test/runTest/actions/splitLine.json
+++ b/test/runTest/actions/splitLine.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"mousedown","time":660,"x":50,"y":175},{"type":"mouseup","time":802,"x":50,"y":175},{"time":803,"delay":400,"type":"screenshot-auto"}],"scrollY":797.2000122070312,"scrollX":0,"timestamp":1648092272395}]

--- a/test/splitLine.html
+++ b/test/splitLine.html
@@ -41,7 +41,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
-
+        <div id="main2"></div>
 
 
 
@@ -201,7 +201,65 @@ under the License.
 
         </script>
 
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    polar: {
+                        // radius: '68.23%'
+                        // radius: '9%'
+                    },
+                    angleAxis: {
+                        max: 4,
+                        startAngle: 75
+                    },
+                    radiusAxis: {
+                        type: 'category',
+                        data: ['a', 'b', 'c', 'd'],
+                        // root cause
+                        splitLine: {
+                            show: true,
+                            lineStyle: {
+                                color: 'blue',
+                                width: 1,
+                                type: 'dashed'
+                            }
+                        },
+                        splitArea: {
+                            show: true
+                        }
+                    },
+                    series: {
+                        type: 'bar',
+                        data: [2, 1.2, 2.4, 3.6],
+                        coordinateSystem: 'polar',
+                        label: {
+                            show: true,
+                            position: 'middle',
+                            formatter: '{b}: {c}'
+                        }
+                    }
+                };
 
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'It shouldn\'t throw errors when **splitLine** is visible',
+                        'Shrink the page or click the **Resize** button to test'
+                    ],
+                    buttons: [
+                        {
+                            text: 'Resize',
+                            onclick: () => {
+                                chart.resize({
+                                    width: 382
+                                });
+                            }
+                        }
+                    ],
+                    option: option
+                });
+            });
+
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

The chart throws errors when `splitLine` is enabled in the radius axis, resolves #16731.

### Fixed issues

- #16731


## Details

### Before: What was the problem?

It will throw illegal argument errors as zrender basic shape `Circle` doesn't handle the value less than `0`, unlike the `Sector` shape, it normalizes such an unexpected radius value.

### After: How is it fixed in this PR?

Ensure the circle radius is non-negative in ECharts.

### Comparison

![image](https://user-images.githubusercontent.com/26999792/159837185-21c72160-b591-4243-8e9b-794a02e49aad.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/splitLine.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
