### PR TITLE
fix: all data mapped to one col when zooming in

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -129,7 +129,12 @@ class Axis {
             fixExtentWithBands(extent, (scale as OrdinalScale).count());
         }
 
-        return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
+        if ((extent[0] === extent[1]) && (data < 0 || data > 1)) {
+            return data * extent[0] * 2
+        } 
+        else {
+            return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
+        }
     }
 
     /**

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -130,8 +130,8 @@ class Axis {
         }
 
         if ((extent[0] === extent[1]) && (data < 0 || data > 1)) {
-            return data * extent[0] * 2
-        } 
+            return data * extent[0] * 2;
+        }
         else {
             return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
         }

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -128,13 +128,7 @@ class Axis {
             extent = extent.slice() as [number, number];
             fixExtentWithBands(extent, (scale as OrdinalScale).count());
         }
-
-        if ((extent[0] === extent[1]) && (data < 0 || data > 1)) {
-            return data * extent[0] * 2;
-        }
-        else {
-            return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
-        }
+        return linearMap(data, NORMALIZED_EXTENT, extent, clamp, true);
     }
 
     /**

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -128,12 +128,7 @@ export function contain(val: number, extent: [number, number]): boolean {
 
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
-        if (val !== extent[0]) {
-            return val - extent[0] + 0.5;
-        }
-        else {
-            return 0.5;
-        }
+        return val - extent[0] + 0.5;
     }
     return (val - extent[0]) / (extent[1] - extent[0]);
 }

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -128,7 +128,7 @@ export function contain(val: number, extent: [number, number]): boolean {
 
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
-        if (val != extent[0]){
+        if (val !== extent[0]) {
             return val - extent[0] + 0.5
         }
         else {

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -129,7 +129,7 @@ export function contain(val: number, extent: [number, number]): boolean {
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
         if (val !== extent[0]) {
-            return val - extent[0] + 0.5
+            return val - extent[0] + 0.5;
         }
         else {
             return 0.5;

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -129,13 +129,13 @@ export function contain(val: number, extent: [number, number]): boolean {
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
         if (val < extent[0]) {
-            return -0.5
+            return -0.5;
         }
         else if (val > extent[0]) {
-            return 1.5
+            return 1.5;
         }
         else {
-            return 0.5
+            return 0.5;
         }
     }
     return (val - extent[0]) / (extent[1] - extent[0]);

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -128,7 +128,12 @@ export function contain(val: number, extent: [number, number]): boolean {
 
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
-        return 0.5;
+        if (val != extent[0]){
+            return val - extent[0] + 0.5
+        }
+        else {
+            return 0.5;
+        }
     }
     return (val - extent[0]) / (extent[1] - extent[0]);
 }

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -128,7 +128,15 @@ export function contain(val: number, extent: [number, number]): boolean {
 
 export function normalize(val: number, extent: [number, number]): number {
     if (extent[1] === extent[0]) {
-        return val - extent[0] + 0.5;
+        if (val < extent[0]) {
+            return -0.5
+        }
+        else if (val > extent[0]) {
+            return 1.5
+        }
+        else {
+            return 0.5
+        }
     }
     return (val - extent[0]) / (extent[1] - extent[0]);
 }

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -67,7 +67,8 @@ export function linearMap(
     //Solving issue #16746, #16852, #17014
     //Check if the mapped-to subRange is a point r0 and val is outside the domain to map
     //If so, val should not exist and never equal to the point r0, returning NaN
-    //However somewhere this function is applied would not accept NaN like returning as index
+    //However somewhere this function is applied would not accept NaN 
+    //For example visualMapping.ts line 637 the result returned is used as index
     //So an option `canBeNaN` is added to toggle if the result can be NaN, by default false
     if ((subRange === 0) && ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1)))) {
         return canBeNaN ? NaN : r0;

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -67,7 +67,7 @@ export function linearMap(
     //Solving issue #16746, #16852, #17014
     //Check if the mapped-to subRange is a point r0 and val is outside the domain to map
     //If so, val should not be mapped to the point r0, returning NaN
-    //However somewhere this function is applied would not accept NaN 
+    //However somewhere this function is applied would not accept NaN
     //For example visualMapping.ts line 637 the result returned is used as index
     //So an option `canBeNaN` is added to toggle if the result can be NaN, by default false
     if ((subRange === 0) && ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1)))) {

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -58,8 +58,10 @@ export function linearMap(
     const subDomain = d1 - d0;
     const subRange = r1 - r0;
 
-    if (subRange === 0) {
+    if ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1))) {
+      if (subRange === 0) {
         return val * 2 * r0;
+      }
     }
     if (subDomain === 0) {
         return subRange === 0

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -63,12 +63,6 @@ export function linearMap(
             ? r0
             : (r0 + r1) / 2;
     }
-    if ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1))) {
-        if (subRange === 0) {
-          return (val - d0) / subDomain * 2 * r0;
-        }
-    }
-
     // Avoid accuracy problem in edge, such as
     // 146.39 - 62.83 === 83.55999999999999.
     // See echarts/test/ut/spec/util/number.js#linearMap#accuracyError

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -66,7 +66,7 @@ export function linearMap(
     }
     //Solving issue #16746, #16852, #17014
     //Check if the mapped-to subRange is a point r0 and val is outside the domain to map
-    //If so, val should not exist and never equal to the point r0, returning NaN
+    //If so, val should not be mapped to the point r0, returning NaN
     //However somewhere this function is applied would not accept NaN 
     //For example visualMapping.ts line 637 the result returned is used as index
     //So an option `canBeNaN` is added to toggle if the result can be NaN, by default false

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -58,6 +58,10 @@ export function linearMap(
     const subDomain = d1 - d0;
     const subRange = r1 - r0;
 
+    if (subRange === 0) {
+        return val * 2 * r0;
+    }
+    
     if (subDomain === 0) {
         return subRange === 0
             ? r0

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -61,7 +61,6 @@ export function linearMap(
     if (subRange === 0) {
         return val * 2 * r0;
     }
-       
     if (subDomain === 0) {
         return subRange === 0
             ? r0

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -48,7 +48,8 @@ export function linearMap(
     val: number,
     domain: number[],
     range: number[],
-    clamp?: boolean
+    clamp?: boolean,
+    canBeNaN: boolean = false
 ): number {
     const d0 = domain[0];
     const d1 = domain[1];
@@ -62,6 +63,14 @@ export function linearMap(
         return subRange === 0
             ? r0
             : (r0 + r1) / 2;
+    }
+    //Solving issue #16746, #16852, #17014
+    //Check if the mapped-to subRange is a point r0 and val is outside the domain to map
+    //If so, val should not exist and never equal to the point r0, returning NaN
+    //However somewhere this function is applied would not accept NaN like returning as index
+    //So an option `canBeNaN` is added to toggle if the result can be NaN, by default false
+    if ((subRange === 0) && ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1)))) {
+        return canBeNaN ? NaN : r0;
     }
     // Avoid accuracy problem in edge, such as
     // 146.39 - 62.83 === 83.55999999999999.

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -58,15 +58,15 @@ export function linearMap(
     const subDomain = d1 - d0;
     const subRange = r1 - r0;
 
-    if ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1))) {
-      if (subRange === 0) {
-        return val * 2 * r0;
-      }
-    }
     if (subDomain === 0) {
         return subRange === 0
             ? r0
             : (r0 + r1) / 2;
+    }
+    if ((val < Math.min(d0, d1)) || (val > Math.max(d0, d1))) {
+        if (subRange === 0) {
+          return (val - d0) / subDomain * 2 * r0;
+        }
     }
 
     // Avoid accuracy problem in edge, such as

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -61,7 +61,7 @@ export function linearMap(
     if (subRange === 0) {
         return val * 2 * r0;
     }
-    
+       
     if (subDomain === 0) {
         return subRange === 0
             ? r0

--- a/test/dataZoom-cartesian-v.html
+++ b/test/dataZoom-cartesian-v.html
@@ -23,6 +23,7 @@ under the License.
         <meta charset="utf-8">
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
     </head>
     <body>
         <style>
@@ -32,6 +33,8 @@ under the License.
             }
         </style>
         <div id="main"></div>
+        <div id="main1" style="width: 800px; height: 400px;"></div>
+        <div id="main2" style="width: 800px; height: 400px;"></div>
         <script>
 
             require([
@@ -90,6 +93,92 @@ under the License.
                         yAxisIndex: [0]
                     }
                 });
+            })
+
+        </script>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var chart = echarts.init(document.getElementById('main1'), null, {});
+            chart.setOption( option={
+                    title:{
+                        text: 'Zoom(scrollbar) in to one column'
+                    },
+                    xAxis: { min: 0, max: 4, data: ["a", "b", "c"], type: "category" },
+                    yAxis: { min: 0, max: 70 },
+                    toolbox: {
+                        feature: {
+                        dataZoom: {
+                            brushStyle: { color: "rgba(0, 145, 255, 0.5)" },
+                            filterMode: "none" // prevents that lines disappear when zooming in
+                        },
+                        restore: {}
+                        }
+                    },
+                    series: [
+                        {
+                        name: "category 1",
+                        data: [
+                            ["a", 10],
+                            ["a", 40]
+                        ],
+                        type: "scatter"
+                        },
+                        {
+                        name: "category 2",
+                        data: [
+                            ["b", 20],
+                            ["b", 50]
+                        ],
+                        type: "line"
+                        },
+                        {
+                        name: "category 3",
+                        data: [
+                            ["c", 30],
+                            ["c", 60]
+                        ],
+                        type: "scatter"
+                        }
+                    ]
+                });
+                // chart = testHelper.create(echarts, 'main1', {
+                //     title: 'Zoom in to one category column',
+                //     option: option
+                // });
+            })
+
+        </script>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var chart = echarts.init(document.getElementById('main2'), null, {});
+                chart.setOption( option = {
+                    title:{
+                        text: 'Zoom(inside) in to one column'
+                    },
+                    dataZoom: [
+                        { filterMode: 'none', type: 'inside', xAxisIndex: [0] },
+                        { filterMode: 'none', type: 'inside', yAxisIndex: [0] }
+                    ],
+                    xAxis: { type: 'category', data: ['Mon', 'Tue'] },
+                    yAxis: { type: 'value' },
+                    series: [
+                        {
+                        data: [
+                            { value: 20, itemStyle: { color: 'green' } },
+                            { value: 200, itemStyle: { color: 'red' } }
+                        ],
+                        type: 'bar'
+                        }
+                    ]
+                });
+                // chart = testHelper.create(echarts, 'main1', {
+                //     title: 'Zoom in to one category column',
+                //     option: option
+                // });
             })
 
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the bug that when zooming in to only one column, all data is mapped on the very data.

### Fixed issues


- fix #16746 
- fix #16852
- fix #17014 


## Details

### Before: What was the problem?

The problem usually occurs when zooming in to one category column, then all data is mapped to the very same column. Why the problem occurs can be referred to here: https://github.com/apache/echarts/issues/16746#issuecomment-1100036918

#### #16746 
| Before Zoom In | After Zoom In |
| --- | --- |
|<img width="437" alt="before#16746" src="https://user-images.githubusercontent.com/14244944/163656908-3ea0bc01-041d-440a-95bf-6fb2bf9f80ec.png">|<img width="450" alt="before-zoomIn#16746" src="https://user-images.githubusercontent.com/14244944/163656923-81ac35b7-1efa-43d0-98bd-4230e0b00bf7.png">|

#### #16852 
| Before Zoom In | After Zoom In |
| --- | --- |
|<img width="426" alt="before2#16746" src="https://user-images.githubusercontent.com/14244944/163656940-76cbf076-6e85-4463-8782-14e3346718a5.png">|<img width="418" alt="before2-zoomIn#16746" src="https://user-images.githubusercontent.com/14244944/163656947-98d1a6c2-cfcf-4e0a-803e-931de32d44c7.png">|

### After: How is it fixed in this PR?

The problem is solved by adding a condition statement in both [places](https://github.com/apache/echarts/issues/16746#issuecomment-1100036918) where bugs exist. Now Echarts will correcty treat the location of item when extent[0] = extent[1].

#### #16746 
| Before Zoom In | After Zoom In |
| --- | --- |
|<img width="437" alt="before#16746" src="https://user-images.githubusercontent.com/14244944/163656908-3ea0bc01-041d-440a-95bf-6fb2bf9f80ec.png">|<img width="441" alt="after-zoomIn#16746" src="https://user-images.githubusercontent.com/14244944/163657063-193284fd-1353-4928-a382-cc8f65eaf1ec.png">|

#### #16852 
| Before Zoom In | After Zoom In |
| --- | --- |
|<img width="426" alt="before2#16746" src="https://user-images.githubusercontent.com/14244944/163656940-76cbf076-6e85-4463-8782-14e3346718a5.png">|<img width="431" alt="after2-zoomIn#16746" src="https://user-images.githubusercontent.com/14244944/163657091-1e0cfb4d-3550-45ab-9267-1ef51d9515d1.png">|


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Attached

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
