### PR TITLE
feat(candlestick): provide borderColorDoji option for custom doji color

### DIFF
--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -43,6 +43,7 @@ type CandlestickDataValue = OptionDataValue[];
 interface CandlestickItemStyleOption extends ItemStyleOption {
     color0?: ZRColor
     borderColor0?: ColorString
+    borderColorDoji?: ZRColor
 }
 export interface CandlestickStateOption {
     itemStyle?: CandlestickItemStyleOption
@@ -116,6 +117,7 @@ class CandlestickSeriesModel extends SeriesModel<CandlestickSeriesOption> {
             color0: '#47b262', // negative
             borderColor: '#eb5454',
             borderColor0: '#47b262',
+            borderColorDoji: null, // when close === open
             // borderColor: '#d24040',
             // borderColor0: '#398f4f',
             borderWidth: 1

--- a/src/chart/candlestick/CandlestickView.ts
+++ b/src/chart/candlestick/CandlestickView.ts
@@ -368,9 +368,16 @@ function createLarge(
         ignoreCoarsePointer: true
     });
     group.add(elN);
+    const elDoji = new LargeBoxPath({
+        shape: {points: largePoints},
+        __sign: 0,
+        ignoreCoarsePointer: true
+    });
+    group.add(elDoji);
 
     setLargeStyle(1, elP, seriesModel, data);
     setLargeStyle(-1, elN, seriesModel, data);
+    setLargeStyle(0, elDoji, seriesModel, data);
 
     if (incremental) {
         elP.incremental = true;
@@ -384,8 +391,12 @@ function createLarge(
 
 function setLargeStyle(sign: number, el: LargeBoxPath, seriesModel: CandlestickSeriesModel, data: SeriesData) {
     // TODO put in visual?
-    const borderColor = seriesModel.get(['itemStyle', sign > 0 ? 'borderColor' : 'borderColor0'])
+    let borderColor = seriesModel.get(['itemStyle', sign > 0 ? 'borderColor' : 'borderColor0'])
+        // Use color for border color by default.
         || seriesModel.get(['itemStyle', sign > 0 ? 'color' : 'color0']);
+    if (sign === 0) {
+        borderColor = seriesModel.get(['itemStyle', 'borderColorDoji']);
+    }
 
     // Color must be excluded.
     // Because symbol provide setColor individually to set fill and stroke

--- a/src/chart/candlestick/candlestickVisual.ts
+++ b/src/chart/candlestick/candlestickVisual.ts
@@ -25,6 +25,7 @@ import { extend } from 'zrender/src/core/util';
 
 const positiveBorderColorQuery = ['itemStyle', 'borderColor'] as const;
 const negativeBorderColorQuery = ['itemStyle', 'borderColor0'] as const;
+const dojiBorderColorQuery = ['itemStyle', 'borderColorDoji'] as const;
 const positiveColorQuery = ['itemStyle', 'color'] as const;
 const negativeColorQuery = ['itemStyle', 'color0'] as const;
 
@@ -47,7 +48,10 @@ const candlestickVisual: StageHandler = {
 
         function getBorderColor(sign: number, model: Model<Pick<CandlestickDataItemOption, 'itemStyle'>>) {
             return model.get(
-                sign > 0 ? positiveBorderColorQuery : negativeBorderColorQuery
+                sign === 0 ? dojiBorderColorQuery
+                    : sign > 0
+                        ? positiveBorderColorQuery
+                        : negativeBorderColorQuery
             );
         }
 

--- a/test/candlestick-doji.html
+++ b/test/candlestick-doji.html
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,45 +18,43 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+
 <html>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
         <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
     </head>
     <body>
         <style>
-            html, body, #main {
-                width: 100%;
-                height: 100%;
-            }
         </style>
-        <div id="info"></div>
-        <div id="main"></div>
+
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+
+
+
+
+
+
         <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
 
-            /**
-             * @see <https://en.wikipedia.org/wiki/Michelson%E2%80%93Morley_experiment>
-             * @see <http://bl.ocks.org/mbostock/4061502>
-             */
-            var chart;
-            var data;
-
-            require([
-                'echarts',
-                'data/security-sh-2013.json.js'
-            ], function (echarts, rawData) {
-
-                chart = echarts.init(document.getElementById('main'), null, {
-
-                });
-
-                option = {
-                    title: {
-                        text: "十字星颜色测试，期望值：红、红、红、绿、红、红、红、绿"
-                    },
+            option = {
                     "xAxis": [{
                         "type": "category",
                         "data": ["2017-08-22", "2017-08-23", "2017-08-24", "2017-08-25", "2017-08-28", "2017-08-29", "2017-08-30", "2017-08-31"],
@@ -94,12 +92,10 @@ under the License.
                             [32, 28, 27, 33]
                         ],
                         "itemStyle": {
-                            "normal": {
-                                "color": "#fa6464",
-                                "color0": "#32C896",
-                                "borderColor": "#fa6464",
-                                "borderColor0": "#32C896"
-                            }
+                            "color": "#fa6464",
+                            "color0": "#32C896",
+                            "borderColor": "#fa6464",
+                            "borderColor0": "#32C896"
                         },
                         "markPoint": {
                             "label": {
@@ -109,8 +105,175 @@ under the License.
                         }
                     }]
                 };
-                chart.setOption(option);
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Doji test',
+                    'Expect: red, red, red, green, red, red, red, green'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
             });
+        });
         </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                    "xAxis": [{
+                        "type": "category",
+                        "data": ["2017-08-22", "2017-08-23", "2017-08-24", "2017-08-25", "2017-08-28", "2017-08-29", "2017-08-30", "2017-08-31"],
+                        "scale": true,
+                        "boundaryGap": false,
+                        "axisLine": {
+                            "onZero": false,
+                            "lineStyle": {
+                                "color": "#f1f1f1"
+                            }
+                        },
+                        "axisTick": {
+                            "show": false
+                        },
+                        "axisLabel": {
+                            "show": false
+                        },
+                        "axisPointer": {
+                            "z": 100
+                        }
+                    }],
+                    "yAxis": [{
+                    }],
+                    "series": [{
+                        "name": "stock",
+                        "type": "candlestick",
+                        "data": [
+                            [20, 20, 17, 29],
+                            [22.68, 22.68, 22.68, 22.68],
+                            [24.95, 24.95, 20, 28],
+                            [20, 20, 18, 24],
+                            [35, 35, 35, 40],
+                            [36.54, 36.54, 30, 36.54],
+                            [40, 45, 38, 45],
+                            [32, 28, 27, 33]
+                        ],
+                        "itemStyle": {
+                            "color": "#fa6464",
+                            "color0": "#32C896",
+                            "borderColorDoji": "#0000ff",
+                            "borderColor": "#fa6464",
+                            "borderColor0": "#32C896"
+                        },
+                        "markPoint": {
+                            "label": {
+                                "normal": {}
+                            },
+                            "data": []
+                        }
+                    }]
+                };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Custom doji color',
+                    'Expect: crosses are all in blue'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                    "xAxis": [{
+                        "type": "category",
+                        "data": ["2017-08-22", "2017-08-23", "2017-08-24", "2017-08-25", "2017-08-28", "2017-08-29", "2017-08-30", "2017-08-31"],
+                        "scale": true,
+                        "boundaryGap": false,
+                        "axisLine": {
+                            "onZero": false,
+                            "lineStyle": {
+                                "color": "#f1f1f1"
+                            }
+                        },
+                        "axisTick": {
+                            "show": false
+                        },
+                        "axisLabel": {
+                            "show": false
+                        },
+                        "axisPointer": {
+                            "z": 100
+                        }
+                    }],
+                    "yAxis": [{
+                    }],
+                    "series": [{
+                        "name": "stock",
+                        "type": "candlestick",
+                        "data": [
+                            [20, 20, 17, 29],
+                            [22.68, 22.68, 22.68, 22.68],
+                            [24.95, 24.95, 20, 28],
+                            [20, 20, 18, 24],
+                            [35, 35, 35, 40],
+                            [36.54, 36.54, 30, 36.54],
+                            [40, 45, 38, 45],
+                            [32, 28, 27, 33]
+                        ],
+                        "itemStyle": {
+                            "color": "#fa6464",
+                            "color0": "#32C896",
+                            "borderColorDoji": "#0000ff",
+                            "borderColor": "#fa6464",
+                            "borderColor0": "#32C896"
+                        },
+                        largeThreshold: 2,
+                        "markPoint": {
+                            "label": {
+                                "normal": {}
+                            },
+                            "data": []
+                        }
+                    }]
+                };
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: [
+                    'Custom doji color with large candlestick',
+                    'Expect: five blue sticks'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Provide option `series-candlestick.itemStyle.borderColorDoji` to set custom doji color.

### Fixed issues

#11042


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Doji means the open and close value of a data item is the same. Previously, it can either be `borderColor` or `borderColor0` according to the previous data item. But if developers want to change it to a custom color, like a neutral colour like gary, it cannot be done.

### After: How does it behave after the fixing?

So in this PR, we provide a new option `borderColorDoji`. If it is set, this color is used for all doji data items.



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/candlestick-doji.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
