### PR TITLE
chore(asf): set notification targets

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -60,4 +60,8 @@ github:
         required_approving_review_count: 1
       required_linear_history: false
       required_signatures: false
-
+  notifications:
+    commits: commits@echarts.apache.org
+    issues: issues@echarts.apache.org
+    pullrequests: pr@echarts.apache.org
+    jobs: notifications@echarts.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -60,8 +60,9 @@ github:
         required_approving_review_count: 1
       required_linear_history: false
       required_signatures: false
-  notifications:
-    commits: commits@echarts.apache.org
-    issues: issues@echarts.apache.org
-    pullrequests: pr@echarts.apache.org
-    jobs: notifications@echarts.apache.org
+
+notifications:
+  commits: commits@echarts.apache.org
+  issues: issues@echarts.apache.org
+  pullrequests: pr@echarts.apache.org
+  jobs: notifications@echarts.apache.org


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?

Distribute the issue and pull request notifications to different mailing lists to prevent too many emails from being sent to the **dev** mailing list.

But we have no other available mailing list to receive these emails. If we don't choose to send them to the **commits** mailing list, we may need to request several new mailing lists.

From my perspective, the proposed mailing lists are as follows,

Either use a total mailing list like `github@echarts.apache.org`, or use different mailing lists for different targets.

- `issues@echarts.apache.org` (for issues)
- `pr@echarts.apache.org` / `pullrequests@echarts.apache.org` (for pull requests)
- `notifications@echarts.apache.org` / `jobs@echarts.apache.org` (for various notifications like GitHub actions)

FYI, here are the mailing lists of some other projects.

- https://lists.apache.org/list.html?dev@zookeeper.apache.org
- https://lists.apache.org/list.html?dev@airflow.apache.org
- https://lists.apache.org/list.html?dev@dolphinscheduler.apache.org