### PR TITLE
fix(custom): set ignore only if old child exists

### DIFF
--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -1341,7 +1341,11 @@ function mergeChildren(
         }
         else {
             if (__DEV__) {
-                assert(oldChild, 'renderItem should not return a group containing elements as null/undefined/{} if they do not exist before.');
+                assert(
+                    oldChild,
+                    'renderItem should not return a group containing elements'
+                    + ' as null/undefined/{} if they do not exist before.'
+                );
             }
             // If the new element option is null, it means to remove the old
             // element. But we cannot really remove the element from the group

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -1339,7 +1339,7 @@ function mergeChildren(
                 el
             );
         }
-        else {
+        else if (oldChild) {
             // If the new element option is null, it means to remove the old
             // element. But we cannot really remove the element from the group
             // directly, because the element order may not be stable when this

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -1339,7 +1339,10 @@ function mergeChildren(
                 el
             );
         }
-        else if (oldChild) {
+        else {
+            if (__DEV__) {
+                assert(oldChild, 'renderItem should not return a group containing elements as null/undefined/{} if they do not exist before.');
+            }
             // If the new element option is null, it means to remove the old
             // element. But we cannot really remove the element from the group
             // directly, because the element order may not be stable when this


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This PR fixes an error brought by #17349.

If custom `renderItem` returns null in the first `setOption`, then in the next `setOption` if it's set to be null, `oldChild` is null so `oldChild.ignore = true;` will bring an error. `null/undefined/{}` is not supported because group element should not be null.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
