### PR TITLE
fix(line): end label not flowing with line progress when setOption called twice.

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -430,7 +430,6 @@ function canShowAllSymbolForCategory(
     return true;
 }
 
-
 function isPointNull(x: number, y: number) {
     return isNaN(x) || isNaN(y);
 }
@@ -496,7 +495,6 @@ function anyStateShowEndLabel(
     return false;
 }
 
-
 interface EndLabelAnimationRecord {
     lastFrameIndex: number
     originalX?: number
@@ -526,17 +524,6 @@ function getEndlabelDuring(
             );
         }
         : null;
-    // const during = (percent: number, clipRect: graphic.Rect) => {
-    //     lineView._endLabelOnDuring(
-    //         percent,
-    //         clipRect,
-    //         data,
-    //         labelAnimationRecord,
-    //         valueAnimation,
-    //         endLabelModel,
-    //         coordSys
-    //     );
-    // };
     return during;
 }
 

--- a/test/line-setOption-twice.html
+++ b/test/line-setOption-twice.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+        <div id="main1"></div>
+        <div id="main2"></div>
+
+        <script>
+        require([
+            'echarts',
+            'data/life-expectancy-table.json'
+        ], function (echarts, data) {
+            const countries = [
+                'Finland',
+                'France',
+                'Germany',
+                'Iceland',
+                'Norway',
+                'Poland',
+                'Russia',
+                'United Kingdom'
+            ];
+            const datasetWithFilters = [];
+            const seriesList = [];
+
+            echarts.util.each(countries, function (country) {
+                var datasetId = 'dataset_' + country;
+                datasetWithFilters.push({
+                    id: datasetId,
+                    fromDatasetId: 'dataset_raw',
+                    transform: {
+                        type: 'filter',
+                        config: {
+                            and: [
+                                { dimension: 'Year', gte: 1950 },
+                                { dimension: 'Country', '=': country }
+                            ]
+                        }
+                    }
+                });
+
+                seriesList.push({
+                    type: 'line',
+                    datasetId: datasetId,
+                    showSymbol: false,
+                    name: country,
+                    endLabel: {
+                        show: true,
+                        formatter: function (params) {
+                            return params.value[3] + ': ' + params.value[0];
+                        }
+                    },
+                    labelLayout: {
+                        moveOverlap: 'shiftY'
+                    },
+                    emphasis: {
+                        focus: 'series'
+                    },
+                    encode: {
+                        x: 'Year',
+                        y: 'Income',
+                        label: ['Country', 'Income'],
+                        itemName: 'Year',
+                        tooltip: ['Income']
+                    }
+                });
+            });
+            
+            const option = {
+                animationDuration: 4000,
+                dataset: [
+                    {
+                        id: 'dataset_raw',
+                        source: data
+                    },
+                    ...datasetWithFilters
+                ],
+                title: {
+                    text: 'Income of Germany and France since 1950'
+                },
+                tooltip: {
+                    order: 'valueDesc',
+                    trigger: 'axis'
+                },
+                xAxis: {
+                    type: 'category',
+                    nameLocation: 'middle'
+                },
+                yAxis: {
+                    name: 'Income'
+                },
+                grid: {
+                    right: 140
+                },
+                series: seriesList
+            };
+
+            const chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Line\'s secondary animation effect, **endlabel** moves with the polyline'
+                ],
+                option
+            });
+            setTimeout(function() {
+                chart.setOption(option);
+            }, 2000);
+        });
+        </script>
+
+        <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            const option2 = {
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: false,
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [{
+                    data: [820, 932, 901, 934, 1290, 1330, 1320],
+                    type: 'line',
+                    areaStyle: {},
+                    endLabel: {
+                        show: true,
+                        formatter: '{b}: {c}'
+                    },
+                }],
+                animationDuration: 3000,
+                animationDurationUpdate: 3000
+            };
+
+            const chart2 = testHelper.create(echarts, 'main2', {
+                title: [
+                    'Dynamic line chart'
+                ],
+                option: option2
+            });
+
+            setTimeout(function() {
+                option2.series[0].data = [1820, 1932, 1901, 94, 290, 330, 320];
+                chart2.setOption(option2);
+            }, 1000);
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
close #16914

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

- #16914 

## Details

### Before: What was the problem?

![2022-05-07 18 03 11](https://user-images.githubusercontent.com/29879262/167250694-535455e5-54ac-40e8-9b61-d99954bffe5a.gif)

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

### After: How is it fixed in this PR?

![2022-05-07 18 01 46](https://user-images.githubusercontent.com/29879262/167250700-6be15212-d583-4ff1-9ffb-288ff740a675.gif)

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/line-setOption-twice.html`


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
