### PR TITLE
lint

### DIFF
--- a/src/layout/barGrid.ts
+++ b/src/layout/barGrid.ts
@@ -603,5 +603,6 @@ function isInLargeMode(seriesModel: BarSeriesModel) {
 
 // See cases in `test/bar-start.html` and `#7412`, `#8747`.
 function getValueAxisStart(baseAxis: Axis2D, valueAxis: Axis2D) {
-    return valueAxis.toGlobalCoord(valueAxis.dataToCoord(valueAxis.type === 'log' ? 1 : 0));
+    const min = valueAxis.type === 'log' ? valueAxis.scale.getExtent()[0] : 0;
+    return valueAxis.toGlobalCoord(valueAxis.dataToCoord(min));
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

When using a log value axis, the layout is set to use `1` as the baseline value when it should be using the actual min value set on the axis (e.g. 0.1).


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<img width="352" alt="Capture d’écran 2022-10-05 à 12 56 12" src="https://user-images.githubusercontent.com/13403295/194044749-04b1f7ee-fdf7-4fa6-93eb-fe5a2f1e47fb.png">


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="352" alt="Capture d’écran 2022-10-05 à 12 56 36" src="https://user-images.githubusercontent.com/13403295/194044780-1ac61b28-5456-43a4-ab3e-49565bece893.png">



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
