### PR TITLE
fix(svg): encode HTML special characters when generating SVG string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.3.2"
+        "zrender": "npm:zrender-nightly@^5.3.3-dev.20220720"
       },
       "devDependencies": {
         "@babel/code-frame": "7.10.4",
@@ -13362,9 +13362,10 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
+      "name": "zrender-nightly",
+      "version": "5.3.3-dev.20220720",
+      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.3.3-dev.20220720.tgz",
+      "integrity": "sha512-rh3tfK2ARgee39pYh1xEaT8ZyT+70kHQKFranukjmKOMQi8/5nM4sBuuYPCwFcoIpvSMM/iiYikZmM9VEMwMKQ==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -24241,9 +24242,9 @@
       }
     },
     "zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
+      "version": "npm:zrender-nightly@5.3.3-dev.20220720",
+      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.3.3-dev.20220720.tgz",
+      "integrity": "sha512-rh3tfK2ARgee39pYh1xEaT8ZyT+70kHQKFranukjmKOMQi8/5nM4sBuuYPCwFcoIpvSMM/iiYikZmM9VEMwMKQ==",
       "requires": {
         "tslib": "2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "tslib": "2.3.0",
-    "zrender": "5.3.2"
+    "zrender": "npm:zrender-nightly@^5.3.3-dev.20220720"
   },
   "devDependencies": {
     "@babel/code-frame": "7.10.4",

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -18,6 +18,7 @@
 */
 
 import * as zrUtil from 'zrender/src/core/util';
+import { encodeHTML } from 'zrender/src/core/dom';
 import { parseDate, isNumeric, numericToNumber } from './number';
 import { TooltipRenderMode, ColorString, ZRColor, DimensionType } from './types';
 import { Dictionary } from 'zrender/src/core/types';
@@ -51,24 +52,7 @@ export function toCamelCase(str: string, upperCaseFirst?: boolean): string {
 
 export const normalizeCssArray = zrUtil.normalizeCssArray;
 
-
-const replaceReg = /([&<>"'])/g;
-const replaceMap: Dictionary<string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    '\'': '&#39;'
-};
-
-export function encodeHTML(source: string): string {
-    return source == null
-        ? ''
-        : (source + '').replace(replaceReg, function (str, c) {
-            return replaceMap[c];
-        });
-}
-
+export { encodeHTML };
 
 /**
  * Make value user readable for tooltip and label.


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the generated SVG string may be broken if it contains special HTML characters. See also ecomfe/zrender#935.

### Fixed issues

- Resolves #17399 

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [x] This PR depends on ZRender changes (ecomfe/zrender#935).

### Related test cases or examples to use the new APIs

test/visualMap-pieces.html

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
