### PR TITLE
fix(bar): fix bar axis range when maximum data is small #13128

### DIFF
--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -138,10 +138,12 @@ export function round(x: number | string, precision: number, returnStr: false): 
 export function round(x: number | string, precision: number, returnStr: true): string;
 export function round(x: number | string, precision?: number, returnStr?: boolean): string | number {
     if (precision == null) {
-        precision = 10;
+        precision = ROUND_SUPPORTED_PRECISION_MAX;
     }
-    // Avoid range error
-    precision = Math.min(Math.max(0, precision), ROUND_SUPPORTED_PRECISION_MAX);
+    else {
+        // Avoid range error
+        precision = Math.min(Math.max(0, precision), ROUND_SUPPORTED_PRECISION_MAX);
+    }
     // PENDING: 1.005.toFixed(2) is '1.00' rather than '1.01'
     x = (+x).toFixed(precision);
     return (returnStr ? x : +x);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When the max value of bar series is small enough (less than 1e^-10), the bar series is not displayed because the calculated axis extent is 0.

### Fixed issues

#13128

## Details

### Before: What was the problem?

Bar series is not displayed.


### After: How does it behave after the fixing?

Bar series is displayed and the axis extent is correct.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

`ROUND_SUPPORTED_PRECISION_MAX` is set to be `20`, which means if the max data is less than `1e-20`, we still have similar problems. But this PR is meaningful because when `precision` is not provided, we should not use `10` for default because this introduces another new concept and causes further confusions. Instead, we should use `20` to make the precision logic constant.
