### PR TITLE
fix: ensure compatibility with typescript@4.8

### DIFF
--- a/src/animation/basicTransition.ts
+++ b/src/animation/basicTransition.ts
@@ -26,7 +26,7 @@ import {
     AnimationOption
 } from '../util/types';
 import { AnimationEasing } from 'zrender/src/animation/easing';
-import Element, { ElementAnimateConfig } from 'zrender/src/Element';
+import Element, { ElementAnimateConfig, ElementProps } from 'zrender/src/Element';
 import Model from '../model/Model';
 import {
     isFunction,
@@ -216,7 +216,7 @@ function animateOrSetProps<Props>(
  *         position: [100, 100]
  *     }, seriesModel, function () { console.log('Animation done!'); });
  */
- function updateProps<Props>(
+ function updateProps<Props extends ElementProps>(
     el: Element<Props>,
     props: Props,
     // TODO: TYPE AnimatableModel
@@ -238,7 +238,7 @@ export {updateProps};
  * So do not use this method to one element twice before
  * animation starts, unless you know what you are doing.
  */
-export function initProps<Props>(
+export function initProps<Props extends ElementProps>(
     el: Element<Props>,
     props: Props,
     animatableModel?: Model<AnimationOptionMixin>,

--- a/src/chart/bar/BaseBarSeries.ts
+++ b/src/chart/bar/BaseBarSeries.ts
@@ -24,14 +24,15 @@ import {
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin,
     ScaleDataValue,
-    DefaultStatesMixin
+    DefaultStatesMixin,
+    StatesMixinBase
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import SeriesData from '../../data/SeriesData';
 
 
-export interface BaseBarSeriesOption<StateOption, ExtraStateOption = DefaultStatesMixin>
+export interface BaseBarSeriesOption<StateOption, ExtraStateOption extends StatesMixinBase = DefaultStatesMixin>
     extends SeriesOption<StateOption, ExtraStateOption>,
     SeriesOnCartesianOptionMixin,
     SeriesOnPolarOptionMixin {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Allows using echarts with newly released ts@4.8, when .d.ts are being checked.


### Fixed issues

fixes #17581


## Details

### Before: What was the problem?

See #17581

### After: How does it behave after the fixing?

Passes type checking

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
