### PR TITLE
fix: incorrect dataGroupId for old data items in universalTransition

### DIFF
--- a/test/universalTransition2.html
+++ b/test/universalTransition2.html
@@ -62,9 +62,9 @@ under the License.
                     data: ['Animals', 'Fruits', 'Cars']
                 },
                 yAxis: {},
-                dataGroupId: '',
                 animationDurationUpdate: ANIMATION_DURATION_UPDATE,
                 series: {
+                    dataGroupId: '',
                     type: 'bar',
                     id: 'main',
                     data: [{


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

dataGroupId for old data items in universalTransition is mistakenly set to that of new data items, not the expected old one. So fix it.

### Fixed issues

- #17309

## Details

### Before: What was the problem?

https://github.com/apache/echarts/blob/89d57f21b7eabfcc6770447f6cf6a20a8f406585/src/animation/universalTransition.ts#L210

When processing old data items, after executing this line, dataGroupId is wrongly assigned a value that is belong to new data items. That will cause universalTransition not work if we fall back to depend on dataGroupId to decide dataItem's key.

### After: How does it behave after the fixing?

By storing the old dataGroupId in globalStore, now the correct old dataGroupId can be accessed!

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

I think [the example](https://echarts.apache.org/examples/zh/editor.html?c=bar-drilldown) should be updated with `dataGroupId` in `series` field.

![image](https://user-images.githubusercontent.com/32434520/186184210-29f4896a-99ff-4406-86a8-ed35199fded8.png)

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Thanks for @pissang's instruction!