### PR TITLE
fix: fix scatter chart legend icon inheritance

### DIFF
--- a/src/chart/scatter/ScatterSeries.ts
+++ b/src/chart/scatter/ScatterSeries.ts
@@ -41,6 +41,9 @@ import {
 import GlobalModel from '../../model/Global';
 import SeriesData from '../../data/SeriesData';
 import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
+import {LegendIconParams} from '../../component/legend/LegendModel';
+import {createSymbol, ECSymbol} from '../../util/symbol';
+import {Group} from '../../util/graphic';
 
 interface ScatterStateOption<TCbParams = never> {
     itemStyle?: ItemStyleOption<TCbParams>
@@ -161,6 +164,53 @@ class ScatterSeriesModel extends SeriesModel<ScatterSeriesOption> {
         // progressive: null
     };
 
+    getLegendIcon(opt: LegendIconParams): ECSymbol | Group {
+        const group = new Group();
+
+        const line = createSymbol(
+            'line',
+            0,
+            opt.itemHeight / 2,
+            opt.itemWidth,
+            0,
+            opt.lineStyle.stroke,
+            false
+        );
+        group.add(line);
+        line.setStyle(opt.lineStyle);
+
+        const visualType = this.getData().getVisual('symbol');
+        const visualRotate = this.getData().getVisual('symbolRotate');
+        const symbolType = visualType === 'none' ? 'circle' : visualType;
+
+        // Symbol size is 80% when there is a line
+        const size = opt.itemHeight * 0.8;
+        const symbol = createSymbol(
+            symbolType,
+            (opt.itemWidth - size) / 2,
+            (opt.itemHeight - size) / 2,
+            size,
+            size,
+            opt.itemStyle.fill
+        );
+        group.add(symbol);
+
+        symbol.setStyle(opt.itemStyle);
+
+        const symbolRotate = opt.iconRotate === 'inherit'
+            ? visualRotate
+            : (opt.iconRotate || 0);
+        symbol.rotation = symbolRotate * Math.PI / 180;
+        symbol.setOrigin([opt.itemWidth / 2, opt.itemHeight / 2]);
+
+        if (symbolType.indexOf('empty') > -1) {
+            symbol.style.stroke = symbol.style.fill;
+            symbol.style.fill = '#fff';
+            symbol.style.lineWidth = 2;
+        }
+
+        return group;
+    }
 }
 
 export default ScatterSeriesModel;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Allow legend icons to inherit style from series icon.



### Fixed issues


- fix #17350 



## Details

### Before: What was the problem?

As is specified [here](https://github.com/apache/echarts/issues/17350#issuecomment-1181271755), a judgement is only satisfied for LineSeriesModel, so icon style can only be inherited in line charts but not in scatter charts. This judgement is whether the model has the method `getLegendIcon()`.
![image](https://user-images.githubusercontent.com/14244944/178403998-73f6575a-b22e-4c91-b7ea-44d45876f826.png)



### After: How does it behave after the fixing?

The way to solve this is simply add the same function `getLegendIcon()` to ScatterSeriesModel. It is not used in any other function by now so it's safe to add it just to allow icon style inheritance. But if we need to use this function for scatter model, further tests are needed.
<img width="849" alt="after #17350" src="https://user-images.githubusercontent.com/14244944/178406836-79f11a46-85fc-4e28-b246-dcbae44f54c1.png">



## Document Info
One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
