### PR TITLE
fix(axis): fix axis symbol is not reversed when axis is reversed

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -255,6 +255,7 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         const matrix = transformGroup.transform;
         const pt1 = [extent[0], 0];
         const pt2 = [extent[1], 0];
+        const inverse = pt1[0] > pt2[0];
         if (matrix) {
             v2ApplyTransform(pt1, pt1, matrix);
             v2ApplyTransform(pt2, pt2, matrix);
@@ -327,10 +328,11 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
                     // Calculate arrow position with offset
                     const r = point.r + point.offset;
 
+                    const pt = inverse ? pt2 : pt1;
                     symbol.attr({
                         rotation: point.rotate,
-                        x: pt1[0] + r * Math.cos(opt.rotation),
-                        y: pt1[1] - r * Math.sin(opt.rotation),
+                        x: pt[0] + r * Math.cos(opt.rotation),
+                        y: pt[1] - r * Math.sin(opt.rotation),
                         silent: true,
                         z2: 11
                     });

--- a/test/axis-arrow.html
+++ b/test/axis-arrow.html
@@ -23,19 +23,18 @@ under the License.
         <meta charset="utf-8">
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="lib/reset.css" />
     </head>
     <body>
         <style>
-            html, body, #main, .chart {
-                width: 100%;
-            }
-
-            .chart {
-                height: 300px;
+            .test-title[title=null] {
+                display: none;
             }
         </style>
-        <div id="main"></div>
+        <div id="main0"></div>
+        <div id="main1"></div>
         <script>
 
             require([
@@ -57,7 +56,7 @@ under the License.
                     }]
                 }, {
                     title: {
-                        text: 'x: ["none", "arrow"]; y: "arrow" of size 30x20'
+                        text: 'x: ["none", "arrow"] symbolOffset: 10; y: "arrow" of size 30x20 symbolOffset: [-10, 10]'
                     },
                     xAxis: {
                         data: ['a', 'b', 'c', 'd', 'e'],
@@ -71,6 +70,7 @@ under the License.
                     },
                     yAxis: {
                         axisLine: {
+                            show: true,
                             symbol: 'arrow',
                             symbolSize: [30, 20],
                             symbolOffset: [-10, 10]
@@ -82,7 +82,7 @@ under the License.
                     }]
                 }, {
                     title: {
-                        text: 'x: "none"; y: ["none", "arrow"], inversed'
+                        text: 'x: "none"; y: ["none", "arrow"] symbolOffset: [10, -10] inversed '
                     },
                     xAxis: {
                         data: ['a', 'b', 'c', 'd', 'e'],
@@ -92,10 +92,11 @@ under the License.
                     },
                     yAxis: {
                         axisLine: {
+                            show: true,
                             symbol: ['none', 'arrow'],
                             symbolOffset: [10, -10]
                         },
-                        inversed: true
+                        inverse: true
                     },
                     series: [{
                         type: 'line',
@@ -103,18 +104,59 @@ under the License.
                     }]
                 }];
 
-                var main = document.getElementById('main');
+                var main = document.getElementById('main0');
                 for (var i = 0; i < options.length; ++i) {
                     var container = document.createElement('div');
-                    container.setAttribute('class', 'chart');
                     main.appendChild(container);
 
-                    var chart = echarts.init(container);
-                    chart.setOption(options[i]);
+                    testHelper.create(echarts, container, {
+                        option: options[i]
+                    });
                 }
 
             });
 
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    dataset: {
+                        source: [
+                            ['水果', '价格'],
+                            ['苹果', 1],
+                            ['香蕉', 0.5],
+                            ['梨', 2],
+                            ['菠萝', 4]
+                        ]
+                    },
+                    xAxis: [{
+                        type: 'category',
+                        inverse: true,
+                        axisLine: {
+                            symbol: 'arrow'
+                        }
+                    }],
+                    yAxis: {
+                        inverse: true,
+                        axisLine: {
+                            show: true,
+                            symbol: 'arrow'
+                        }
+                    },
+                    series: [{
+                        type: 'bar'
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'The arrows of axis line should be inverted when the axis is inverse',
+                        'Case from https://github.com/apache/echarts/issues/17325'
+                    ],
+                    option: option
+                });
+            })
         </script>
     </body>
 </html>


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the symbol of the axis line is not reversed when the axis is reversed.

### Fixed issues

- Resolves #17325


## Comparison

| Before | After |
| :----: | :----: |
| <img src="https://user-images.githubusercontent.com/26999792/177685065-c24ae05e-2028-49a4-9d15-0625e1393300.png" width="400"> | <img src="https://user-images.githubusercontent.com/26999792/177685088-be1e12c3-727a-4f46-9d63-b81dc1f8681c.png" width="400"> |


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/axis-arrow.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
