### PR TITLE
fix #17633: add gauge sectors in the order of the "clockwise" option

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -31,7 +31,7 @@ import SeriesData from '../../data/SeriesData';
 import Sausage from '../../util/shape/sausage';
 import {createSymbol} from '../../util/symbol';
 import ZRImage from 'zrender/src/graphic/Image';
-import {extend, isFunction, isString, isNumber} from 'zrender/src/core/util';
+import { extend, isFunction, isString, isNumber, each } from 'zrender/src/core/util';
 import {setCommonECData} from '../../util/innerStore';
 import { normalizeArcAngles } from 'zrender/src/core/PathProxy';
 
@@ -161,7 +161,7 @@ class GaugeView extends ChartView {
         }
 
         sectors.reverse();
-        sectors.forEach(sector => group.add(sector));
+        each(sectors, sector => group.add(sector));
 
         const getColor = function (percent: number) {
             // Less than 0

--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -127,6 +127,7 @@ class GaugeView extends ChartView {
 
         let prevEndAngle = startAngle;
 
+        const sectors: (Sausage | graphic.Sector)[] = [];
         for (let i = 0; showAxis && i < colorList.length; i++) {
             // Clamp
             const percent = Math.min(Math.max(colorList[i][0], 0), 1);
@@ -154,10 +155,13 @@ class GaugeView extends ChartView {
                 ['color', 'width']
             ));
 
-            group.add(sector);
+            sectors.push(sector);
 
             prevEndAngle = endAngle;
         }
+
+        sectors.reverse();
+        sectors.forEach(sector => group.add(sector));
 
         const getColor = function (percent: number) {
             // Less than 0

--- a/test/gauge-case.html
+++ b/test/gauge-case.html
@@ -22,14 +22,14 @@ under the License.
 <html>
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
         <script src="lib/jquery.min.js"></script>
         <script src="lib/facePrint.js"></script>
         <script src="lib/testHelper.js"></script>
         <!-- <script src="ut/lib/canteen.js"></script> -->
-        <link rel="stylesheet" href="lib/reset.css" />
+        <link rel="stylesheet" href="lib/reset.css"/>
     </head>
     <body>
         <style>
@@ -39,56 +39,58 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
+        <div id="main3-1"></div>
+        <div id="main3-2"></div>
 
 
         <script>
-        require(['echarts'/*, 'map/js/china' */], function (echarts) {
-            var option = {
-                tooltip: {
-                    formatter: '{a} <br/>{b} : {c}%'
-                },
-                toolbox: {
-                    feature: {
-                        restore: {},
-                        saveAsImage: {}
-                    }
-                },
-                series:  {
-                    type: 'gauge',
-                    center: ["50%", "50%"],
-                    radius: '70%',
-                    startAngle: 150,
-                    endAngle: -20,
-                    min: 0,
-                    max: 2000,
-                    progress: {
-                        show: true,
-                        width: 18
+            require(['echarts'/*, 'map/js/china' */], function (echarts) {
+                var option = {
+                    tooltip: {
+                        formatter: '{a} <br/>{b} : {c}%'
                     },
-                    axisLabel: {
-                        distance: 30,
-                        rotate: 50
-                    },
-                    data: [
-                        {
-                            value: 0
+                    toolbox: {
+                        feature: {
+                            restore: {},
+                            saveAsImage: {}
                         }
-                    ]
-                }
-            };
+                    },
+                    series: {
+                        type: 'gauge',
+                        center: ["50%", "50%"],
+                        radius: '70%',
+                        startAngle: 150,
+                        endAngle: -20,
+                        min: 0,
+                        max: 2000,
+                        progress: {
+                            show: true,
+                            width: 18
+                        },
+                        axisLabel: {
+                            distance: 30,
+                            rotate: 50
+                        },
+                        data: [
+                            {
+                                value: 0
+                            }
+                        ]
+                    }
+                };
 
-            var chart = testHelper.create(echarts, 'main0', {
-                title: [
-                    'Regression Test from #14162',
-                    'Should not display a circle'
-                ],
-                option: option
-                // height: 1200,
-                // buttons: [{text: 'btn-txt', onclick: function () {}}],
-                // recordCanvas: true,
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Regression Test from #14162',
+                        'Should not display a circle'
+                    ],
+                    option: option
+                    // height: 1200,
+                    // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                    // recordCanvas: true,
+                });
+
             });
-
-        });
         </script>
 
         <script>
@@ -103,7 +105,7 @@ under the License.
                             {
                                 value: 0,
                                 name: 'SCORE'
-                                }
+                            }
                         ],
                         axisLabel: {
                             distance: 30,
@@ -154,6 +156,61 @@ under the License.
                     option: option
                 });
             });
+        </script>
+        <script>
+            require(['echarts'], function (echarts) {
+                const option = {
+                    tooltip: {
+                        formatter: '{a} <br/>{b} : {c}%'
+                    },
+                    series: [
+                        {
+                            name: 'Pressure',
+                            type: 'gauge',
+                            clockwise: true,
+                            detail: {
+                                valueAnimation: true,
+                                formatter: '{value}'
+                            },
+                            data: [
+                                {
+                                    value: 50,
+                                    name: 'SCORE'
+                                }
+                            ],
+                            axisLine: {
+                                "roundCap": true,
+                                "lineStyle": {
+                                    "width": 16,
+                                    "color": [[0.3, "#C9781B"], [0.7, "#F163EA"], [1, "#6366F1"]]
+                                }
+                            }
+                        }
+                    ]
+                };
+                testHelper.create(echarts, 'main3-1', {
+                    title: [
+                        'Case from #17633',
+                        'Order of Axis lines should respect the clockwise option',
+                        'clockwise: true'
+                    ],
+                    option
+                });
+                testHelper.create(echarts, 'main3-2', {
+                    title: [
+                        'Case from #17633',
+                        'Order of Axis lines should respect the clockwise option',
+                        'clockwise: false'
+                    ],
+                    option: {
+                        ...option,
+                        series: [{
+                            ...option.series[0],
+                            clockwise: false
+                        }]
+                    }
+                });
+            })
         </script>
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

add gauge sectors in the order of the "clockwise" option

### Fixed issues

<!--
- #xxxx: ...
-->

#17633 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/13861843/192080757-b5bc4dc4-a1d0-4eb9-abb1-27786b4e8837.png)

The gauge view adds sectors in the order of the `colorList` option,  however, these elements will be covered by elements added later, and the order of the sectors looks reversed when the `roundCap` option is enabled.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Reverse the sectors array before adding them to the graphic group

![image](https://user-images.githubusercontent.com/13861843/192080967-d9390563-d36e-40e9-b1db-6b6ff49837a1.png)



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

[gauge-case](https://github.com/ZeekoZhu/echarts/blob/86bbd4d8dd0b828cd91aa45584df53808d41e0db/test/gauge-case.html)


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
