### PR TITLE
{yy} should be padded to 2 digits

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -289,7 +289,7 @@ export function formatTime(tpl: string, value: unknown, isUTC?: boolean) {
     tpl = tpl.replace('MM', pad(M, 2))
         .replace('M', M)
         .replace('yyyy', y)
-        .replace('yy', y % 100 + '')
+        .replace('yy', pad(y % 100 + '', 2))
         .replace('dd', pad(d, 2))
         .replace('d', d)
         .replace('hh', pad(h, 2))


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fixes padding on {yy} formatting to pad to 2 digits e.g. 1 to 01



### Fixed issues

<!--
- #17063:
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
Echarts.time.format("2001-01-01 00:00:00", "{yy}") --> 1
Should have been 01
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Added padding to the output
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
