### PR TITLE
feat: Add stackDim to specify axis to stack

### DIFF
--- a/src/data/helper/dataStackHelper.ts
+++ b/src/data/helper/dataStackHelper.ts
@@ -104,7 +104,7 @@ export function enableDataStack(
         if (mayStack && !dimensionInfo.isExtraCoord) {
             //If a dimension is specified by user, use it as stack dimension
             let stackDim = seriesModel && seriesModel.get('stackDim');
-            if (dimensionInfo && stackDim === dimensionInfo.name){
+            if (dimensionInfo && stackDim === dimensionInfo.name) {
                 stackedDimInfo = dimensionInfo;
             }
             // Find the first ordinal dimension as the stackedByDimInfo.

--- a/src/data/helper/dataStackHelper.ts
+++ b/src/data/helper/dataStackHelper.ts
@@ -102,6 +102,11 @@ export function enableDataStack(
         }
 
         if (mayStack && !dimensionInfo.isExtraCoord) {
+            //If a dimension is specified by user, use it as stack dimension
+            let stackDim = seriesModel && seriesModel.get('stackDim');
+            if (dimensionInfo && stackDim === dimensionInfo.name){
+                stackedDimInfo = dimensionInfo;
+            }
             // Find the first ordinal dimension as the stackedByDimInfo.
             if (!byIndex && !stackedByDimInfo && dimensionInfo.ordinalMeta) {
                 stackedByDimInfo = dimensionInfo;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1660,7 +1660,8 @@ export interface SeriesLargeOptionMixin {
     largeThreshold?: number
 }
 export interface SeriesStackOptionMixin {
-    stack?: string
+    stack?: string,
+    stackDim?: string
 }
 
 type SamplingFunc = (frame: ArrayLike<number>) => number;

--- a/test/dataStackDimension.html
+++ b/test/dataStackDimension.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                "xAxis": {
+                    "type": "log",
+                },
+                "yAxis": {
+                    "type": "log",
+                    
+                },
+                "series": [
+                    {
+                        "name": null,
+                        "type": "line",
+                        "smooth": true,
+                        "symbol": "none",
+                        "lineStyle": {
+                            "type": "solid"
+                        },
+                        "itemStyle": {
+                            "color": "#E3000B"
+                        },
+                        "areaStyle": {
+                            "color": ""
+                        },
+                        "stack": "0",
+                        "data": [
+                            [
+                                0,
+                                0.0000014737799999999998
+                            ],
+                            [
+                                0.225,
+                                0.0000014682600000000002
+                            ],
+                            [
+                                0.45,
+                                0.0000014636399999999999
+                            ],
+                            [
+                                0.675,
+                                0.00000145296
+                            ],
+                            [
+                                0.9,
+                                0.0000014407
+                            ],
+                            [
+                                1.125,
+                                0.0000014275999999999999
+                            ],
+                            [
+                                1.35,
+                                0.00000140994
+                            ],
+                            [
+                                1.575,
+                                0.0000013875399999999999
+                            ],
+                            [
+                                1.8,
+                                0.00000135424
+                            ],
+                            [
+                                2.025,
+                                0.0000013085399999999999
+                            ],
+                            [
+                                2.25,
+                                0.00000123032
+                            ],
+                            [
+                                2.475,
+                                0.0000011012000000000001
+                            ],
+                            [
+                                2.7,
+                                8.937799999999999e-7
+                            ],
+                            [
+                                2.925,
+                                6.304e-7
+                            ],
+                            [
+                                3.15,
+                                4.467e-7
+                            ],
+                            [
+                                3.375,
+                                3.6019999999999996e-7
+                            ],
+                            [
+                                3.6,
+                                3.1755e-7
+                            ],
+                            [
+                                3.825,
+                                2.93e-7
+                            ],
+                            [
+                                4.05,
+                                2.7654999999999997e-7
+                            ],
+                            [
+                                4.275,
+                                2.6430000000000006e-7
+                            ],
+                            [
+                                4.5,
+                                2.5445000000000006e-7
+                            ]
+                        ]
+                    },
+                    {
+                        "name": null,
+                        "type": "line",
+                        "smooth": true,
+                        "symbol": "none",
+                        "lineStyle": {
+                            "type": "solid"
+                        },
+                        "itemStyle": {
+                            "color": "#FE9F9B"
+                        },
+                        "areaStyle": {
+                            "color": ""
+                        },
+                        "stack": "1",
+                        "stackDim": 'y',
+                        "data": [
+                            [
+                                0,
+                                0.0000014094
+                            ],
+                            [
+                                0.225,
+                                0.0000014048
+                            ],
+                            [
+                                0.45,
+                                0.0000014004
+                            ],
+                            [
+                                0.675,
+                                0.0000013934
+                            ],
+                            [
+                                0.9,
+                                0.0000013839999999999998
+                            ],
+                            [
+                                1.125,
+                                0.0000013724
+                            ],
+                            [
+                                1.35,
+                                0.0000013586
+                            ],
+                            [
+                                1.575,
+                                0.0000013416
+                            ],
+                            [
+                                1.8,
+                                0.0000012916
+                            ],
+                            [
+                                2.025,
+                                0.0000012564
+                            ],
+                            [
+                                2.25,
+                                0.0000011756
+                            ],
+                            [
+                                2.475,
+                                0.0000010336
+                            ],
+                            [
+                                2.7,
+                                7.895e-7
+                            ],
+                            [
+                                2.925,
+                                5.1e-7
+                            ],
+                            [
+                                3.15,
+                                3.74e-7
+                            ],
+                            [
+                                3.375,
+                                3.1750000000000003e-7
+                            ],
+                            [
+                                3.6,
+                                2.87e-7
+                            ],
+                            [
+                                3.825,
+                                2.67e-7
+                            ],
+                            [
+                                4.05,
+                                2.545e-7
+                            ],
+                            [
+                                4.275,
+                                2.435e-7
+                            ],
+                            [
+                                4.5,
+                                2.3499999999999997e-7
+                            ]
+                        ]
+                    },
+                    {
+                        "name": null,
+                        "type": "line",
+                        "smooth": true,
+                        "symbol": "none",
+                        "lineStyle": {
+                            "type": "solid"
+                        },
+                        "itemStyle": {
+                            "color": "#FE9F9B"
+                        },
+                        "areaStyle": {
+                            "color": "#FE9F9B"
+                        },
+                        "stack": "1",
+                        "stackDim": 'y',
+                        "data": [
+                            [
+                                0,
+                                1.6039999999999998e-7
+                            ],
+                            [
+                                0.225,
+                                1.608e-7
+                            ],
+                            [
+                                0.45,
+                                1.5840000000000004e-7
+                            ],
+                            [
+                                0.675,
+                                1.5419999999999994e-7
+                            ],
+                            [
+                                0.9,
+                                1.478000000000003e-7
+                            ],
+                            [
+                                1.125,
+                                1.3999999999999993e-7
+                            ],
+                            [
+                                1.35,
+                                1.298e-7
+                            ],
+                            [
+                                1.575,
+                                1.1600000000000003e-7
+                            ],
+                            [
+                                1.8,
+                                1.225999999999999e-7
+                            ],
+                            [
+                                2.025,
+                                8.820000000000006e-8
+                            ],
+                            [
+                                2.25,
+                                9.02e-8
+                            ],
+                            [
+                                2.475,
+                                1.352e-7
+                            ],
+                            [
+                                2.7,
+                                2.2610000000000005e-7
+                            ],
+                            [
+                                2.925,
+                                2.565e-7
+                            ],
+                            [
+                                3.15,
+                                1.5450000000000001e-7
+                            ],
+                            [
+                                3.375,
+                                9.449999999999995e-8
+                            ],
+                            [
+                                3.6,
+                                7.05e-8
+                            ],
+                            [
+                                3.825,
+                                6.049999999999999e-8
+                            ],
+                            [
+                                4.05,
+                                5.3499999999999996e-8
+                            ],
+                            [
+                                4.275,
+                                5.050000000000009e-8
+                            ],
+                            [
+                                4.5,
+                                4.8000000000000006e-8
+                            ]
+                        ]
+                    }
+                ],
+                
+                }
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Stack data on line chart'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+        <script>
+            require([
+                'echarts',
+                // 'map/js/china',
+                // './data/nutrients.json'
+            ], function (echarts) {
+                var option;
+    
+                option = {
+                    xAxis: {
+                        type: 'value',
+                        data: [1, 2, 3, 4, 5, 6, 7]
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [120, 200, 150, 80, 70, 110, 130],
+                        type: 'bar',
+                        stack: '1',
+                        stackDim: 'y',
+                        showBackground: true,
+                        backgroundStyle: {
+                            color: 'rgba(180, 180, 180, 0.2)'
+                        }
+                        },
+                        {
+                        data: [120, 200, 150, 80, 70, 110, 130],
+                        type: 'bar',
+                        stack: '1',
+                        stackDim: 'y',
+                        showBackground: true,
+                        backgroundStyle: {
+                            color: 'rgba(180, 180, 180, 0.2)'
+                        }
+                        }
+                    ]
+                    };
+    
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Stack data on line chart'
+                    ],
+                    option: option
+                    // height: 300,
+                    // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                    // recordCanvas: true,
+                });
+            });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add series-line.stackDim to let series-line.stack work properly.



