### PR TITLE
fix: Enable 'nameTextStyle.width' to take effect

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -418,6 +418,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
             }
         }
 
+        !axisNameAvailableWidth && (axisNameAvailableWidth = textStyleModel.get('width',true));
         const textFont = textStyleModel.getFont();
 
         const truncateOpt = axisModel.get('nameTruncate', true) || {};
@@ -435,7 +436,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
                 text: name,
                 font: textFont,
                 overflow: 'truncate',
-                width: maxWidth,
+                width: Number(maxWidth),
                 ellipsis,
                 fill: textStyleModel.getTextColor()
                     || axisModel.get(['axisLine', 'lineStyle', 'color']) as ColorString,

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -418,7 +418,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
             }
         }
 
-        !axisNameAvailableWidth && (axisNameAvailableWidth = textStyleModel.get('width',true));
+        !axisNameAvailableWidth && (axisNameAvailableWidth = textStyleModel.get('width', true));
         const textFont = textStyleModel.getFont();
 
         const truncateOpt = axisModel.get('nameTruncate', true) || {};


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Enable user to use `nameTextStyle.width` to adjust the maximum width of axis name text rect.



### Fixed issues


- fix #16940 



## Details

### Before: What was the problem?

User cannot change the width of axis name text rect with attribute `nameTextStyle.width`. The reason for this can be referred to at https://github.com/apache/echarts/issues/16940#issuecomment-1108227649

<img width="942" alt="before #16940" src="https://user-images.githubusercontent.com/14244944/165050791-ddf3d277-fb89-4c56-b339-41e538db3be4.png">

### After: How is it fixed in this PR?

Now by specifying `nameTextStyle.width`, user can limit the maximum width of the text rect. 

<img width="946" alt="after #16940" src="https://user-images.githubusercontent.com/14244944/165051004-6866602e-6f21-4de7-8497-7e9fc06bd7c5.png">

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
