### PR TITLE
fix(log): fix log axis breaks a single data whose log value is negative

### DIFF
--- a/src/scale/Interval.ts
+++ b/src/scale/Interval.ts
@@ -250,7 +250,8 @@ class IntervalScale<SETTING extends Dictionary<unknown> = Dictionary<unknown>> e
         if (extent[0] === extent[1]) {
             if (extent[0] !== 0) {
                 // Expand extent
-                const expandSize = extent[0];
+                // Note that extents can be both negative. See #13154
+                const expandSize = Math.abs(extent[0]);
                 // In the fowllowing case
                 //      Axis has been fixed max 100
                 //      Plus data are all 100 and axis extent are [100, 100].

--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -85,10 +85,10 @@ class LogScale extends Scale {
     }
 
     setExtent(start: number, end: number): void {
-        const base = this.base;
+        const base = mathLog(this.base);
         // log(-Infinity) is NaN, so safe guard here
-        start = mathLog(Math.max(0, start)) / mathLog(base);
-        end = mathLog(Math.max(0, end)) / mathLog(base);
+        start = mathLog(Math.max(0, start)) / base;
+        end = mathLog(Math.max(0, end)) / base;
         intervalScaleProto.setExtent.call(this, start, end);
     }
 

--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -86,8 +86,9 @@ class LogScale extends Scale {
 
     setExtent(start: number, end: number): void {
         const base = this.base;
-        start = mathLog(start) / mathLog(base);
-        end = mathLog(end) / mathLog(base);
+        // log(-Infinity) is NaN, so safe guard here
+        start = mathLog(Math.max(0, start)) / mathLog(base);
+        end = mathLog(Math.max(0, end)) / mathLog(base);
         intervalScaleProto.setExtent.call(this, start, end);
     }
 

--- a/test/logScale.html
+++ b/test/logScale.html
@@ -26,12 +26,13 @@ under the License.
     </head>
     <body>
         <style>
-            html, body, #main {
+            html, body, #main, #main1 {
                 width: 100%;
                 height: 100%;
             }
         </style>
         <div id='main'></div>
+        <div id='main1'></div>
         <script>
 
             require([
@@ -78,6 +79,36 @@ under the License.
                         type: 'line',
                         data: [1, 0.1, 0.01, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8]
                     }]
+                });
+            });
+
+        </script>
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                var chart = echarts.init(document.getElementById('main1'));
+                // See #13154
+                chart.setOption({
+                    xAxis: {
+                        type: 'value',
+                    },
+                    yAxis: {
+                        type: 'log',
+                        logBase: 2,
+                    },
+                    series: [
+                        {
+                            type: 'scatter',
+                            itemStyle: {
+                                color: 'red',
+                            },
+                            data: [
+                                [1, .5],
+                            ],
+                        },
+                    ],
                 });
             });
 


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When the log axis contains only one data and its value is less than 1, echarts fail to render. This PR fixes this problem.

### Fixed issues

#13154


## Details

### Before: What was the problem?

```js
chart.setOption({
    xAxis: {
        type: 'value',
    },
    yAxis: {
        type: 'log',
        logBase: 2,
    },
    series: [
        {
            type: 'scatter',
            itemStyle: {
                color: 'red',
            },
            data: [
                [1, .5],
            ],
        },
    ],
});
```

<img width="704" alt="image" src="https://user-images.githubusercontent.com/779050/177290130-21b26f14-d4ff-46b1-8e6c-154c0e08d657.png">


### After: How does it behave after the fixing?
<img width="672" alt="image" src="https://user-images.githubusercontent.com/779050/177290224-d1c9c64f-095f-4a8e-a643-0aa3358e02fd.png">


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
