### PR TITLE
chore(lint): enforce consistent spacing after comment starts

### DIFF
--- a/.eslintrc-common.yaml
+++ b/.eslintrc-common.yaml
@@ -163,7 +163,7 @@ rules:
         - 2
         - "never"
     space-unary-ops: 2
-    spaced-comment: 0
+    spaced-comment: "error"
 
     max-nested-callbacks:
         - 1

--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -77,7 +77,7 @@ export function getScaleExtent(scale: Scale, model: AxisBaseModel) {
     // (4) Consider other chart types using `barGrid`?
     // See #6728, #4862, `test/bar-overflow-time-plot.html`
     const ecModel = model.ecModel;
-    if (ecModel && (scaleType === 'time' /*|| scaleType === 'interval' */)) {
+    if (ecModel && (scaleType === 'time' /* || scaleType === 'interval' */)) {
         const barSeriesModels = prepareLayoutBarSeries('bar', ecModel);
         let isBaseAxisAndHasBarSeries = false;
 

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -384,7 +384,7 @@ const iterator: TaskDataIterator = (function () {
 
 
 
-///////////////////////////////////////////////////////////
+// -----------------------------------------------------------------------------
 // For stream debug (Should be commented out after used!)
 // @usage: printTask(this, 'begin');
 // @usage: printTask(this, null, {someExtraProp});

--- a/src/export/api.ts
+++ b/src/export/api.ts
@@ -41,7 +41,7 @@ export {use} from '../extension';
 
 export {setPlatformAPI} from 'zrender/src/core/platform';
 
-//////////////// Helper Methods /////////////////////
+// --------------------- Helper Methods ---------------------
 export {default as parseGeoJSON} from '../coord/geo/parseGeoJson';
 export {default as parseGeoJson} from '../coord/geo/parseGeoJson';
 
@@ -55,7 +55,7 @@ export * as util from './api/util';
 
 export {default as env} from 'zrender/src/core/env';
 
-//////////////// Export for Exension Usage ////////////////
+// --------------------- Export for Exension Usage ---------------------
 // export {SeriesData};
 export {SeriesData as List};    // TODO: Compatitable with exists echarts-gl code
 export {default as Model} from '../model/Model';
@@ -72,7 +72,7 @@ export {
 export {brushSingle as innerDrawElementOnCanvas} from 'zrender/src/canvas/graphic';
 
 
-//////////////// Deprecated Extension Methods ////////////////
+// --------------------- Deprecated Extension Methods ---------------------
 
 // Should use `ComponentModel.extend` or `class XXXX extend ComponentModel` to create class.
 // Then use `registerComponentModel` in `install` parameter when `use` this extension. For example:

--- a/src/layout/barPolar.ts
+++ b/src/layout/barPolar.ts
@@ -100,7 +100,7 @@ function barLayoutPolar(seriesType: string, ecModel: GlobalModel, api: Extension
 
         const valueDim = data.mapDimension(valueAxis.dim);
         const baseDim = data.mapDimension(baseAxis.dim);
-        const stacked = isDimensionStacked(data, valueDim /*, baseDim*/);
+        const stacked = isDimensionStacked(data, valueDim /* , baseDim */);
         const clampLayout = baseAxis.dim !== 'radius'
             || !seriesModel.get('roundCap', true);
 

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -365,7 +365,8 @@ function elementStateProxy(this: Displayable, stateName: string, targetStates?: 
     }
     return state;
 }
-/**FI
+
+/**
  * Set hover style (namely "emphasis style") of element.
  * @param el Should not be `zrender/graphic/Group`.
  * @param focus 'self' | 'selfInSeries' | 'series'

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -758,7 +758,8 @@ export type ComponentLayoutMode = {
     type?: 'box',
     ignoreSize?: boolean | boolean[]
 };
-/******************* Mixins for Common Option Properties   ********************** */
+
+// ------------------ Mixins for Common Option Properties ------------------
 export type PaletteOptionMixin = ColorPaletteOptionMixin;
 
 export interface ColorPaletteOptionMixin {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Disallow comments starting without space. For example: `//This is not allowed`.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Sometimes contributors forget to add a space after comment starts.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The CI will break if there is no space after a comment starts.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
