### PR TITLE
fix: wrong jpg instead of jpeg image export types

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -29,7 +29,7 @@ import { isFunction } from 'zrender/src/core/util';
 export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
     icon?: string
     title?: string
-    type?: 'png' | 'jpg'
+    type?: 'png' | 'jpeg'
 
     backgroundColor?: ZRColor
     connectedBackgroundColor?: ZRColor

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -763,7 +763,7 @@ class ECharts extends Eventful<ECEventDefinition> {
 
     getDataURL(opts?: {
         // file type 'png' by default
-        type?: 'png' | 'jpg' | 'svg',
+        type?: 'png' | 'jpeg' | 'svg',
         pixelRatio?: number,
         backgroundColor?: ZRColor,
         // component type array
@@ -807,7 +807,7 @@ class ECharts extends Eventful<ECEventDefinition> {
 
     getConnectedDataURL(opts?: {
         // file type 'png' by default
-        type?: 'png' | 'jpg' | 'svg',
+        type?: 'png' | 'jpeg' | 'svg',
         pixelRatio?: number,
         backgroundColor?: ZRColor,
         connectedBackgroundColor?: ZRColor


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Change the expected image types from `jpg` to `jpeg`.