### PR TITLE
fix: add width, height, x,y to CustomSeriesRenderItemParamsCoordSys type

### DIFF
--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -282,6 +282,10 @@ export interface CustomSeriesRenderItemAPI extends
 }
 export interface CustomSeriesRenderItemParamsCoordSys {
     type: string;
+    width?: number;
+    height?: number;
+    x?: number;
+    y?: number;
     // And extra params for each coordinate systems.
 }
 export interface CustomSeriesRenderItemCoordinateSystemAPI {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information
Adding more params -- `width`, `height`, `x`, `y` to `CustomSeriesRenderItemParamsCoordSys` type, which can be useful when creating custom rectangle shapes with echarts.

```js
const rectShape = echarts.graphic.clipRectByRect(
    {
        x: start[0],
        y: start[1] - height / 2,
        width: end[0] - start[0],
        height: height,
    },
    {
        x: params.coordSys.x ?? 0,
        y: params.coordSys.y ?? 0,
        width: params.coordSys.width ?? 0,
        height: params.coordSys.height ?? 0,
    }
);
```


This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Adding more params to `CustomSeriesRenderItemParamsCoordSys` type, which can be useful when creating custom rectangle shapes with echarts.



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
TypeScript check fails while creating custom rectangles using `coorsSys`.



### After: How does it behave after the fixing?
Fixing the type interface



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
