### PR TITLE
chore(workflow): close stale issues as not planned rather than completed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,7 @@ jobs:
           stale-pr-label: stale
           stale-issue-message: 'This issue has been automatically marked as stale because it did not have recent activity. It will be closed in 7 days if no further activity occurs. If you wish not to mark it as stale, please leave a comment in this issue.'
           close-issue-message: 'This issue has been automatically closed because it did not have recent activity. If this remains to be a problem with the latest version of Apache ECharts, please open a new issue and link this to it. Thanks!'
+          close-issue-reason: 'not_planned'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. If you wish not to mark it as stale, please leave a comment in this PR. We are sorry for this but 2 years is a long time and the code base has been changed a lot. Thanks for your contribution anyway.'
           close-pr-message: 'This PR has been automatically closed because it has not had recent activity. Sorry for that and we are looking forward to your next contribution.'
           exempt-issue-labels: 'FAQ,priority: high'


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Follow up with the latest GitHub updates, close stale issues as **_not planned_**.

<img src="https://user-images.githubusercontent.com/26999792/177070191-8b874a37-bb75-46b2-8657-1ba239f84587.png" width="300">
