### PR TITLE
fix: sliderZoom in candlestick dataset error

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -359,7 +359,8 @@ class SliderZoomView extends DataZoomView {
         const oldSize = this._shadowSize || [];
         const seriesModel = info.series;
         const data = seriesModel.getRawData();
-        const otherDim: string = seriesModel.getShadowDim
+        const candlestickDim = seriesModel.getShadowDim && seriesModel.getShadowDim();
+        const otherDim: string = candlestickDim && data.getDimensionInfo(candlestickDim)
             ? seriesModel.getShadowDim() // @see candlestick
             : info.otherDim;
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix the error that occurs when using `sliderZoom` component in candlestick with dataset.


### Fixed issues


- #17228


## Details

### Before: What was the problem?

As is illustrated in #17228, error occurs when using `sliderZoom` component in candlestick with dataset.



### After: How does it behave after the fixing?

No errors occur now. The pr has passed the visual tests too.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
