### PR TITLE
fix(symbol): fix `square` icon is not being respected

### DIFF
--- a/src/chart/helper/Symbol.ts
+++ b/src/chart/helper/Symbol.ts
@@ -395,7 +395,12 @@ class Symbol extends graphic.Group {
     }
 
     static getSymbolSize(data: SeriesData, idx: number) {
-        return normalizeSymbolSize(data.getItemVisual(idx, 'symbolSize'));
+        const symbolSize = normalizeSymbolSize(data.getItemVisual(idx, 'symbolSize'));
+        const symbolType = data.getItemVisual(idx, 'symbol');
+        if (symbolType === 'square') {
+            symbolSize[0] = symbolSize[1] = Math.min(symbolSize[0], symbolSize[1]);
+        }
+        return symbolSize;
     }
 }
 

--- a/test/scatter.html
+++ b/test/scatter.html
@@ -43,11 +43,13 @@ under the License.
                 var data1 = [];
                 var data2 = [];
                 var data3 = [];
+                var data4 = [];
 
                 var names = [
                     'diamond, red, show inside label only on hover',
                     'green, show top label only on hover',
-                    'indigo, show inside label on normal'
+                    'indigo, show inside label on normal',
+                    'square'
                 ];
 
                 var random = function (max) {
@@ -58,6 +60,7 @@ under the License.
                     data1.push([random(5), random(5), random(2)]);
                     data2.push([random(10), random(10), random(2)]);
                     data3.push([random(15), random(10), random(2)]);
+                    data4.push([random(20), random(10), random(2)]);
                 }
 
                 chart.setOption({
@@ -142,6 +145,13 @@ under the License.
                             return val[2] * 40;
                         },
                         data: data3
+                    },
+                    {
+                        name: names[3],
+                        type: 'scatter',
+                        symbol: 'square',
+                        symbolSize: [50, 20],
+                        data: data4
                     }],
                     animationDelay: function (idx) {
                         return idx * 20;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

`square` is one of the built-in icons. But it seems this icon is not being respected, which behaves like `rect`.

### Fixed issues

N.A.

But it's related to apache/echarts-doc#256

## Details

### Before: What was the problem?

The `square` icon behaves like `rect` because of the [symbol scale strategy.

- [chart/helper/Symbol.ts#L85-L86](https://github.com/apache/echarts/blob/master/src/chart/helper/Symbol.ts#L85-L86)
- [chart/helper/Symbol.ts#L170-L171](https://github.com/apache/echarts/blob/master/src/chart/helper/Symbol.ts#L170-L171)

![image](https://user-images.githubusercontent.com/26999792/170819447-c213245b-cfb3-4280-8b87-a62e2c54a28a.png)


### After: How is it fixed in this PR?

![image](https://user-images.githubusercontent.com/26999792/170820041-24abfc60-3e10-4111-b5d6-228c46a2faa1.png)

## Misc

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/scatter.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
