### PR TITLE
fix: Dump areaStyle polygon when notMerge is true

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -730,6 +730,10 @@ class LineView extends ChartView {
                 polygon = this._newPolygon(
                     points, stackedOnPoints
                 );
+            }// If areaStyle is removed
+            else if(polygon){
+                lineGroup.remove(polygon);
+                polygon = this._polygon = null;
             }
 
             // NOTE: Must update _endLabel before setClipPath.

--- a/test/setOption.html
+++ b/test/setOption.html
@@ -40,6 +40,7 @@ under the License.
 
 
         <div id="main0"></div>
+        <div id="main1"></div>
 
 
         <script>
@@ -154,6 +155,45 @@ under the License.
 
             });
 
+        </script>
+
+        <script>
+            require([
+                'echarts'/*, 'map/js/china' */
+            ], function (echarts) {
+                var option;
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [820, 932, 901, 934, 1290, 1330, 1320],
+                        type: 'line',
+                        areaStyle: {}
+                        }
+                    ]
+                };
+                chart = myChart = testHelper.create(echarts, 'main1', {
+                    title: 'Click the two buttons. Animation should be appropriate, and dataZoom state should be kept.',
+                    option: option,
+                    buttons: {
+                        text: 'setOption: with notMerge mode' ,
+                        onClick: function () {
+                            option.series.map(s => {
+                                s.step = 'end';
+                                delete s.areaStyle;
+                            });
+                            myChart.setOption(option,{ notMerge: true });
+                        }
+                    }
+                })
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the problem where area shading is not removed after setting chart to be step chart without areaStyle.



### Fixed issues


- #16769



## Details

### Before: What was the problem?

When a line chart with area shade on, changes its option in notMerge mode into a step line chart and turned off the area shade, the previous area shade would not disappear. The causing code is discussed here: https://github.com/apache/echarts/issues/16769#issuecomment-1082591304.

|Before change Option|After change Option|
|---|---|
|<img width="518" alt="before setOption" src="https://user-images.githubusercontent.com/14244944/160765396-0178d574-ff5c-4347-8ef8-fe10b91eba0c.png">|<img width="512" alt="after setOption-bug" src="https://user-images.githubusercontent.com/14244944/160765453-355ede23-7e56-4085-a1c2-6b651a7429e4.png">


### After: How is it fixed in this PR?

Add an `else` to dump the `polygon` if `isAreaChart` is false.

|Before change Option|After change Option|
|---|---|
|<img width="518" alt="before setOption" src="https://user-images.githubusercontent.com/14244944/160765396-0178d574-ff5c-4347-8ef8-fe10b91eba0c.png">|<img width="459" alt="after setOption-fix" src="https://user-images.githubusercontent.com/14244944/160765877-e50d4d0e-a07a-45ab-9783-ffe4539b94ed.png">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

**A test case is added in test/setOption.html**


