### PR TITLE
fix(type): add alignWithLabel and interval props to AxisTick

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -179,6 +179,8 @@ interface AxisLineOption {
 
 interface AxisTickOption {
     show?: boolean | 'auto',
+    alignWithLabel?: boolean,
+    interval?: 'auto' | number | ((index:number, value: string) => boolean),
     // Whether axisTick is inside the grid or outside the grid.
     inside?: boolean,
     // The length of axisTick.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Adds missing properties to the `AxisTickOption` interface, so that it matches the [documentation](https://echarts.apache.org/en/option.html#xAxis.axisTick).

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

We were getting a typescript error about `alignWithLabel` and `interval` when we tried setting them

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

We no longer get a typescript error using these properties.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.
