### PR TITLE
fix: tooltip content changes with axis extent when 'triggerOn' set to 'click'

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -257,6 +257,7 @@ class TooltipView extends ComponentView {
             // self.manuallyShowTip({x, y}) might cause tooltip hide,
             // which is not expected.
             && tooltipModel.get('triggerOn') !== 'none'
+            && tooltipModel.get('triggerOn') !== 'click'
         ) {
             const self = this;
             clearTimeout(this._refreshUpdateTimeout);

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -249,6 +249,7 @@ class TooltipView extends ComponentView {
         const tooltipModel = this._tooltipModel;
         const ecModel = this._ecModel;
         const api = this._api;
+        const triggerOn = tooltipModel.get('triggerOn');
 
         // Try to keep the tooltip show when refreshing
         if (this._lastX != null
@@ -256,8 +257,8 @@ class TooltipView extends ComponentView {
             // When user is willing to control tooltip totally using API,
             // self.manuallyShowTip({x, y}) might cause tooltip hide,
             // which is not expected.
-            && tooltipModel.get('triggerOn') !== 'none'
-            && tooltipModel.get('triggerOn') !== 'click'
+            && triggerOn !== 'none'
+            && triggerOn !== 'click'
         ) {
             const self = this;
             clearTimeout(this._refreshUpdateTimeout);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fix the problem that the tooltip changes as the axis extent changes when `triggerOn` is set to `click`



### Fixed issues


- fix #16930



## Details

### Before: What was the problem?

When `tooltip.triggerOn` is set to `'click'`, tooltip is expected to stay the same until user clicks another item. But the tool tip content will change with axis extent now after zooming in and slide the axis around. The reason causing this is stated in https://github.com/apache/echarts/issues/16930#issuecomment-1107786045

![before#16930](https://user-images.githubusercontent.com/14244944/164970031-d3722595-d6a5-4181-97e4-88dfaa163e8e.gif)


### After: How is it fixed in this PR?

The content of tooltip will stay the same until user clicks another item.


![after#16930](https://user-images.githubusercontent.com/14244944/164970476-227c8480-31cd-409d-b12e-7b482f602dcb.gif)



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
