### PR TITLE
fix: legend visual still with decal when user set 'legend.itemStyle.decal' to 'none'

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -49,6 +49,7 @@ import Model from '../../model/Model';
 import {LineStyleProps} from '../../model/mixin/lineStyle';
 import {createSymbol, ECSymbol} from '../../util/symbol';
 import SeriesModel from '../../model/Series';
+import { createOrUpdatePatternFromDecal } from '../../util/decal';
 
 const curry = zrUtil.curry;
 const each = zrUtil.each;
@@ -564,10 +565,14 @@ function getLegendStyle(
     const legendItemModel = legendModel.getModel('itemStyle') as Model<LegendItemStyleOption>;
     const itemStyle = legendItemModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
-
-    if (itemStyle.decal !== 'none') {
+    const decalStyle = legendItemModel.getShallow('decal', false);
+    if (decalStyle === 'inherit') {
         itemStyle.decal = itemVisualStyle.decal;
+    } 
+    else {
+        itemStyle.decal = createOrUpdatePatternFromDecal(decalStyle, legendItemModel.ecModel.scheduler.api);
     }
+    
     if (itemStyle.fill === 'inherit') {
         /**
          * Series with visualDrawType as 'stroke' should have

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -565,7 +565,9 @@ function getLegendStyle(
     const itemStyle = legendItemModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
 
-    itemStyle.decal = itemVisualStyle.decal;
+    if (itemStyle.decal !== 'none') {
+        itemStyle.decal = itemVisualStyle.decal;
+    }
     if (itemStyle.fill === 'inherit') {
         /**
          * Series with visualDrawType as 'stroke' should have

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -542,7 +542,7 @@ class LegendView extends ComponentView {
 
 function getLegendStyle(
     iconType: string,
-    legendModel: LegendModel['_data'][number],
+    legendItemModel: LegendModel['_data'][number],
     lineVisualStyle: PathStyleProps,
     itemVisualStyle: PathStyleProps,
     drawType: 'fill' | 'stroke',
@@ -565,10 +565,10 @@ function getLegendStyle(
     }
 
     // itemStyle
-    const legendItemModel = legendModel.getModel('itemStyle') as Model<LegendItemStyleOption>;
-    const itemStyle = legendItemModel.getItemStyle();
+    const itemStyleModel = legendItemModel.getModel('itemStyle') as Model<LegendItemStyleOption>;
+    const itemStyle = itemStyleModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
-    const decalStyle = legendItemModel.getShallow('decal', false);
+    const decalStyle = itemStyleModel.getShallow('decal', false);
     itemStyle.decal = (!decalStyle || decalStyle === 'inherit')
                     ? itemVisualStyle.decal
                     : createOrUpdatePatternFromDecal(decalStyle, api);
@@ -596,7 +596,7 @@ function getLegendStyle(
     handleCommonProps(itemStyle, itemVisualStyle);
 
     // lineStyle
-    const legendLineModel = legendModel.getModel('lineStyle') as Model<LegendLineStyleOption>;
+    const legendLineModel = legendItemModel.getModel('lineStyle') as Model<LegendLineStyleOption>;
     const lineStyle: LineStyleProps = legendLineModel.getLineStyle();
     handleCommonProps(lineStyle, lineVisualStyle);
 
@@ -606,7 +606,7 @@ function getLegendStyle(
     (lineStyle.stroke === 'auto') && (lineStyle.stroke = itemVisualStyle.fill);
 
     if (!isSelected) {
-        const borderWidth = legendModel.get('inactiveBorderWidth');
+        const borderWidth = legendItemModel.get('inactiveBorderWidth');
         /**
          * Since stroke is set to be inactiveBorderColor, it may occur that
          * there is no border in series but border in legend, so we need to
@@ -616,8 +616,8 @@ function getLegendStyle(
         itemStyle.lineWidth = borderWidth === 'auto'
             ? (itemVisualStyle.lineWidth > 0 && visualHasBorder ? 2 : 0)
             : itemStyle.lineWidth;
-        itemStyle.fill = legendModel.get('inactiveColor');
-        itemStyle.stroke = legendModel.get('inactiveBorderColor');
+        itemStyle.fill = legendItemModel.get('inactiveColor');
+        itemStyle.stroke = legendItemModel.get('inactiveBorderColor');
         lineStyle.stroke = legendLineModel.get('inactiveColor');
         lineStyle.lineWidth = legendLineModel.get('inactiveWidth');
     }

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -569,12 +569,9 @@ function getLegendStyle(
     const itemStyle = legendItemModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
     const decalStyle = legendItemModel.getShallow('decal', false);
-    if (!decalStyle || decalStyle === 'inherit') {
-        itemStyle.decal = itemVisualStyle.decal;
-    }
-    else {
-        itemStyle.decal = createOrUpdatePatternFromDecal(decalStyle, api);
-    }
+    itemStyle.decal = (!decalStyle || decalStyle === 'inherit') 
+                    ? itemVisualStyle.decal
+                    : createOrUpdatePatternFromDecal(decalStyle, api)
 
     if (itemStyle.fill === 'inherit') {
         /**

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -566,13 +566,13 @@ function getLegendStyle(
     const itemStyle = legendItemModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
     const decalStyle = legendItemModel.getShallow('decal', false);
-    if (decalStyle === 'inherit') {
+    if (!decalStyle || decalStyle === 'inherit') {
         itemStyle.decal = itemVisualStyle.decal;
-    } 
+    }
     else {
         itemStyle.decal = createOrUpdatePatternFromDecal(decalStyle, legendItemModel.ecModel.scheduler.api);
     }
-    
+
     if (itemStyle.fill === 'inherit') {
         /**
          * Series with visualDrawType as 'stroke' should have

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -568,7 +568,7 @@ function getLegendStyle(
     const itemStyleModel = legendItemModel.getModel('itemStyle') as Model<LegendItemStyleOption>;
     const itemStyle = itemStyleModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
-    const decalStyle = itemStyleModel.getShallow('decal', false);
+    const decalStyle = itemStyleModel.getShallow('decal');
     itemStyle.decal = (!decalStyle || decalStyle === 'inherit')
                     ? itemVisualStyle.decal
                     : createOrUpdatePatternFromDecal(decalStyle, api);

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -569,9 +569,9 @@ function getLegendStyle(
     const itemStyle = legendItemModel.getItemStyle();
     const iconBrushType = iconType.lastIndexOf('empty', 0) === 0 ? 'fill' : 'stroke';
     const decalStyle = legendItemModel.getShallow('decal', false);
-    itemStyle.decal = (!decalStyle || decalStyle === 'inherit') 
+    itemStyle.decal = (!decalStyle || decalStyle === 'inherit')
                     ? itemVisualStyle.decal
-                    : createOrUpdatePatternFromDecal(decalStyle, api)
+                    : createOrUpdatePatternFromDecal(decalStyle, api);
 
     if (itemStyle.fill === 'inherit') {
         /**

--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -218,7 +218,7 @@ class LegendView extends ComponentView {
                 const itemGroup = this._createItem(
                     seriesModel, name, dataIndex,
                     legendItemModel, legendModel, itemAlign,
-                    lineVisualStyle, style, legendIcon, selectMode
+                    lineVisualStyle, style, legendIcon, selectMode, api
                 );
 
                 itemGroup.on('click', curry(dispatchSelectAction, name, null, api, excludeSeriesId))
@@ -259,7 +259,7 @@ class LegendView extends ComponentView {
                         const itemGroup = this._createItem(
                             seriesModel, name, dataIndex,
                             legendItemModel, legendModel, itemAlign,
-                            {}, style, legendIcon, selectMode
+                            {}, style, legendIcon, selectMode, api
                         );
 
                         // FIXME: consider different series has items with the same name.
@@ -340,7 +340,8 @@ class LegendView extends ComponentView {
         lineVisualStyle: LineStyleProps,
         itemVisualStyle: PathStyleProps,
         legendIcon: string,
-        selectMode: LegendOption['selectedMode']
+        selectMode: LegendOption['selectedMode'],
+        api: ExtensionAPI
     ) {
         const drawType = seriesModel.visualDrawType;
         const itemWidth = legendModel.get('itemWidth');
@@ -359,7 +360,8 @@ class LegendView extends ComponentView {
             lineVisualStyle,
             itemVisualStyle,
             drawType,
-            isSelected
+            isSelected,
+            api
         );
 
         const itemGroup = new Group();
@@ -544,7 +546,8 @@ function getLegendStyle(
     lineVisualStyle: PathStyleProps,
     itemVisualStyle: PathStyleProps,
     drawType: 'fill' | 'stroke',
-    isSelected: boolean
+    isSelected: boolean,
+    api: ExtensionAPI
 ) {
     /**
      * Use series style if is inherit;
@@ -570,7 +573,7 @@ function getLegendStyle(
         itemStyle.decal = itemVisualStyle.decal;
     }
     else {
-        itemStyle.decal = createOrUpdatePatternFromDecal(decalStyle, legendItemModel.ecModel.scheduler.api);
+        itemStyle.decal = createOrUpdatePatternFromDecal(decalStyle, api);
     }
 
     if (itemStyle.fill === 'inherit') {

--- a/src/model/mixin/itemStyle.ts
+++ b/src/model/mixin/itemStyle.ts
@@ -35,7 +35,8 @@ export const ITEM_STYLE_KEY_MAP = [
     ['lineDashOffset', 'borderDashOffset'],
     ['lineCap', 'borderCap'],
     ['lineJoin', 'borderJoin'],
-    ['miterLimit', 'borderMiterLimit']
+    ['miterLimit', 'borderMiterLimit'],
+    ['decal']
     // Option decal is in `DecalObject` but style.decal is in `PatternObject`.
     // So do not transfer decal directly.
 ];

--- a/src/model/mixin/itemStyle.ts
+++ b/src/model/mixin/itemStyle.ts
@@ -35,8 +35,7 @@ export const ITEM_STYLE_KEY_MAP = [
     ['lineDashOffset', 'borderDashOffset'],
     ['lineCap', 'borderCap'],
     ['lineJoin', 'borderJoin'],
-    ['miterLimit', 'borderMiterLimit'],
-    ['decal']
+    ['miterLimit', 'borderMiterLimit']
     // Option decal is in `DecalObject` but style.decal is in `PatternObject`.
     // So do not transfer decal directly.
 ];


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the problem that the legend patterns are still with decals when user sets 'legend.itemStyle.decal' to 'none'.



### Fixed issues


- fix #16909



## Details

### Before: What was the problem?

As is described in https://github.com/apache/echarts/issues/16909#issuecomment-1104676217, `legend.itemStyle.decal` is directly overwritten by series itemStyle without checking if it's set to 'none' by user.

<img width="398" alt="before#16909" src="https://user-images.githubusercontent.com/14244944/164368789-35e1a861-6b58-4fb5-a9b0-914e4def32c5.png">

### After: How is it fixed in this PR?

By adding the 'decal' into the ITEM_STYLE_KEY_MAP, Echarts now can correctly read the value of `legend.itemstyle.decal` set by users.
By checking whether user sets `legend.itemstyle.decal` to `none`, we decide whether `decal` should be overwritten by series itemStyle.

<img width="374" alt="after#16909" src="https://user-images.githubusercontent.com/14244944/164369114-82d3f781-98f7-4473-94b2-25574f1447b8.png">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
