### PR TITLE
fix: EChartsInitOpts type error about height and width. close #17667

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -328,8 +328,8 @@ type EChartsInitOpts = {
     useCoarsePointer?: boolean,
     pointerSize?: number,
     ssr?: boolean,
-    width?: number,
-    height?: number
+    width?: number | string,
+    height?: number | string
 };
 class ECharts extends Eventful<ECEventDefinition> {
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

fix type error about `height` and `width` of `EChartsInitOpts`

### Fixed issues

<!--
- #xxxx: ...
-->
#17667 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
[Bug] The documentation for EChartsInitOpts has a type error about height and width

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
The description type of the document differs from that in the code
![image](https://user-images.githubusercontent.com/32701177/194076171-70165aa9-059a-4315-9758-ebaff452f252.png)
![image](https://user-images.githubusercontent.com/32701177/194076251-46071624-ffe5-420a-a5f2-6c75b2ab9e92.png)

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Add union types `number | string` for `height` and `width` 
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
