### PR TITLE
fix(label): propagate the lineOverflow label option. close #14506

### DIFF
--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -417,6 +417,10 @@ function setTextStyleCommon(
     if (overflow) {
         textStyle.overflow = overflow;
     }
+    const lineOverflow = textStyleModel.get('lineOverflow');
+    if (lineOverflow) {
+        textStyle.lineOverflow = lineOverflow;
+    }
     const margin = textStyleModel.get('minMargin');
     if (margin != null) {
         textStyle.margin = margin;

--- a/test/axisLabel-lineOverflow.html
+++ b/test/axisLabel-lineOverflow.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <div id="main0" style="width: 800px;height:600px;"></div>
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require([
+                'echarts'/*, 'map/js/china' */
+            ], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: [
+                            'A Really big label that overflows into more than two lines',
+                            'B',
+                            'C',
+                            'D',
+                            'E',
+                            'F',
+                        ],
+                        axisLabel: {
+                            interval: 0,
+                            width: 80,
+                            height: 30,
+                            lineHeight: 15,
+                            overflow: 'break',
+                            lineOverflow: 'truncate'
+                        }
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                            data: [1, 2, 3, 4, 5, 6],
+                            type: 'bar'
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'X axis labels should only render two lines max'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

Allows to truncate labels that overflow multiple lines by propagating the `lineOverflow` label option to ZRender.

### Fixed issues

- #14506
- #15248


## Details

### Before: What was the problem?

It was not possible to limit the number of lines in labels.
![2022-06-17-003410_685x367_scrot](https://user-images.githubusercontent.com/247440/174195384-cc782c7e-67aa-4a52-b562-8ca6046be29e.png)

### After: How does it behave after the fixing?

Please assume the following configuration:

```js
{
    ...
    xAxis: {
        ...
        axisLabel: {
            ...
            width: 80,  // both width and height are required
            height: 30,  // twice the line height, so only 2 lines are displayed
            lineHeight: 15,
            overflow: 'break',
            lineOverflow: 'truncate'  // the option that is now being propagated
        }
    }
}
```

![2022-06-17-003359_683x343_scrot](https://user-images.githubusercontent.com/247440/174195568-965387ab-9053-442d-b13e-78924e402bf1.png)

Please check `axisLabel-lineOverflow.html` visual test case for more details.


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#263


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- Visual test case `axisLabel-lineOverflow.html` was added.


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
