### PR TITLE
chore(workflow): upgrade stale action to v5

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository_owner == 'apache' }}
     steps:
       - name: Close Stale Issues
-        uses: actions/stale@v4
+        uses: actions/stale@v5
         with:
           days-before-stale: 730
           days-before-close: 7


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others


### What does this PR do?

fix `close-issue-reason` option is not being recognized. It's introduced in v5.

Related PR: #17304