### PR TITLE
fix(theme): fix tooltips text style of the theme macarons

### DIFF
--- a/theme/macarons.js
+++ b/theme/macarons.js
@@ -87,7 +87,11 @@
         },
 
         tooltip: {
+            borderWidth: 0,
             backgroundColor: 'rgba(50,50,50,0.5)',
+            textStyle: {
+                color: '#FFF'
+            },
             axisPointer: {
                 type: 'line',
                 lineStyle: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?
fix tooltips text style of the theme macarons same as v4.9.0

### Fixed issues
* [5.3.3部分配置项默认值同文档不一致](https://github.com/apache/echarts/issues/17542)

## Details

### Before: What was the problem?
The theme macarons' tooltips style is not sam as it show in v4.9.0



### After: How does it behave after the fixing?
The theme macarons' tooltips style is same as the tooltips show in v4.9.0



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
