### PR TITLE
[infra] reset notifications to commits@echarts for commits, PRs and issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,3 +61,7 @@ github:
       required_linear_history: false
       required_signatures: false
 
+notifications:
+    commits: commits@echarts.apache.org
+    pullrequests: commits@echarts.apache.org
+    issues: commits@echarts.apache.org


### PR DESCRIPTION
This will reset your notifications back to commits@infra for PRs and issues.