### PR TITLE
feat(tree): `tree` focus supports `relative`

### DIFF
--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -55,7 +55,7 @@ export interface TreeSeriesStateOption<TCbParams = never> {
 
 interface TreeStatesMixin {
     emphasis?: {
-        focus?: DefaultEmphasisFocus | 'ancestor' | 'descendant'
+        focus?: DefaultEmphasisFocus | 'ancestor' | 'descendant' | 'relative'
         scale?: boolean
     }
 }

--- a/src/chart/tree/TreeView.ts
+++ b/src/chart/tree/TreeView.ts
@@ -485,9 +485,11 @@ function updateNode(
 
     // Handle status
     const focus = itemModel.get(['emphasis', 'focus']);
-    const focusDataIndices: number[] = focus === 'ancestor'
-        ? node.getAncestorsIndices()
-        : focus === 'descendant' ? node.getDescendantIndices() : null;
+    const focusDataIndices: number[] = focus === 'relative'
+        ? zrUtil.concatArray(node.getAncestorsIndices(), node.getDescendantIndices()) as number[]
+        : focus === 'ancestor'
+            ? node.getAncestorsIndices()
+            : focus === 'descendant' ? node.getDescendantIndices() : null;
 
     if (focusDataIndices) {
         // Modify the focus to data indices.

--- a/test/tree-legend.html
+++ b/test/tree-legend.html
@@ -235,7 +235,9 @@ under the License.
                                 right: '60%',
 
                                 symbolSize: 7,
-
+                                emphasis: {
+                                    focus: 'relative'
+                                },
                                 label: {
                                     position: 'left',
                                     verticalAlign: 'middle',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

We had `ancestor` and `descendant`, but user might want to see the full relation with it's relative.

![Screen Shot 2022-05-11 at 11 49 45 AM](https://user-images.githubusercontent.com/20318608/167765510-912cdbfe-5f39-4a72-a31c-1f85dd32bbec.png)


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [x] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/tree-legend.html



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
