### PR TITLE
fix: xAxis label overflow fixed when containLabel=true

### DIFF
--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -292,9 +292,9 @@ export function getAxisRawValue(axis: Axis, tick: ScaleTick): number | string {
 
 /**
  * @param axis
- * @return Be null/undefined if no labels.
+ * @return Return the largest, first and the last label BoundingRects. Be null/undefined if no labels.
  */
-export function estimateLabelUnionRect(axis: Axis) {
+export function estimateLabelRect(axis: Axis) {
     const axisModel = axis.model;
     const scale = axis.scale;
 
@@ -319,6 +319,8 @@ export function estimateLabelUnionRect(axis: Axis) {
     const labelFormatter = makeLabelFormatter(axis);
 
     let rect;
+    let firstLabelRect;
+    let lastLabelRect;
     let step = 1;
     // Simple optimization for large amount of labels
     if (tickCount > 40) {
@@ -333,11 +335,16 @@ export function estimateLabelUnionRect(axis: Axis) {
         const label = labelFormatter(tick, i);
         const unrotatedSingleRect = axisLabelModel.getTextRect(label);
         const singleRect = rotateTextRect(unrotatedSingleRect, axisLabelModel.get('rotate') || 0);
-
+        if (i === 0) {
+            firstLabelRect = new BoundingRect(singleRect.x, singleRect.y, singleRect.width, singleRect.height);
+        }
+        if (i + step >= tickCount) {
+            lastLabelRect = new BoundingRect(singleRect.x, singleRect.y, singleRect.width, singleRect.height);
+        }
         rect ? rect.union(singleRect) : (rect = singleRect);
     }
 
-    return rect;
+    return {rect, firstLabelRect, lastLabelRect};
 }
 
 function rotateTextRect(textRect: RectLike, rotate: number) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the problem of xAxis label overflow when `grid.contailLabel` is true.



### Fixed issues

- fix #16875



## Details

### Before: What was the problem?

As is described in https://github.com/apache/echarts/issues/16875#issuecomment-1097508437, overflow of x-axis label is not considered when applying `grid.containLabel`. 

<img width="552" alt="before#16875" src="https://user-images.githubusercontent.com/14244944/163195891-268ada63-1e0d-44da-9cb3-72614f4e1b22.png">

### After: How is it fixed in this PR?

Judgements whether the label will exceed boundary are added and grid will be adjusted accordingly.

<img width="455" alt="after#16875" src="https://user-images.githubusercontent.com/14244944/163196358-c89bd83f-cc8c-4923-9586-6924841ba22e.png">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Attached
### Merging options

- [x] Please squash the commits into a single one when merging.

