### PR TITLE
fix:improve PictorialBarSeriesOption

### DIFF
--- a/src/chart/bar/PictorialBarSeries.ts
+++ b/src/chart/bar/PictorialBarSeries.ts
@@ -26,7 +26,8 @@ import {
     SeriesStackOptionMixin,
     StatesOptionMixin,
     OptionDataItemObject,
-    DefaultEmphasisFocus
+    DefaultEmphasisFocus,
+    SeriesEncodeOptionMixin
 } from '../../util/types';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import { inheritDefaultOption } from '../../util/component';
@@ -111,7 +112,7 @@ export interface PictorialBarDataItemOption extends PictorialBarSeriesSymbolOpti
 export interface PictorialBarSeriesOption
     extends BaseBarSeriesOption<PictorialBarStateOption, ExtraStateOption>, PictorialBarStateOption,
     PictorialBarSeriesSymbolOption,
-    SeriesStackOptionMixin {
+    SeriesStackOptionMixin, SeriesEncodeOptionMixin {
 
     type?: 'pictorialBar'
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Let the interface **PictorialBarSeriesOption** extends the interface **SeriesEncodeOptionMixin** .


### Fixed issues
No issues.
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
The interface **PictorialBarSeriesOption** don't extends interface **SeriesEncodeOptionMixin**.
But **PictorialBar** supports the config `encode`  as document describled.
So,this PR was produced to improve the definition of **PictorialBar**.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Let the interface **PictorialBarSeriesOption**  extends interface **SeriesEncodeOptionMixin** .
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
