### PR TITLE
chore: fix wrong imports from `echarts.all`

### DIFF
--- a/src/animation/customGraphicKeyframeAnimation.ts
+++ b/src/animation/customGraphicKeyframeAnimation.ts
@@ -22,7 +22,7 @@ import Element from 'zrender/src/Element';
 import { keys, filter, each, isArray, indexOf } from 'zrender/src/core/util';
 import { ELEMENT_ANIMATABLE_PROPS } from './customGraphicTransition';
 import { AnimationOption, AnimationOptionMixin, Dictionary } from '../util/types';
-import { Model } from '../echarts.all';
+import type Model from '../model/Model';
 import { getAnimationConfig } from './basicTransition';
 import { warn } from '../util/log';
 import { makeInner } from '../util/model';

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -99,7 +99,7 @@ import {
     applyKeyframeAnimation,
     stopPreviousKeyframeAnimationAndRestore
 } from '../../animation/customGraphicKeyframeAnimation';
-import { SeriesModel } from '../../echarts.all';
+import type SeriesModel from '../../model/Series';
 
 const EMPHASIS = 'emphasis' as const;
 const NORMAL = 'normal' as const;

--- a/src/coord/geo/geoCreator.ts
+++ b/src/coord/geo/geoCreator.ts
@@ -27,14 +27,13 @@ import MapSeries, { MapSeriesOption } from '../../chart/map/MapSeries';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { CoordinateSystemCreator } from '../CoordinateSystem';
 import { NameMap } from './geoTypes';
-import SeriesModel from '../../model/Series';
 import { SeriesOption, SeriesOnGeoOptionMixin } from '../../util/types';
 import { Dictionary } from 'zrender/src/core/types';
-import GlobalModel from '../../model/Global';
-import ComponentModel from '../../model/Component';
-import { Model } from '../../echarts.all';
+import type Model from '../../model/Model';
+import type GlobalModel from '../../model/Global';
+import type SeriesModel from '../../model/Series';
+import type ComponentModel from '../../model/Component';
 import * as vector from 'zrender/src/core/vector';
-
 
 export type resizeGeoType = typeof resizeGeo;
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?

- Fix incorrect import of `SeriesModel` from `echarts.all`. See also
https://github.com/apache/echarts/pull/17349#discussion_r932843099
- Fix similar issues in `geoCreator.ts` & `animation/customGraphicKeyframeAnimation.ts`