### PR TITLE
chore: update pr template to improve doc control

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@ This pull request is in the type of:
 
 
 
-### After: How is it fixed in this PR?
+### After: How does it behave after the fixing?
 
 <!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
 
@@ -41,11 +41,20 @@ This pull request is in the type of:
 
 
 
+## Document Info
+
+One of the following should be checked.
+
+- [ ] This PR doesn't relate to document changes
+- [ ] The document should be updated later
+- [ ] The document changes have been made in apache/echarts-doc#xxx
+
+
+
 ## Misc
 
-<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->
+### ZRender Changes
 
-- [ ] The API has been changed (apache/echarts-doc#xxx).
 - [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).
 
 ### Related test cases or examples to use the new APIs


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Improve the PR template so that doc can always under control for each issue.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

The release manager has to manually look through all pull requests in a certain release to check whether there should be document changes and whether they have been made into the `echarts-doc` repo. Sometimes it's hard for the release manager to know the detail of all PRs so it's not always an easy job to do.



### After: How is it fixed in this PR?

So I decide to improve the workflow so that:

- The author of a PR is mainly responsible to decide whether a PR requires document changes and whether a PR in `echarts-doc` repo has been made. This is done by editing the description of the PR.
- The reviews of the PR should check this info before merging.

The [Apache ECharts bot](https://github.com/apps/echarts-bot) is recently under debugging for this feature. It should add one of `PR: doc unchanged`, `PR: doc awaiting`, `PR: doc ready` to the PR based on the description. It will also give a warning if none of the three checks are made when a PR is opened and when a reviewer approves it.

I will also look into if we can made checking labels to be a prerequisite before merging.

## Misc

<!-- ADD RELATED ISSUE ID WHEN APPLICABLE -->

- [ ] The API has been changed (apache/echarts-doc#xxx).
- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
