### PR TITLE
perf(pie): optimize performance of pie series

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -20,7 +20,7 @@
 import createSeriesDataSimply from '../helper/createSeriesDataSimply';
 import * as zrUtil from 'zrender/src/core/util';
 import * as modelUtil from '../../util/model';
-import { getPercentWithPrecision } from '../../util/number';
+import { getPercentSeats } from '../../util/number';
 import { makeSeriesEncodeForNameBased } from '../../data/helper/sourceHelper';
 import LegendVisualProvider from '../../visual/LegendVisualProvider';
 import SeriesModel from '../../model/Series';
@@ -133,6 +133,8 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
 
     static type = 'series.pie' as const;
 
+    seats: number[];
+
     /**
      * @overwrite
      */
@@ -159,31 +161,25 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
      * @overwrite
      */
     getInitialData(this: PieSeriesModel): SeriesData {
-        return createSeriesDataSimply(this, {
+        const data = createSeriesDataSimply(this, {
             coordDimensions: ['value'],
             encodeDefaulter: zrUtil.curry(makeSeriesEncodeForNameBased, this)
         });
+        const valueList:number[] = [];
+        data.each(data.mapDimension('value'), function (value: number) {
+            valueList.push(value);
+        });
+
+        this.seats = getPercentSeats(valueList, data.hostModel.get('percentPrecision'));
+        return data;
     }
 
     /**
      * @overwrite
      */
     getDataParams(dataIndex: number): PieCallbackDataParams {
-        const data = this.getData();
         const params = super.getDataParams(dataIndex) as PieCallbackDataParams;
-        // FIXME toFixed?
-
-        const valueList: number[] = [];
-        data.each(data.mapDimension('value'), function (value: number) {
-            valueList.push(value);
-        });
-
-        params.percent = getPercentWithPrecision(
-            valueList,
-            dataIndex,
-            data.hostModel.get('percentPrecision')
-        );
-
+        params.percent = this.seats[dataIndex];
         params.$vars.push('percent');
         return params;
     }

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -233,11 +233,27 @@ export function getPercentWithPrecision(valueList: number[], idx: number, precis
         return 0;
     }
 
+    const seats = getPercentSeats(valueList, precision);
+
+    return seats[idx] || 0;
+}
+
+/**
+ * Get a data of given precision, assuring the sum of percentages
+ * in valueList is 1.
+ * The largest remainer method is used.
+ * https://en.wikipedia.org/wiki/Largest_remainder_method
+ *
+ * @param valueList a list of all data
+ * @param precision integer number showing digits of precision
+ * @return {Array<number>}
+ */
+export function getPercentSeats(valueList: number[], precision: number): number[] {
     const sum = zrUtil.reduce(valueList, function (acc, val) {
         return acc + (isNaN(val) ? 0 : val);
     }, 0);
     if (sum === 0) {
-        return 0;
+        return [];
     }
 
     const digits = Math.pow(10, precision);
@@ -275,8 +291,9 @@ export function getPercentWithPrecision(valueList: number[], idx: number, precis
         remainder[maxId] = 0;
         ++currentSum;
     }
-
-    return seats[idx] / digits;
+    return zrUtil.map(seats, function (seat) {
+        return seat / digits;
+    });
 }
 
 /**

--- a/test/pie-percent.html
+++ b/test/pie-percent.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+            var data = [];
+            for (var i = 0; i < 1e3; i++) {
+                data.push({
+                    name: 'test' + i,
+                    value: Math.random() * 1000,
+                });
+            }
+            option = {
+                series: {
+                    type: 'pie',
+                    data: data,
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Test Pie performance'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/pie-percent.html
+++ b/test/pie-percent.html
@@ -46,9 +46,7 @@ under the License.
 
         <script>
         require([
-            'echarts',
-            // 'map/js/china',
-            // './data/nutrients.json'
+            'echarts'
         ], function (echarts) {
             var option;
             var data = [];
@@ -62,17 +60,27 @@ under the License.
                 series: {
                     type: 'pie',
                     data: data,
+                    percentPrecision: 5,
+                    label: {
+                        formatter: '{b} {d}%'
+                    }
                 }
             };
 
             var chart = testHelper.create(echarts, 'main0', {
                 title: [
                     'Test Pie performance'
-                ],
-                option: option
-                // height: 300,
-                // buttons: [{text: 'btn-txt', onclick: function () {}}],
-                // recordCanvas: true,
+                ]
+            });
+
+            var startTs = performance.now();
+            chart.setOption(option);
+
+            chart.on('finished', function () {
+                var endTs = performance.now();
+                var time = endTs - startTs;
+                console.log('Finished in ' + time + 'ms');
+                startTs = endTs;
             });
         });
         </script>

--- a/test/pie3.html
+++ b/test/pie3.html
@@ -74,7 +74,7 @@ under the License.
                         formatter: function (params) {
                             return '<div class="tooltip-content">\
                                 <h4>' + params.name + '</h4>\
-                                <h5>' + (params.percent).toFixed(1) + '%</h5>\
+                                <h5>' + params.percent.toFixed(1) + '%</h5>\
                                 </div><script>console.log(1111)<\/script>\
                             ';
                         },
@@ -125,7 +125,7 @@ under the License.
                         formatter: function (params) {
                             return '<div class="tooltip-content">\
                                 <h4>' + params.name + '</h4>\
-                                <h5>' + (params.percent * 100).toFixed(1) + '%</h5>\
+                                <h5>' + params.percent.toFixed(1) + '%</h5>\
                                 </div>\
                             ';
                         },

--- a/test/pie3.html
+++ b/test/pie3.html
@@ -74,7 +74,7 @@ under the License.
                         formatter: function (params) {
                             return '<div class="tooltip-content">\
                                 <h4>' + params.name + '</h4>\
-                                <h5>' + (params.percent * 100).toFixed(1) + '%</h5>\
+                                <h5>' + (params.percent).toFixed(1) + '%</h5>\
                                 </div><script>console.log(1111)<\/script>\
                             ';
                         },


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

饼图现在的渲染有性能问题，getPercentWithPrecision是很消耗性能的方法，每一个数据项都需要执行一次，在10000个数据点的时候就能把页面卡死，可以总的执行一次再取数使用。


### Fixed issues

#17173 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

   没有删掉getPercentWithPrecision，因为api里面有暴露给外包
   
   测试之前需要执行 prepublish