### PR TITLE
fix(pie): fix `labelLine` NPE when `minShowLabelRadian` is set

### DIFF
--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -394,8 +394,11 @@ export default function pieLabelLayout(
 
         if (Math.abs(sectorShape.endAngle - sectorShape.startAngle) < minShowLabelRadian) {
             each(label.states, setNotShow);
-            each(labelLine.states, setNotShow);
-            label.ignore = labelLine.ignore = true;
+            label.ignore = true;
+            if (labelLine) {
+                each(labelLine.states, setNotShow);
+                labelLine.ignore = true;
+            }
             return;
         }
 

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -52,6 +52,7 @@ under the License.
         <div id="main9"></div>
         <div id="main10"></div>
         <div id="main11"></div>
+        <div id="main12"></div>
 
         <script>
 
@@ -975,6 +976,40 @@ under the License.
                     title: [
                         'Label line should be hidden after clicking the legend item **其他**',
                         'Test case from issue #17013',
+                    ],
+                    height: 300,
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    series: [{
+                        type: 'pie',
+                        radius: ['40%', '70%'],
+                        minShowLabelAngle: 100,
+                        label: {
+                            show: true,
+                            position: 'inside'
+                        },
+                        data: [
+                            { value: 1048, name: 'Search Engine' },
+                            { value: 735, name: 'Direct' },
+                            { value: 580, name: 'Email' },
+                            { value: 484, name: 'Union Ads' },
+                            { value: 300, name: 'Video Ads' }
+                        ]
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main12', {
+                    title: [
+                        'The labels should be rendered correctly and no errors in the console',
+                        'Test case from issue #17712',
                     ],
                     height: 300,
                     option: option


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix an undefined error of `labelLine` when the sector angle is less than `minShowLabelRadian`.
This bug was unexpectedly brought by #17412, which is in v5.4.0.

### Fixed issues

- Resolves #17712

## Details

### Before: What was the problem?

![image](https://user-images.githubusercontent.com/26999792/192932933-6faf9ac3-746e-49ec-bf6e-9b80792f96b6.png)

### After: How does it behave after the fixing?

![image](https://user-images.githubusercontent.com/26999792/192932953-b05ff61e-5094-4479-b279-1e85de58a243.png)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last case in `test/pie-label.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
