### PR TITLE
feat(gauge): axisLabel support angle rotating. close 15944

### DIFF
--- a/src/chart/gauge/GaugeSeries.ts
+++ b/src/chart/gauge/GaugeSeries.ts
@@ -170,8 +170,9 @@ export interface GaugeSeriesOption extends SeriesOption<GaugeStateOption, GaugeS
         lineStyle?: LineStyleOption
     }
 
-    axisLabel?: LabelOption & {
+    axisLabel?: Omit<LabelOption, 'rotate'> & {
         formatter?: LabelFormatter | string
+        rotate?: 'tangential' | 'radial' | number
     }
 
     pointer?: PointerOption
@@ -265,7 +266,8 @@ class GaugeSeriesModel extends SeriesModel<GaugeSeriesOption> {
             distance: 15,
             // formatter: null,
             color: '#464646',
-            fontSize: 12
+            fontSize: 12,
+            rotate: 0
         },
         pointer: {
             icon: null,

--- a/test/gauge-case.html
+++ b/test/gauge-case.html
@@ -65,6 +65,10 @@ under the License.
                         show: true,
                         width: 18
                     },
+                    axisLabel: {
+                        distance: 30,
+                        rotate: 50
+                    },
                     data: [
                         {
                             value: 0
@@ -101,6 +105,10 @@ under the License.
                                 name: 'SCORE'
                                 }
                         ],
+                        axisLabel: {
+                            distance: 30,
+                            rotate: 'radial'
+                        },
                         progress: {
                             show: true,
                             roundCap: true

--- a/test/gauge-simple.html
+++ b/test/gauge-simple.html
@@ -210,6 +210,7 @@ under the License.
                         color: '#464646',
                         fontSize: 20,
                         distance: -60,
+                        rotate: 'tangential',
                         formatter: function(value) {
                             if (value === 0.875) {
                                 return '优'


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:
- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

gauge text label rotate.  https://github.com/apache/echarts/issues/15944

## Details

### Before: What was the problem?

gauge text label can`t rotating by angle.


### After: How is it fixed in this PR?

add new option: `gauge-series.axisLabel.rotating`
if true, rotating label by angle.
<img width="581" alt="image" src="https://user-images.githubusercontent.com/12808432/166918941-20347921-5b35-462a-8f2b-bc0e68c9cbcc.png">
<img width="324" alt="image" src="https://user-images.githubusercontent.com/12808432/166918969-36a322de-6212-4026-ae7f-93dacb2d206f.png">



## Misc
- [x] The API has been changed (apache/echarts-doc#xxx)  


### Related test cases or examples to use the new APIs

gauge-case.html
gauge-simple.html
