### PR TITLE
feat: add new stacking strategies

### DIFF
--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -39,13 +39,13 @@ type StackInfo = Pick<
 // (1) [Caution]: the logic is correct based on the premises:
 //     data processing stage is blocked in stream.
 //     See <module:echarts/stream/Scheduler#performDataProcessorTasks>
-// (2) Only register once when import repeatly.
-//     Should be executed after series filtered and before stack calculation.
+// (2) Only register once when import repeatedly.
+//     Should be executed after series is filtered and before stack calculation.
 export default function dataStack(ecModel: GlobalModel) {
     const stackInfoMap = createHashMap<StackInfo[]>();
     ecModel.eachSeries(function (seriesModel: SeriesModel<SeriesOption & SeriesStackOptionMixin>) {
         const stack = seriesModel.get('stack');
-        // Compatibal: when `stack` is set as '', do not stack.
+        // Compatible: when `stack` is set as '', do not stack.
         if (stack) {
             const stackInfoList = stackInfoMap.get(stack) || stackInfoMap.set(stack, []);
             const data = seriesModel.getData();
@@ -87,6 +87,7 @@ function calculateStack(stackInfoList: StackInfo[]) {
         const dims: [string, string] = [targetStackInfo.stackResultDimension, targetStackInfo.stackedOverDimension];
         const targetData = targetStackInfo.data;
         const isStackedByIndex = targetStackInfo.isStackedByIndex;
+        const stackStrategy = targetStackInfo.seriesModel.get('stackStrategy');
 
         // Should not write on raw data, because stack series model list changes
         // depending on legend selection.
@@ -126,12 +127,16 @@ function calculateStack(stackInfoList: StackInfo[]) {
                     ) as number;
 
                     // Considering positive stack, negative stack and empty data
-                    if ((sum >= 0 && val > 0) // Positive stack
-                        || (sum <= 0 && val < 0) // Negative stack
+                    if (
+                        stackStrategy === 'all' // single stack group
+                        || (stackStrategy === 'positive' && val > 0)
+                        || (stackStrategy === 'negative' && val < 0)
+                        || (!stackStrategy && sum >= 0 && val > 0) // Positive stack
+                        || (!stackStrategy && sum <= 0 && val < 0) // Negative stack
                     ) {
-                        // The sum should be as less as possible to be effected
-                        // by floating arithmetic problem. A wrong result probably
-                        // filtered incorrectly by axis min/max.
+                        // The sum has to be very small to be affected by the
+                        // floating arithmetic problem. An incorrect result will probably
+                        // cause axis min/max to be filtered incorrectly.
                         sum = addSafe(sum, val);
                         stackedOver = val;
                         break;

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -87,7 +87,7 @@ function calculateStack(stackInfoList: StackInfo[]) {
         const dims: [string, string] = [targetStackInfo.stackResultDimension, targetStackInfo.stackedOverDimension];
         const targetData = targetStackInfo.data;
         const isStackedByIndex = targetStackInfo.isStackedByIndex;
-        const stackStrategy = targetStackInfo.seriesModel.get('stackStrategy');
+        const stackStrategy = targetStackInfo.seriesModel.get('stackStrategy') || 'samesign';
 
         // Should not write on raw data, because stack series model list changes
         // depending on legend selection.
@@ -131,8 +131,8 @@ function calculateStack(stackInfoList: StackInfo[]) {
                         stackStrategy === 'all' // single stack group
                         || (stackStrategy === 'positive' && val > 0)
                         || (stackStrategy === 'negative' && val < 0)
-                        || (!stackStrategy && sum >= 0 && val > 0) // Positive stack
-                        || (!stackStrategy && sum <= 0 && val < 0) // Negative stack
+                        || (stackStrategy === 'samesign' && sum >= 0 && val > 0) // All positive stack
+                        || (stackStrategy === 'samesign' && sum <= 0 && val < 0) // All negative stack
                     ) {
                         // The sum has to be very small to be affected by the
                         // floating arithmetic problem. An incorrect result will probably

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1661,6 +1661,7 @@ export interface SeriesLargeOptionMixin {
 }
 export interface SeriesStackOptionMixin {
     stack?: string
+    stackStrategy?: 'all' | 'positive' | 'negative';
 }
 
 type SamplingFunc = (frame: ArrayLike<number>) => number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1661,7 +1661,7 @@ export interface SeriesLargeOptionMixin {
 }
 export interface SeriesStackOptionMixin {
     stack?: string
-    stackStrategy?: 'all' | 'positive' | 'negative';
+    stackStrategy?: 'samesign' | 'all' | 'positive' | 'negative';
 }
 
 type SamplingFunc = (frame: ArrayLike<number>) => number;

--- a/test/area-stack.html
+++ b/test/area-stack.html
@@ -609,7 +609,7 @@ under the License.
                 };
 
                 testHelper.create(echarts, 'stack-default', {
-                    title: 'Stacking with positive and negative values (default)',
+                    title: 'Stacking with positive and negative values (default: samesign)',
                     option: option
                 });
             });

--- a/test/area-stack.html
+++ b/test/area-stack.html
@@ -579,7 +579,7 @@ under the License.
 
             require(['echarts'], function (echarts) {
 
-                var             option = {
+                var option = {
                     xAxis: [
                         {
                             type: 'category',
@@ -623,7 +623,7 @@ under the License.
 
             require(['echarts'], function (echarts) {
 
-                var             option = {
+                var option = {
                     xAxis: [
                         {
                             type: 'category',
@@ -669,7 +669,7 @@ under the License.
 
             require(['echarts'], function (echarts) {
 
-                var             option = {
+                var option = {
                     xAxis: [
                         {
                             type: 'category',
@@ -715,7 +715,7 @@ under the License.
 
             require(['echarts'], function (echarts) {
 
-                var             option = {
+                var option = {
                     xAxis: [
                         {
                             type: 'category',

--- a/test/area-stack.html
+++ b/test/area-stack.html
@@ -40,13 +40,10 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
-
-
-
-
-
-
-
+        <div id="stack-default"></div>
+        <div id="stack-all"></div>
+        <div id="stack-positive"></div>
+        <div id="stack-negative"></div>
 
         <script>
 
@@ -431,7 +428,6 @@ under the License.
         <script>
 
             var chart;
-            var myChart;
             var option;
 
             require(['echarts'], function (echarts) {
@@ -576,9 +572,186 @@ under the License.
 
         </script>
 
+        <script>
 
+            var chart;
+            var option;
 
+            require(['echarts'], function (echarts) {
 
+                var             option = {
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value'
+                        }
+                    ],
+                    series: [
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            data: [3, 1, 2, -1, -3, 1, 3, -3, -1, -2, 1, 3, -1, -3]
+                        },
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            areaStyle: {},
+                            data: [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1]
+                        }
+                    ]
+                };
 
+                testHelper.create(echarts, 'stack-default', {
+                    title: 'Stacking with positive and negative values (default)',
+                    option: option
+                });
+            });
+
+        </script>
+
+        <script>
+
+            var chart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+
+                var             option = {
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value'
+                        }
+                    ],
+                    series: [
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'all',
+                            data: [3, 1, 2, -1, -3, 1, 3, -3, -1, -2, 1, 3, -1, -3]
+                        },
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'all',
+                            areaStyle: {},
+                            data: [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'stack-all', {
+                    title: 'Stacking with positive and negative values (stackStrategy: all)',
+                    option: option
+                });
+            });
+
+        </script>
+
+        <script>
+
+            var chart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+
+                var             option = {
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value'
+                        }
+                    ],
+                    series: [
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'positive',
+                            data: [3, 1, 2, -1, -3, 1, 3, -3, -1, -2, 1, 3, -1, -3]
+                        },
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'positive',
+                            areaStyle: {},
+                            data: [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'stack-positive', {
+                    title: 'Stacking with positive and negative values (stackStrategy: positive)',
+                    option: option
+                });
+            });
+
+        </script>
+
+        <script>
+
+            var chart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+
+                var             option = {
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value'
+                        }
+                    ],
+                    series: [
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'negative',
+                            data: [3, 1, 2, -1, -3, 1, 3, -3, -1, -2, 1, 3, -1, -3]
+                        },
+                        {
+                            name: 'stack',
+                            type: 'line',
+                            stack: 'stack',
+                            stackStrategy: 'negative',
+                            areaStyle: {},
+                            data: [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'stack-negative', {
+                    title: 'Stacking with positive and negative values (stackStrategy: negative)',
+                    option: option
+                });
+            });
+
+        </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

This PR adds a new property `stackStrategy` to the `SeriesStackOptionMixin` which defaults to `samesign` (current behavior). Associated PR on the docs repo: https://github.com/apache/echarts-doc/pull/255

### Fixed issues

- Closes #9317
- Close #9141
- Close #13747    
- Close #15083     
- Close #14365
## Details

### Before: What was the problem?

Currently stacking is only applied if the cumulative sum has the same sign as the value to be stacked. This makes it impossible to mix positive and negative values in the same series, something typically needed when creating confidence bands:

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/33317356/169771990-d8c9f7a4-8cb8-477f-b347-5bec3ada4e72.png">

### After: How is it fixed in this PR?

Here we introduce the following new stacking options:
- `all`: stack all values, irrespective of the sign of the stackable value:
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/33317356/169772261-730b1310-e90c-499f-bc80-204ff586e009.png">

- `positive`: only stack positive values:
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/33317356/169772350-bccce456-6f5a-48ce-b694-00fadd433630.png">

- `negative`: only stack negative values:
<img width="1203" alt="image" src="https://user-images.githubusercontent.com/33317356/169772408-81f0e232-c127-4d8a-a1e8-f4380ff1dd6e.png">

We also add the strategy `samesign` which corresponds to the current behavior which we default to to avoid introducing a breaking change. However, I propose defaulting to `all` in the next major version, as I assume this is the behavior users will expect to see.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

New test cases added to the `area-stack.html` test.

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
