### PR TITLE
fix: log axis extent display incorrectly

### DIFF
--- a/src/coord/scaleRawExtentInfo.ts
+++ b/src/coord/scaleRawExtentInfo.ts
@@ -79,6 +79,18 @@ export class ScaleRawExtentInfo {
         this._prepareParams(scale, model, originalExtent);
     }
 
+    getModelMinRaw() {
+        return this._modelMinRaw;
+    }
+    getModelMaxRaw() {
+        return this._modelMaxRaw;
+    }
+    getDataMin() {
+        return this._dataMin;
+    }
+    getDataMax() {
+        return this._dataMax;
+    }
     /**
      * Parameters depending on ouside (like model, user callback)
      * are prepared and fixed here.

--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -114,10 +114,10 @@ class LogScale extends Scale {
         const originalScale = this._originalScale;
         const originalExtent = originalScale.getExtent();
         // To get extent without precision problem, get the original extent directly
-        extent[0] = (extent[0] === mathLog(originalExtent[0])/mathLog(base))
+        extent[0] = (extent[0] === mathLog(originalExtent[0]) / mathLog(base))
             ? originalExtent[0]
             : mathPow(base, extent[0]);
-        extent[1] = (extent[1] === mathLog(originalExtent[1])/mathLog(base))
+        extent[1] = (extent[1] === mathLog(originalExtent[1]) / mathLog(base))
             ? originalExtent[1]
             : mathPow(base, extent[1]);
         return extent;

--- a/test/logScale.html
+++ b/test/logScale.html
@@ -31,7 +31,9 @@ under the License.
                 height: 100%;
             }
         </style>
-        <div id='main'></div>
+        <div id='main' style = "width:100%; height: 500px"></div>
+        <div id='main1' style = "width:100%; height: 500px"></div>
+        <div id='main2' style = "width:100%; height: 500px"></div>
         <script>
 
             require([
@@ -80,6 +82,218 @@ under the License.
                     }]
                 });
             });
+
+        </script>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+            var chart = echarts.init(document.getElementById('main1'));
+            var data = [
+                    ['2000-06-05', 116],
+                    ['2000-06-06', 129],
+                    ['2000-06-07', 135],
+                    ['2000-06-08', 86],
+                    ['2000-06-09', 73],
+                    ['2000-06-10', 85],
+                    ['2000-06-11', 73],
+                    ['2000-06-12', 68],
+                    ['2000-06-13', 92],
+                    ['2000-06-14', 130],
+                    ['2000-06-15', 245],
+                    ['2000-06-16', 139],
+                    ['2000-06-17', 115],
+                    ['2000-06-18', 111],
+                    ['2000-06-19', 309],
+                    ['2000-06-20', 206],
+                    ['2000-06-21', 137],
+                    ['2000-06-22', 128],
+                    ['2000-06-23', 85],
+                    ['2000-06-24', 94],
+                    ['2000-06-25', 71],
+                    ['2000-06-26', 106],
+                    ['2000-06-27', 84],
+                    ['2000-06-28', 93],
+                    ['2000-06-29', 85],
+                    ['2000-06-30', 73],
+                    ['2000-07-01', 83],
+                    ['2000-07-02', 125],
+                    ['2000-07-03', 107],
+                    ['2000-07-04', 82],
+                    ['2000-07-05', 44],
+                    ['2000-07-06', 72],
+                    ['2000-07-07', 106],
+                    ['2000-07-08', 107],
+                    ['2000-07-09', 66],
+                    ['2000-07-10', 91],
+                    ['2000-07-11', 92],
+                    ['2000-07-12', 113],
+                    ['2000-07-13', 107],
+                    ['2000-07-14', 131],
+                    ['2000-07-15', 111],
+                    ['2000-07-16', 64],
+                    ['2000-07-17', 69],
+                    ['2000-07-18', 88],
+                    ['2000-07-19', 77],
+                    ['2000-07-20', 83],
+                    ['2000-07-21', 111],
+                    ['2000-07-22', 57],
+                    ['2000-07-23', 55],
+                    ['2000-07-24', 60]
+                ];
+                const dateList = data.map((item) => item[0]);
+                const valueList = data.map((item) => item[1]);
+                chart.setOption(
+                    option = {
+                    title: [
+                        {
+                        left: 'center',
+                        text: 'Gradient along the y axis'
+                        },
+                        {
+                        top: '55%',
+                        left: 'center',
+                        text: 'Gradient along the x axis\nTick label 0.1 should exist'
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    xAxis: [
+                        {
+                        data: dateList
+                        },
+                        {
+                        data: dateList,
+                        gridIndex: 1
+                        }
+                    ],
+                    yAxis: [
+                        {
+                        type: 'log',
+                        min: 0.01
+                        },
+                        {
+                        type: 'log',
+                        gridIndex: 1,
+                        min: 0.1,
+                        axisLabel: {
+                            fontSize: '10'
+                        }
+                        }
+                    ],
+                    grid: [
+                        {
+                        bottom: '60%'
+                        },
+                        {
+                        top: '60%'
+                        }
+                    ],
+                    series: [
+                        {
+                        type: 'line',
+                        showSymbol: false,
+                        data: valueList
+                        },
+                        {
+                        type: 'line',
+                        showSymbol: false,
+                        data: valueList,
+                        xAxisIndex: 1,
+                        yAxisIndex: 1
+                        }
+                    ]
+                    });
+            });
+
+        </script>
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+            var chart = echarts.init(document.getElementById('main2'));
+                chart.setOption(option = {
+                    title: {
+                        text: '堆叠区域图\nMax value should show 2000000000000000'
+                    },
+                    tooltip : {
+                        trigger: 'axis'
+                    },
+                    legend: {
+                        data:['邮件营销','联盟广告','视频广告','直接访问','搜索引擎']
+                    },
+                    toolbox: {
+                        feature: {
+                            saveAsImage: {}
+                        }
+                    },
+                    grid: {
+                        left: '3%',
+                        right: '4%',
+                        bottom: '3%',
+                        containLabel: true
+                    },
+                    yAxis : [
+                        {
+                            type : 'category',
+                            boundaryGap : false,
+                            data : ['周一','周二','周三','周四','周五','周六','周日']
+                        }
+                    ],
+                    xAxis : [
+                        {
+                            type : 'log',
+                            min:'dataMin',
+                            max:'dataMax'
+                        }
+                    ],
+                    series : [
+                        {
+                            name:'邮件营销',
+                            type:'line',
+                            stack: '总量',
+                            areaStyle: {normal: {}},
+                            data:[100, 100, 100, 100, 100, 1000,2000000000000000]
+                        },
+                        {
+                            name:'联盟广告',
+                            type:'line',
+                            stack: '总量',
+                            areaStyle: {normal: {}},
+                            data:[100, 100, 100, 100, 100, 100, 0]
+                        },
+                        {
+                            name:'视频广告',
+                            type:'line',
+                            stack: '总量',
+                            areaStyle: {normal: {}},
+                            data:[100, 100, 100, 100, 100, 100, 0]
+                        },
+                        {
+                            name:'直接访问',
+                            type:'line',
+                            stack: '总量',
+                            areaStyle: {normal: {}},
+                            data:[100, 100, 100, 100, 100, 100, 0]
+                        },
+                        {
+                            name:'搜索引擎',
+                            type:'line',
+                            stack: '总量',
+                            label: {
+                                normal: {
+                                    show: true,
+                                    position: 'top'
+                                }
+                            },
+                            areaStyle: {normal: {}},
+                            data:[100, 100, 100, 100, 100, 100, 0]
+                        }
+                    ]
+                })
+            })
 
         </script>
     </body>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the problem that log axis extent displays incorrectly when user set max/min for it or the data max is too large.



### Fixed issues


- fix #16992
- correctly fix #4158 



## Details

### Before: What was the problem?

#### Problem 1
As is stated in #4158. When data is too large and user set `max` to `'dataMax'`, the tick label is displayed incorrectly. This is because the data after logarithm cannot keep precision and after exponentiation back, it's different from original data. The former fix is just looking at fixing decimal by recovering the precision, but it cannot fix a very large integer.  

**Max data = 2000000000000000; max = 'dataMax'**
<img width="960" alt="before#4158" src="https://user-images.githubusercontent.com/14244944/168982452-4c7fa70c-92b2-49e5-8537-a5b74de2d0ea.png">

#### Problem 2
This problem is caused by the former fix of #4158. As is stated in https://github.com/apache/echarts/issues/16992#issuecomment-1129657338,  it's fixing the precision of `min` set by user (0.01) with the precision of real min of data (44), deriving a 0 as min and 0 has nowhere to go on log scale axis.

<img width="836" alt="before#16992" src="https://user-images.githubusercontent.com/14244944/168982982-e0a417ff-a568-47cb-9f95-ca101c9680bb.png">

### After: How is it fixed in this PR?

This PR change the way to fix #4158. Instead of fixing the precision of wrong logarithm result, the originalExtent is directly used as the tick label if user sets it as 'dataMax'/'dataMin'. Also a check is added to see if user set a number as min/max and use it directly as head/tail tick label. This way avoid checking precision and also solves the situation where user set a number as min/max.


<img width="955" alt="after#4158" src="https://user-images.githubusercontent.com/14244944/168984289-07d1216e-635f-4900-8ddc-19e58260c887.png">

<img width="836" alt="after#16992" src="https://user-images.githubusercontent.com/14244944/168984322-a7b3d281-465b-4a13-bc19-2854aa3717b8.png">


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

logScale.html



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
