### PR TITLE
fix(geo): fix `dataToPoint` may not be working in lineGL series.

### DIFF
--- a/src/coord/geo/Geo.ts
+++ b/src/coord/geo/Geo.ts
@@ -211,7 +211,7 @@ class Geo extends View {
                 // projection may return null point.
                 data = projection.project(data);
             }
-            return data && this.projectedToPoint(data);
+            return data && this.projectedToPoint(data, noRoam, out);
         }
     }
 

--- a/test/linesGL-ny-appendData.html
+++ b/test/linesGL-ny-appendData.html
@@ -23,6 +23,7 @@ under the License.
         <meta charset='utf-8'>
         <script src='../dist/echarts.js'></script>
         <script src="../../echarts-gl/dist/echarts-gl.js"></script>
+        <!-- <script src="https://fastly.jsdelivr.net/npm/echarts-gl@2/dist/echarts-gl.min.js"></script> -->
         <script src='./data/map/js/world.js'></script>
         <meta name='viewport' content='width=device-width, initial-scale=1' />
     </head>
@@ -51,6 +52,7 @@ under the License.
                     return;
                 }
                 var dataURL = `../../echarts-examples/public/data/asset/data/links-ny/links_ny_${idx}.bin`;
+                // var dataURL = `https://fastly.jsdelivr.net/gh/apache/echarts-website@asf-site/examples/data/asset/data/links-ny/links_ny_${idx}.bin`;
                 var xhr = new XMLHttpRequest();
                 xhr.open('GET', dataURL, true);
                 xhr.responseType = 'arraybuffer';
@@ -109,7 +111,7 @@ under the License.
                         }
                     },
                     series: [{
-                        type: 'lines',
+                        type: 'linesGL',
 
                         coordinateSystem: 'geo',
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix `dataToPoint` may not be working in `lineGL` series - add back two missing arguments to `projectedToPoint` called in Geo `dataToPoint` function.

### Fixed issues

- #16967

## Details

### Before: What was the problem?

The example `lineGL-ny` can't work since v5.3.0 - All lines collapse to the left top corner.

![image](https://user-images.githubusercontent.com/26999792/171778606-08d06914-6d80-4924-aa98-fe7211fad76c.png)

### After: How is it fixed in this PR?

Add back two missing arguments to `projectedToPoint` called in Geo `dataToPoint` function.

![image](https://user-images.githubusercontent.com/26999792/171778678-0ff9032b-9ab5-4994-8433-a5fa09d5f357.png)


## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/linesGL-ny-appendData.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Related PR: #16364
