### PR TITLE
fix(types): fix `SunburstSeriesOption` and `TreemapSeriesOption` types

### DIFF
--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -81,7 +81,7 @@ export interface SunburstSeriesNodeItemOption extends
     StatesOptionMixin<SunburstStateOption<CallbackDataParams>, SunburstStatesMixin>,
     OptionDataItemObject<OptionDataValue>
 {
-    nodeClick?: 'rootToNode' | 'link'
+    nodeClick?: 'rootToNode' | 'link' | false
     // Available when nodeClick is link
     link?: string
     target?: string
@@ -138,7 +138,7 @@ export interface SunburstSeriesOption extends
      */
     // highlightPolicy?: 'descendant' | 'ancestor' | 'self'
 
-    nodeClick?: 'rootToNode' | 'link'
+    nodeClick?: 'rootToNode' | 'link' | false
 
     renderLabelForZeroData?: boolean
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -192,7 +192,7 @@ export interface TreemapSeriesOption
      * be on left depth, the behaviour would be changing root. Otherwise
      * use behavious defined above.
      */
-    nodeClick?: 'zoomToNode' | 'link'
+    nodeClick?: 'zoomToNode' | 'link' | false
 
     breadcrumb?: BoxLayoutOptionMixin & {
         show?: boolean


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix interface **SunburstSeriesOption** and **TreemapSeriesOption** .


### Fixed issues
No issue.
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
**Sunburst** and **Treemap** supports the option `nodeClick=false` as document described.
But,the interface SunburstSeriesOption and TreemapSeriesOption is inaccurate.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/25882839/173726483-fe0c6704-a654-41a7-94ac-2f6b5c57dd59.png)
![image](https://user-images.githubusercontent.com/25882839/173726525-c22129cd-8651-40b1-9483-7c10474b73e6.png)



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Add the `false` to the interface SunburstSeriesOption.nodeClick and TreemapSeriesOption.nodeClick.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
