### PR TITLE
feat: nameFormatter and headerFormatter added

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -591,7 +591,25 @@ class TooltipView extends ComponentView {
                             [series as Model<TooltipableOption>],
                             globalTooltipModel
                         ).get('valueFormatter');
-                        axisSectionMarkup.blocks.push(valueFormatter ? extend({ valueFormatter }, frag) : frag);
+                        const nameFormatter = buildTooltipModel(
+                            [series as Model<TooltipableOption>],
+                            globalTooltipModel
+                        ).get('nameFormatter');
+                        const headerFormatter = buildTooltipModel(
+                            [series as Model<TooltipableOption>],
+                            globalTooltipModel
+                        ).get('headerFormatter');
+                        let newFrag = extend({}, frag);
+                        valueFormatter && extend(newFrag, {
+                            valueFormatter: valueFormatter
+                        });
+                        nameFormatter && extend(newFrag, {
+                            nameFormatter: nameFormatter
+                        });
+                        headerFormatter && extend(newFrag, {
+                            headerFormatter: headerFormatter
+                        });
+                        axisSectionMarkup.blocks.push(newFrag);
                     }
                     if (seriesTooltipResult.text) {
                         markupTextArrLegacy.push(seriesTooltipResult.text);
@@ -688,17 +706,24 @@ class TooltipView extends ComponentView {
         );
         const orderMode = tooltipModel.get('order');
         const valueFormatter = tooltipModel.get('valueFormatter');
+        const nameFormatter = tooltipModel.get('nameFormatter');
+        const headerFormatter = tooltipModel.get('headerFormatter');
         const frag = seriesTooltipResult.frag;
-        const markupText = frag ? buildTooltipMarkup(
-                valueFormatter ? extend({ valueFormatter }, frag) : frag,
+        let markupText = seriesTooltipResult.text;
+        if (frag) {
+            let newFrag = extend({}, frag);
+            valueFormatter && extend(newFrag, {valueFormatter: valueFormatter});
+            nameFormatter && extend(newFrag, {nameFormatter: nameFormatter});
+            headerFormatter && extend(newFrag, {headerFormatter: headerFormatter});
+            markupText = buildTooltipMarkup(
+                newFrag,
                 markupStyleCreator,
                 renderMode,
                 orderMode,
                 ecModel.get('useUTC'),
                 tooltipModel.get('textStyle')
             )
-            : seriesTooltipResult.text;
-
+        }
         const asyncTicket = 'item_' + dataModel.name + '_' + dataIndex;
 
         this._showOrMove(tooltipModel, function (this: TooltipView) {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1261,6 +1261,18 @@ export interface CommonTooltipOption<FormatterParams> {
      */
     valueFormatter?: (value: OptionDataValue | OptionDataValue[]) => string
     /**
+     * Formatter of value.
+     *
+     * Will be ignored if tooltip.formatter is specified.
+     */
+     nameFormatter?: (value: OptionDataValue | OptionDataValue[]) => string
+     /**
+     * Formatter of value.
+     *
+     * Will be ignored if tooltip.formatter is specified.
+     */
+    headerFormatter?: (value: OptionDataValue | OptionDataValue[]) => string
+    /**
      * Absolution pixel [x, y] array. Or relative percent string [x, y] array.
      * If trigger is 'item'. position can be set to 'inside' / 'top' / 'left' / 'right' / 'bottom',
      * which is relative to the hovered element.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

New APIs `tooltip.nameFormatter` and `tooltip.headerFormatter` that allow user to change name and header respectively in tooltip are added. 



### Fixed issues

- fix #16703

## Details

### Before: What was the problem?

**"New formatter"** like `tooltip.valueFormatter` is requested to change the name and header in tooltip. With these formatters users can change only the series name or the header (x-axis value), without changing the other default parts of the tooltip.

<img width="835" alt="before #16703" src="https://user-images.githubusercontent.com/14244944/165213836-56c0c870-8798-4d59-9c1d-75ffc7ba33ff.png">
Users cannot change the format of date and have to display the exact time despite they don't need it.


### After: How is it fixed in this PR?

New APIs `tooltip.nameFormatter` and `tooltip.headerFormatter` are added. They allow user to change name and header respectively in tooltip without changing other default part.

After setting `tooltip` to:
```
tooltip: {
    trigger: 'axis',
    headerFormatter: header => `${new Date(header).toDateString()}`,
    nameFormatter: name => `Score`,
    valueFormatter: value => `${value}/10`
  }
```

We have
<img width="829" alt="after #16703" src="https://user-images.githubusercontent.com/14244944/165214464-78bc7c61-4903-405d-9245-3eccec77a41c.png">
User can change name and header as wish without having to write the whole thing from scratch with `tooltip.formatter`.


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