### Fixed issues


- #16744 
- #16646


## Details

### Before: What was the problem?

When using series-line.stack, and turn x-axis type into 'log' or 'value' ( or any other type that's **"stackable"**), the chart does not stack correctly. The reason why the problem happens is specified in https://github.com/apache/echarts/issues/16744#issuecomment-1078871530

Below is an example of problem happens in 
### Line chart

| Chart without stack | Chart stack correctly<br>(xAxis.type = 'category') | Chart stack incorrectly<br>(xAxis.type = 'log') |
| :----: | :----: | :----: |
| <img width="450" alt="echart_original" src="https://user-images.githubusercontent.com/14244944/160137055-d0114336-089c-4d96-9fb3-ebabe2e46325.png"> | <img width="432" alt="echart_noproblem" src="https://user-images.githubusercontent.com/14244944/160140290-ce93b4cd-b9b1-4271-831e-f3b9f0e7b2bb.png"> | <img width="429" alt="echart_problem" src="https://user-images.githubusercontent.com/14244944/160135832-b3e12a4d-1060-4a6c-8129-e6e931a17409.png"> |

<details>
<summary><b>Code to reproduce:</b></summary>
<br>

- xAxis.type = 'category': Stack correctly
- xAxis.type = 'log': Stack incorrectly

```js
option = {
    "xAxis": {
        "type": "log",
    },
    "yAxis": {
        "type": "log",
        
    },
    "series": [
        {
            "name": null,
            "type": "line",
            "smooth": true,
            "symbol": "none",
            "lineStyle": {
                "type": "solid"
            },
            "itemStyle": {
                "color": "#E3000B"
            },
            "areaStyle": {
                "color": ""
            },
            "stack": "0",
            "data": [
                [
                    0,
                    0.0000014737799999999998
                ],
                [
                    0.225,
                    0.0000014682600000000002
                ],
                [
                    0.45,
                    0.0000014636399999999999
                ],
                [
                    0.675,
                    0.00000145296
                ],
                [
                    0.9,
                    0.0000014407
                ],
                [
                    1.125,
                    0.0000014275999999999999
                ],
                [
                    1.35,
                    0.00000140994
                ],
                [
                    1.575,
                    0.0000013875399999999999
                ],
                [
                    1.8,
                    0.00000135424
                ],
                [
                    2.025,
                    0.0000013085399999999999
                ],
                [
                    2.25,
                    0.00000123032
                ],
                [
                    2.475,
                    0.0000011012000000000001
                ],
                [
                    2.7,
                    8.937799999999999e-7
                ],
                [
                    2.925,
                    6.304e-7
                ],
                [
                    3.15,
                    4.467e-7
                ],
                [
                    3.375,
                    3.6019999999999996e-7
                ],
                [
                    3.6,
                    3.1755e-7
                ],
                [
                    3.825,
                    2.93e-7
                ],
                [
                    4.05,
                    2.7654999999999997e-7
                ],
                [
                    4.275,
                    2.6430000000000006e-7
                ],
                [
                    4.5,
                    2.5445000000000006e-7
                ]
            ]
        },
        {
            "name": null,
            "type": "line",
            "smooth": true,
            "symbol": "none",
            "lineStyle": {
                "type": "solid"
            },
            "itemStyle": {
                "color": "#FE9F9B"
            },
            "areaStyle": {
                "color": ""
            },
            "stack": "1",
            "data": [
                [
                    0,
                    0.0000014094
                ],
                [
                    0.225,
                    0.0000014048
                ],
                [
                    0.45,
                    0.0000014004
                ],
                [
                    0.675,
                    0.0000013934
                ],
                [
                    0.9,
                    0.0000013839999999999998
                ],
                [
                    1.125,
                    0.0000013724
                ],
                [
                    1.35,
                    0.0000013586
                ],
                [
                    1.575,
                    0.0000013416
                ],
                [
                    1.8,
                    0.0000012916
                ],
                [
                    2.025,
                    0.0000012564
                ],
                [
                    2.25,
                    0.0000011756
                ],
                [
                    2.475,
                    0.0000010336
                ],
                [
                    2.7,
                    7.895e-7
                ],
                [
                    2.925,
                    5.1e-7
                ],
                [
                    3.15,
                    3.74e-7
                ],
                [
                    3.375,
                    3.1750000000000003e-7
                ],
                [
                    3.6,
                    2.87e-7
                ],
                [
                    3.825,
                    2.67e-7
                ],
                [
                    4.05,
                    2.545e-7
                ],
                [
                    4.275,
                    2.435e-7
                ],
                [
                    4.5,
                    2.3499999999999997e-7
                ]
            ]
        },
        {
            "name": null,
            "type": "line",
            "smooth": true,
            "symbol": "none",
            "lineStyle": {
                "type": "solid"
            },
            "itemStyle": {
                "color": "#FE9F9B"
            },
            "areaStyle": {
                "color": "#FE9F9B"
            },
            "stack": "1",
            "data": [
                [
                    0,
                    1.6039999999999998e-7
                ],
                [
                    0.225,
                    1.608e-7
                ],
                [
                    0.45,
                    1.5840000000000004e-7
                ],
                [
                    0.675,
                    1.5419999999999994e-7
                ],
                [
                    0.9,
                    1.478000000000003e-7
                ],
                [
                    1.125,
                    1.3999999999999993e-7
                ],
                [
                    1.35,
                    1.298e-7
                ],
                [
                    1.575,
                    1.1600000000000003e-7
                ],
                [
                    1.8,
                    1.225999999999999e-7
                ],
                [
                    2.025,
                    8.820000000000006e-8
                ],
                [
                    2.25,
                    9.02e-8
                ],
                [
                    2.475,
                    1.352e-7
                ],
                [
                    2.7,
                    2.2610000000000005e-7
                ],
                [
                    2.925,
                    2.565e-7
                ],
                [
                    3.15,
                    1.5450000000000001e-7
                ],
                [
                    3.375,
                    9.449999999999995e-8
                ],
                [
                    3.6,
                    7.05e-8
                ],
                [
                    3.825,
                    6.049999999999999e-8
                ],
                [
                    4.05,
                    5.3499999999999996e-8
                ],
                [
                    4.275,
                    5.050000000000009e-8
                ],
                [
                    4.5,
                    4.8000000000000006e-8
                ]
            ]
        }
    ],
}
```
</details>

### Bar chart

| Chart without stack | Chart stack correctly<br>(xAxis.type = 'category') | Chart stack incorrectly<br>(xAxis.type = 'value') |
| :----: | :----: | :----: |
| <img width="483" alt="echart_original_bar" src="https://user-images.githubusercontent.com/14244944/160137759-815a5ecb-0d79-49bf-9bf6-76bb57b8ed25.png"> | <img width="450" alt="echart_noproblem_bar" src="https://user-images.githubusercontent.com/14244944/160140813-51ea4803-f692-4346-ae6f-283321785a26.png"> | <img width="456" alt="echart_problem_bar" src="https://user-images.githubusercontent.com/14244944/160137800-a760c7a1-4389-4c3c-adb3-ed7eacef1c4a.png"> |

<details>
<summary><b>Code to reproduce:</b></summary>
<br>

- xAxis.type = 'category': Stack correctly
- xAxis.type = 'value': Stack incorrectly

```js
option = {
  xAxis: {
    type: 'value',
    data: [1,2,3,4,5,6,7]
  },
  yAxis: {
    type: 'value'
  },
  series: [
    {
      data: [120, 200, 150, 80, 70, 110, 130],
      type: 'bar',
      stack: '1',
      showBackground: true,
      backgroundStyle: {
        color: 'rgba(180, 180, 180, 0.2)'
      }
    },
    {
      data: [120, 200, 150, 80, 70, 110, 130],
      type: 'bar',
      stack: '1',
      showBackground: true,
      backgroundStyle: {
        color: 'rgba(180, 180, 180, 0.2)'
      }
    },
  ]
};
```
</details>

### After: How is it fixed in this PR?

After fix and adding `series.stackDim: 'y'` to option, the data can stacked correctly.

### Line chart

**Chart stack correctly after fix**

<img width="426" alt="echart_fix" src="https://user-images.githubusercontent.com/14244944/160137254-aee3586b-38fe-42f2-b271-b69a459e742b.png">

<details>
<summary><b>Code to reproduce:</b></summary>

```js
option = {
  "xAxis": {
      "type": "log",
  },
  "yAxis": {
      "type": "log",
      
  },
  "series": [
      {
          "name": null,
          "type": "line",
          "smooth": true,
          "symbol": "none",
          "lineStyle": {
              "type": "solid"
          },
          "itemStyle": {
              "color": "#E3000B"
          },
          "areaStyle": {
              "color": ""
          },
          "stack": "0",
          "data": [
              [
                  0,
                  0.0000014737799999999998
              ],
              [
                  0.225,
                  0.0000014682600000000002
              ],
              [
                  0.45,
                  0.0000014636399999999999
              ],
              [
                  0.675,
                  0.00000145296
              ],
              [
                  0.9,
                  0.0000014407
              ],
              [
                  1.125,
                  0.0000014275999999999999
              ],
              [
                  1.35,
                  0.00000140994
              ],
              [
                  1.575,
                  0.0000013875399999999999
              ],
              [
                  1.8,
                  0.00000135424
              ],
              [
                  2.025,
                  0.0000013085399999999999
              ],
              [
                  2.25,
                  0.00000123032
              ],
              [
                  2.475,
                  0.0000011012000000000001
              ],
              [
                  2.7,
                  8.937799999999999e-7
              ],
              [
                  2.925,
                  6.304e-7
              ],
              [
                  3.15,
                  4.467e-7
              ],
              [
                  3.375,
                  3.6019999999999996e-7
              ],
              [
                  3.6,
                  3.1755e-7
              ],
              [
                  3.825,
                  2.93e-7
              ],
              [
                  4.05,
                  2.7654999999999997e-7
              ],
              [
                  4.275,
                  2.6430000000000006e-7
              ],
              [
                  4.5,
                  2.5445000000000006e-7
              ]
          ]
      },
      {
          "name": null,
          "type": "line",
          "smooth": true,
          "symbol": "none",
          "lineStyle": {
              "type": "solid"
          },
          "itemStyle": {
              "color": "#FE9F9B"
          },
          "areaStyle": {
              "color": ""
          },
          "stack": "1",
          "stackDim": 'y',
          "data": [
              [
                  0,
                  0.0000014094
              ],
              [
                  0.225,
                  0.0000014048
              ],
              [
                  0.45,
                  0.0000014004
              ],
              [
                  0.675,
                  0.0000013934
              ],
              [
                  0.9,
                  0.0000013839999999999998
              ],
              [
                  1.125,
                  0.0000013724
              ],
              [
                  1.35,
                  0.0000013586
              ],
              [
                  1.575,
                  0.0000013416
              ],
              [
                  1.8,
                  0.0000012916
              ],
              [
                  2.025,
                  0.0000012564
              ],
              [
                  2.25,
                  0.0000011756
              ],
              [
                  2.475,
                  0.0000010336
              ],
              [
                  2.7,
                  7.895e-7
              ],
              [
                  2.925,
                  5.1e-7
              ],
              [
                  3.15,
                  3.74e-7
              ],
              [
                  3.375,
                  3.1750000000000003e-7
              ],
              [
                  3.6,
                  2.87e-7
              ],
              [
                  3.825,
                  2.67e-7
              ],
              [
                  4.05,
                  2.545e-7
              ],
              [
                  4.275,
                  2.435e-7
              ],
              [
                  4.5,
                  2.3499999999999997e-7
              ]
          ]
      },
      {
          "name": null,
          "type": "line",
          "smooth": true,
          "symbol": "none",
          "lineStyle": {
              "type": "solid"
          },
          "itemStyle": {
              "color": "#FE9F9B"
          },
          "areaStyle": {
              "color": "#FE9F9B"
          },
          "stack": "1",
          "stackDim": 'y',
          "data": [
              [
                  0,
                  1.6039999999999998e-7
              ],
              [
                  0.225,
                  1.608e-7
              ],
              [
                  0.45,
                  1.5840000000000004e-7
              ],
              [
                  0.675,
                  1.5419999999999994e-7
              ],
              [
                  0.9,
                  1.478000000000003e-7
              ],
              [
                  1.125,
                  1.3999999999999993e-7
              ],
              [
                  1.35,
                  1.298e-7
              ],
              [
                  1.575,
                  1.1600000000000003e-7
              ],
              [
                  1.8,
                  1.225999999999999e-7
              ],
              [
                  2.025,
                  8.820000000000006e-8
              ],
              [
                  2.25,
                  9.02e-8
              ],
              [
                  2.475,
                  1.352e-7
              ],
              [
                  2.7,
                  2.2610000000000005e-7
              ],
              [
                  2.925,
                  2.565e-7
              ],
              [
                  3.15,
                  1.5450000000000001e-7
              ],
              [
                  3.375,
                  9.449999999999995e-8
              ],
              [
                  3.6,
                  7.05e-8
              ],
              [
                  3.825,
                  6.049999999999999e-8
              ],
              [
                  4.05,
                  5.3499999999999996e-8
              ],
              [
                  4.275,
                  5.050000000000009e-8
              ],
              [
                  4.5,
                  4.8000000000000006e-8
              ]
          ]
      }
  ],
}
```
</details>

### Bar chart

**Chart stack correctly after fix**

<img width="449" alt="echart_fix_bar" src="https://user-images.githubusercontent.com/14244944/160137818-1c1b3e80-06df-4a9d-aa16-edf5da505b79.png">

<details>
<summary><b>Code to reproduce:</b></summary>

```js
option = {
  xAxis: {
    type: 'value',
    data: [1, 2, 3, 4, 5, 6, 7]
  },
  yAxis: {
    type: 'value'
  },
  series: [
    {
      data: [120, 200, 150, 80, 70, 110, 130],
      type: 'bar',
      stack: '1',
      stackDim: 'y',
      showBackground: true,
      backgroundStyle: {
        color: 'rgba(180, 180, 180, 0.2)'
      }
    },
    {
      data: [120, 200, 150, 80, 70, 110, 130],
      type: 'bar',
      stack: '1',
      stackDim: 'y',
      showBackground: true,
      backgroundStyle: {
        color: 'rgba(180, 180, 180, 0.2)'
      }
    }
  ]
};
```
</details>

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).
