### PR TITLE
fix(custom): provide generic for itemStyle. close #16775

### DIFF
--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -319,7 +319,7 @@ export type CustomSeriesRenderItem = (
     api: CustomSeriesRenderItemAPI
 ) => CustomSeriesRenderItemReturn;
 
-export interface CustomSeriesOption<TCbParams = never> extends
+export interface CustomSeriesOption<CallbackDataParams = never> extends
     SeriesOption<unknown>,    // don't support StateOption in custom series.
     SeriesEncodeOptionMixin,
     SeriesOnCartesianOptionMixin,
@@ -338,7 +338,7 @@ export interface CustomSeriesOption<TCbParams = never> extends
     /**
      * @deprecated
      */
-    itemStyle?: ItemStyleOption<TCbParams>;
+    itemStyle?: ItemStyleOption<CallbackDataParams>;
     /**
      * @deprecated
      */

--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -319,7 +319,7 @@ export type CustomSeriesRenderItem = (
     api: CustomSeriesRenderItemAPI
 ) => CustomSeriesRenderItemReturn;
 
-export interface CustomSeriesOption extends
+export interface CustomSeriesOption<TCbParams = never> extends
     SeriesOption<unknown>,    // don't support StateOption in custom series.
     SeriesEncodeOptionMixin,
     SeriesOnCartesianOptionMixin,
@@ -338,7 +338,7 @@ export interface CustomSeriesOption extends
     /**
      * @deprecated
      */
-    itemStyle?: ItemStyleOption;
+    itemStyle?: ItemStyleOption<TCbParams>;
     /**
      * @deprecated
      */


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ x ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes the TS error in case color is provided as a callback.



### Fixed issues

#16775


## Details

### Before: What was the problem?
```
series: [
    {
      type: 'custom',
      name: 'trend',
      itemStyle: {
        color: function f(_item){ //TS error
          return "red"
        }
      },
```



### After: How is it fixed in this PR?

Now the generic parameter can be passed to CustomChart to properly define a callback for `color` property.



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
