### PR TITLE
fix(selectedMode): get data id first

### DIFF
--- a/src/model/Series.ts
+++ b/src/model/Series.ts
@@ -65,7 +65,7 @@ const inner = modelUtil.makeInner<{
 }, SeriesModel>();
 
 function getSelectionKey(data: SeriesData, dataIndex: number): string {
-    return data.getName(dataIndex) || data.getId(dataIndex);
+    return data.getId(dataIndex) || data.getName(dataIndex);
 }
 
 export const SERIES_UNIVERSAL_TRANSITION_PROP = '__universalTransitionEnabled';

--- a/test/scatter-selectedMode.html
+++ b/test/scatter-selectedMode.html
@@ -1,0 +1,125 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+
+</head>
+
+<body>
+    <style>
+        html,
+        body {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+    <div id="main"></div>
+    <script>
+
+        require(['echarts'], function (echarts) {
+            const categoricalLabels = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
+            const dataPoints = [
+                [1, 8],
+                [1, 6],
+                [2, 7],
+                [9, 8],
+                [3, 8],
+                [3, 7],
+                [5, 6],
+                [6, 8],
+                [4, 6],
+                [9, 7],
+                [5, 7],
+                [3, 4],
+                [1, 7],
+                [2, 4],
+                [1, 3],
+                [4, 4],
+                [6, 7]
+            ];
+            var option;
+
+            option = {
+                xAxis: {
+                    type: "category",
+                    data: categoricalLabels
+                },
+                yAxis: {},
+                series: [
+                    {
+                        symbolSize: 20,
+                        data: dataPoints,
+                        type: "scatter",
+                        select: {
+                            itemStyle: {
+                                color: "red"
+                            }
+                        },
+                        selectedMode: true
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main', {
+                title: ['scatter chart selectedMode'],
+                option: option,
+                height: 500,
+                width: '100%',
+                button: [
+                    {
+                        text: 'single',
+                        onClick: function () {
+                            chart.setOption({
+                                series: [
+                                    {
+                                        selectedMode: 'single'
+                                    }
+                                ]
+                            });
+                        }
+                    },
+                    {
+                        text: 'multiple',
+                        onClick: function () {
+                            chart.setOption({
+                                series: [
+                                    {
+                                        selectedMode: 'multiple'
+                                    }
+                                ]
+                            });
+                        }
+                    }
+                ]
+            });
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

When `xAxis` is `category`, multiple data will share same `name` which cause muliple data selected under `single` `selectedMode`. So rearrange `getSelectionKey`, it should get id first then name.



### Fixed issues
- Close #17206


## Details

### Before: What was the problem?

<img width="550" alt="Screen Shot 2022-06-25 at 11 20 59 AM" src="https://user-images.githubusercontent.com/20318608/175756269-b58c16fe-ab27-449d-8b4b-1c02a8b6bdee.png">




### After: How does it behave after the fixing?

<img width="670" alt="Screen Shot 2022-06-25 at 11 20 38 AM" src="https://user-images.githubusercontent.com/20318608/175756261-b9f99a8f-412d-49d5-a04e-3d0ce8a63293.png">




## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/scatter-selectedMode.html`



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
