### PR TITLE
feat: Allow user to use `interval` on time axis

### DIFF
--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -168,6 +168,7 @@ export function niceScaleExtent(
 
     scale.setExtent(extent[0], extent[1]);
     scale.calcNiceExtent({
+        interval: interval,
         splitNumber: splitNumber,
         fixMin: extentInfo.fixMin,
         fixMax: extentInfo.fixMax,
@@ -182,6 +183,8 @@ export function niceScaleExtent(
     // FIXME
     if (interval != null) {
         (scale as IntervalScale).setInterval && (scale as IntervalScale).setInterval(interval);
+        //If interval is set by user, mark it as true
+        (scale as IntervalScale).intervalSetByUser();
     }
 }
 

--- a/src/scale/Interval.ts
+++ b/src/scale/Interval.ts
@@ -86,7 +86,7 @@ class IntervalScale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> e
 
         this._intervalPrecision = helper.getIntervalPrecision(interval);
     }
-    
+
     intervalSetByUser(): void {
         this._isIntervalSetByUser = true;
     }

--- a/src/scale/Interval.ts
+++ b/src/scale/Interval.ts
@@ -35,6 +35,7 @@ class IntervalScale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> e
     protected _interval: number = 0;
     protected _niceExtent: [number, number];
     private _intervalPrecision: number = 2;
+    protected _isIntervalSetByUser: boolean = false;
 
 
     parse(val: number): number {
@@ -84,6 +85,10 @@ class IntervalScale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> e
         this._niceExtent = this._extent.slice() as [number, number];
 
         this._intervalPrecision = helper.getIntervalPrecision(interval);
+    }
+    
+    intervalSetByUser(): void {
+        this._isIntervalSetByUser = true;
     }
 
     /**
@@ -214,8 +219,9 @@ class IntervalScale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> e
 
     /**
      * @param splitNumber By default `5`.
+     * @param interval Interval Set by user, not used here but inheritated by TimeScale
      */
-    calcNiceTicks(splitNumber?: number, minInterval?: number, maxInterval?: number): void {
+    calcNiceTicks(splitNumber?: number, minInterval?: number, maxInterval?: number, interval?: number): void {
         splitNumber = splitNumber || 5;
         const extent = this._extent;
         let span = extent[1] - extent[0];

--- a/src/scale/Scale.ts
+++ b/src/scale/Scale.ts
@@ -153,11 +153,13 @@ abstract class Scale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> 
         // FIXME:TS make them in a "opt", the same with `niceExtent`?
         splitNumber?: number,
         minInterval?: number,
-        maxInterval?: number
+        maxInterval?: number,
+        interval?: number
     ): void;
 
     abstract calcNiceExtent(
         opt?: {
+            interval?: number,
             splitNumber?: number,
             fixMin?: boolean,
             fixMax?: boolean,

--- a/src/scale/Time.ts
+++ b/src/scale/Time.ts
@@ -523,14 +523,18 @@ function getIntervalTicks(
                 case 'quarter':
                 case 'month':
                     //Use interval set by user if specified
-                    interval = isIntervalSetByUser ? Math.max(1, Math.round(approxInterval / ONE_DAY / 30)) : getMonthInterval(approxInterval);
+                    interval = isIntervalSetByUser
+                        ? Math.max(1, Math.round(approxInterval / ONE_DAY / 30))
+                        : getMonthInterval(approxInterval);
                     getterName = monthGetterName(isUTC);
                     setterName = monthSetterName(isUTC);
                     break;
                 case 'week':    // PENDING If week is added. Ignore day.
                 case 'half-week':
                 case 'day':
-                    interval = isIntervalSetByUser ? Math.max(1, Math.round(approxInterval / ONE_DAY)) : getDateInterval(approxInterval, 31); // Use 32 days and let interval been 16
+                    interval = isIntervalSetByUser
+                        ? Math.max(1, Math.round(approxInterval / ONE_DAY))
+                        : getDateInterval(approxInterval, 31); // Use 32 days and let interval been 16
                     getterName = dateGetterName(isUTC);
                     setterName = dateSetterName(isUTC);
                     isDate = true;
@@ -538,17 +542,23 @@ function getIntervalTicks(
                 case 'half-day':
                 case 'quarter-day':
                 case 'hour':
-                    interval = isIntervalSetByUser ? Math.max(1, Math.round(approxInterval / ONE_HOUR)) : getHourInterval(approxInterval);
+                    interval = isIntervalSetByUser
+                        ? Math.max(1, Math.round(approxInterval / ONE_HOUR))
+                        : getHourInterval(approxInterval);
                     getterName = hoursGetterName(isUTC);
                     setterName = hoursSetterName(isUTC);
                     break;
                 case 'minute':
-                    interval = isIntervalSetByUser ? Math.max(1, Math.round(approxInterval / ONE_MINUTE)) : getMinutesAndSecondsInterval(approxInterval, true);
+                    interval = isIntervalSetByUser
+                        ? Math.max(1, Math.round(approxInterval / ONE_MINUTE))
+                        : getMinutesAndSecondsInterval(approxInterval, true);
                     getterName = minutesGetterName(isUTC);
                     setterName = minutesSetterName(isUTC);
                     break;
                 case 'second':
-                    interval = isIntervalSetByUser ? Math.max(1, Math.round(approxInterval / ONE_SECOND)) : getMinutesAndSecondsInterval(approxInterval, false);
+                    interval = isIntervalSetByUser
+                        ? Math.max(1, Math.round(approxInterval / ONE_SECOND))
+                        : getMinutesAndSecondsInterval(approxInterval, false);
                     getterName = secondsGetterName(isUTC);
                     setterName = secondsSetterName(isUTC);
                     break;

--- a/test/axis-interval.html
+++ b/test/axis-interval.html
@@ -69,6 +69,8 @@ under the License.
     </div>
 
     <div class="chart" id="main5"></div>
+    <div class="chart" id="main60"></div>
+    <div class="chart" id="main61"></div>
 
 
     <script>
@@ -533,8 +535,151 @@ under the License.
         </script>
 
 
+<script>
+
+    require([
+        'echarts'
+    ], function (echarts) {
+
+        var option = {
+            color: ['#1890ff'],
+            grid: {
+                top: 30,
+                bottom: 20,
+                left: 50,
+                right: 50,
+            },
+            xAxis: {
+                type: 'time',
+                interval: 43200000,
+                min: 1649740400000,
+                max: 1650199600000,
+                axisLabel: {
+                    formatter: '{MM}-{dd} {HH}:{mm}',
+                },
+            },
+            yAxis: {
+                type: 'value',
+                name: '数量',
+                minInterval: 1,
+                splitLine: {
+                    lineStyle: {
+                        type: 'dashed',
+                    },
+                },
+            },
+            series: [
+                {
+                    name: '数量',
+                    data: [
+                        [
+                        1649926800000,4
+                        ],
+                        [
+                        1650013200000,4
+                        ],
+                        [
+                        1650099600000,4
+                        ],
+                        [
+                        1649840400000,4
+                        ],
+                        [
+                        1649754000000,4
+                        ],
+                    ],
+                    type: 'bar',
+                    barCategoryGap: '2%',
+                    barWidth: '98%',
+                    symbol: 'none',
+                },
+            ],
+            tooltip: {
+                show: true,
+                trigger: 'axis',
+            },
+            toolbox: {
+                show: false,
+            },
+            brush: {
+                throttleType: 'debounce',
+                xAxisIndex: 'all',
+                brushLink: 'all',
+                outOfBrush: {
+                    colorAlpha: 0.1,
+                },
+            },
+        };
+
+        testHelper.create(echarts, 'main60', {
+            title: 'xAxis (type: time) should always be 12 hours interval',
+            option: option
+        });
+    });
+
+</script>
+
+<script>
+
+    require([
+        'echarts'
+    ], function (echarts) {
+
+        var data = [
+            [1650511428000, 22],
+            [1650511438000, 22],
+            [1650511458000, 22]
+        ];
+        option = {
+        tooltip: {
+            trigger: 'axis',
+            axisPointer: {
+            type: 'cross'
+            }
+        },
+        xAxis: {
+            type: 'time',
+            name: '时间',
+            interval: 600000, //10分钟
+            min: 1650506400000,
+            max: 1650513600000,
+            axisLabel: {}
+        },
+        grid: {
+            top: 40,
+            left: 60,
+            right: 40,
+            bottom: 40
+        },
+        yAxis: {
+            type: 'value',
+            name: '温度℃',
+            min: 0,
+            interval: 33,
+            axisLabel: {
+            show: true
+            },
+            max: 528
+        },
+        series: [
+            {
+            name: '温度',
+            data: data,
+            type: 'line',
+            smooth: true,
+            showSymbol: false
+            }
+        ]
+        };
 
 
+        testHelper.create(echarts, 'main61', {
+            title: 'xAxis (type: time) should always be 10 minutes interval',
+            option: option
+        });
+    });
+
+</script>
 
 </body>
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Allow user to use `interval` to specify the interval between ticks on time axis.



### Fixed issues


- fix #16927
- fix #16905 



## Details

### Before: What was the problem?

User-specified `interval` does not work even after `min` and `max` is speicified.
|#16905 (interval = 12 hours) | #16927 (interval = 10 minutes)|
|--|--|
|<img width="910" alt="before#16905" src="https://user-images.githubusercontent.com/14244944/168744180-aa63137b-dd52-4cb9-8b1a-06d75516b2cd.png">|<img width="950" alt="before#16927" src="https://user-images.githubusercontent.com/14244944/168744221-5d03d2d7-c481-42de-863e-7fa044aaafe3.png">|



### After: How is it fixed in this PR?

User-specified `interval` is taken in and will overwrite default `interval` if specified.

|#16905 (interval = 12 hours) | #16927 (interval = 10 minutes)|
|--|--|
|<img width="913" alt="after #16905" src="https://user-images.githubusercontent.com/14244944/168744577-293ccef5-e9ce-49f5-bcf6-79870321df1c.png">|<img width="942" alt="after#16927" src="https://user-images.githubusercontent.com/14244944/168744611-b08ea644-c91a-4668-8bd2-fef72bc64be6.png">


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

axis-inerval.html



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
