### PR TITLE
chore: update deprecated Node v12 to v16 & update action dependency version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - name: Fetch commit count
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -15,15 +15,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: next
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,12 +15,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -11,13 +11,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -26,7 +26,7 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -34,7 +34,7 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Prepare releaes materials
+      - name: Prepare release materials
         run: |
           npm i
           node build/source-release/prepareReleaseMaterials.js \
@@ -44,7 +44,7 @@ jobs:
             --out tmp/materials
 
       - name: Archive materials
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apache-echarts-${{env.RELEASE_VERSION}}-release-materials
           path: |
@@ -56,13 +56,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -72,7 +72,7 @@ jobs:
 
       # Get RELEASE_NOTE.txt and pack it into zip.
       - name: Download materials
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: apache-echarts-${{env.RELEASE_VERSION}}-release-materials
 
@@ -80,7 +80,7 @@ jobs:
 
       # Archive before run others to avoid packing unknown files.
       - name: Archive source release
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apache-echarts-${{env.RELEASE_VERSION}}-src
           path: |
@@ -109,11 +109,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -122,7 +122,7 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Download source release
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: apache-echarts-${{env.RELEASE_VERSION}}-src
           path: tmp/echarts

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository_owner == 'apache' }}
     steps:
       - name: Close Stale Issues
-        uses: actions/stale@v5
+        uses: actions/stale@v6
         with:
           days-before-stale: 730
           days-before-close: 7


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?

1. Update deprecated Node v12 to v16 for removing the warnings from GitHub Action.

![image](https://user-images.githubusercontent.com/26999792/195737374-cf588c77-426c-487e-84ec-a199eafb4830.png)

See also https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

2. Update the dependency actions to the latest version.