### PR TITLE
fix(axis): fix `inverse` option does not work for `singleAxis`

### DIFF
--- a/src/coord/single/Single.ts
+++ b/src/coord/single/Single.ts
@@ -140,7 +140,7 @@ class Single implements CoordinateSystem, CoordinateSystemMaster {
 
         const isHorizontal = axis.isHorizontal();
         const extent = isHorizontal ? [0, rect.width] : [0, rect.height];
-        const idx = axis.reverse ? 1 : 0;
+        const idx = axis.inverse ? 1 : 0;
 
         axis.setExtent(extent[idx], extent[1 - idx]);
 

--- a/src/coord/single/SingleAxis.ts
+++ b/src/coord/single/SingleAxis.ts
@@ -43,8 +43,6 @@ class SingleAxis extends Axis {
 
     orient: LayoutOrient;
 
-    reverse: boolean;
-
     coordinateSystem: Single;
 
     model: SingleAxisModel;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

修复单轴反向的bug，原来属性定义的是inverse，在使用的时候是reverse

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
