### PR TITLE
fix(type): add missing type `number` to `emphasis.scale` for scatter/line/graph series

### DIFF
--- a/src/action/roamHelper.ts
+++ b/src/action/roamHelper.ts
@@ -22,7 +22,7 @@ import type View from '../coord/View';
 import type ExtensionAPI from '../core/ExtensionAPI';
 import type { Payload } from '../util/types';
 
-export interface RoamPaylod extends Payload {
+export interface RoamPayload extends Payload {
     dx: number
     dy: number
     zoom: number
@@ -39,7 +39,7 @@ function getCenterCoord(view: View, point: number[]) {
 
 export function updateCenterAndZoom(
     view: View,
-    payload: RoamPaylod,
+    payload: RoamPayload,
     zoomLimit?: {
         min?: number,
         max?: number

--- a/src/chart/graph/GraphSeries.ts
+++ b/src/chart/graph/GraphSeries.ts
@@ -184,7 +184,7 @@ export interface GraphSeriesOption
 
     emphasis?: {
         focus?: Exclude<GraphNodeItemOption['emphasis'], undefined>['focus']
-        scale?: boolean
+        scale?: boolean | number
         label?: SeriesLabelOption
         edgeLabel?: SeriesLabelOption
         itemStyle?: ItemStyleOption

--- a/src/chart/graph/install.ts
+++ b/src/chart/graph/install.ts
@@ -29,7 +29,7 @@ import createView from './createView';
 import View from '../../coord/View';
 import GraphView from './GraphView';
 import GraphSeriesModel from './GraphSeries';
-import { RoamPaylod, updateCenterAndZoom } from '../../action/roamHelper';
+import { RoamPayload, updateCenterAndZoom } from '../../action/roamHelper';
 import GlobalModel from '../../model/Global';
 import { noop } from 'zrender/src/core/util';
 import type ExtensionAPI from '../../core/ExtensionAPI';
@@ -73,7 +73,7 @@ export function install(registers: EChartsExtensionInstallRegisters) {
     }, noop);
 
     // Register roam action.
-    registers.registerAction(actionInfo, function (payload: RoamPaylod, ecModel: GlobalModel, api: ExtensionAPI) {
+    registers.registerAction(actionInfo, function (payload: RoamPayload, ecModel: GlobalModel, api: ExtensionAPI) {
         ecModel.eachComponent({
             mainType: 'series', query: payload
         }, function (seriesModel: GraphSeriesModel) {

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -48,7 +48,7 @@ type LineDataValue = OptionDataValue | OptionDataValue[];
 interface LineStateOptionMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus
-        scale?: boolean
+        scale?: boolean | number
     }
 }
 

--- a/src/chart/scatter/ScatterSeries.ts
+++ b/src/chart/scatter/ScatterSeries.ts
@@ -50,7 +50,7 @@ interface ScatterStateOption<TCbParams = never> {
 interface ScatterStatesOptionMixin {
     emphasis?: {
         focus?: DefaultEmphasisFocus
-        scale?: boolean
+        scale?: boolean | number
     }
 }
 

--- a/src/chart/tree/treeAction.ts
+++ b/src/chart/tree/treeAction.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {updateCenterAndZoom, RoamPaylod} from '../../action/roamHelper';
+import {updateCenterAndZoom, RoamPayload} from '../../action/roamHelper';
 import { Payload } from '../../util/types';
 import TreeSeriesModel from './TreeSeries';
 import GlobalModel from '../../model/Global';
@@ -52,7 +52,7 @@ export function installTreeAction(registers: EChartsExtensionInstallRegisters) {
         // the layout. So don't need to go through the whole update process, such
         // as 'dataPrcocess', 'coordSystemUpdate', 'layout' and so on.
         update: 'none'
-    }, function (payload: RoamPaylod, ecModel: GlobalModel, api: ExtensionAPI) {
+    }, function (payload: RoamPayload, ecModel: GlobalModel, api: ExtensionAPI) {
         ecModel.eachComponent({
             mainType: 'series', subType: 'tree', query: payload
         }, function (seriesModel: TreeSeriesModel) {

--- a/src/component/geo/install.ts
+++ b/src/component/geo/install.ts
@@ -23,7 +23,7 @@ import geoCreator from '../../coord/geo/geoCreator';
 import { ActionInfo } from '../../util/types';
 import { each } from 'zrender/src/core/util';
 import GlobalModel from '../../model/Global';
-import { updateCenterAndZoom, RoamPaylod } from '../../action/roamHelper';
+import { updateCenterAndZoom, RoamPayload } from '../../action/roamHelper';
 import MapSeries from '../../chart/map/MapSeries';
 import GeoView from './GeoView';
 import geoSourceManager from '../../coord/geo/geoSourceManager';
@@ -115,7 +115,7 @@ export function install(registers: EChartsExtensionInstallRegisters) {
         type: 'geoRoam',
         event: 'geoRoam',
         update: 'updateTransform'
-    }, function (payload: RoamPaylod, ecModel: GlobalModel, api: ExtensionAPI) {
+    }, function (payload: RoamPayload, ecModel: GlobalModel, api: ExtensionAPI) {
         const componentType = payload.componentType || 'series';
 
         ecModel.eachComponent(


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

PR #16688 allows customizing the scale size of the symbol, but it is only for the EffectScatter series. In fact, this new feature is suitable for the symbol of all series. So this PR is to add the missing type to the Scatter, Line, and Graph series.


### Fixed issues

- Resolves  https://github.com/apache/echarts/issues/17072#issuecomment-1173256689
- Resolves #17384

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
