### PR TITLE
feat(treemap): add `scaleLimit` to limit the zooming

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -250,6 +250,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
                                             // to align specialized icon. ▷▶❒❐▼✚
 
         zoomToNodeRatio: 0.32 * 0.32,
+        scaleLimit: null,
 
         roam: true,
         nodeClick: 'zoomToNode',

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -160,6 +160,8 @@ class TreemapView extends ChartView {
 
     private _storage = createStorage() as RenderElementStorage;
 
+    private _zoom = 1;;
+
     seriesModel: TreemapSeriesModel;
     api: ExtensionAPI;
     ecModel: GlobalModel;
@@ -528,6 +530,12 @@ class TreemapView extends ChartView {
         let mouseY = e.originY;
 
         if (this._state !== 'animating') {
+            let newZoom = this._zoom * e.scale;
+            const scaleLimit = this.seriesModel.get('scaleLimit');
+            if (newZoom > scaleLimit.max || newZoom < scaleLimit.min) {
+              return;
+            }
+            this._zoom = newZoom;
             // These param must not be cached.
             const root = this.seriesModel.getData().tree.root;
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add `scaleLimit` option to allow limiting the zooming in treemap.
<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
- #17511
- #14599


<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

We don't have any limitation for zooming in treemap.

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

Support `scaleLimit` in treemap series, as graph series, tree series, geo component did.

Like [scaleLimit in geo](https://echarts.apache.org/en/option.html#geo.scaleLimit)

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
