### PR TITLE
chore(workflow): always install the latest nightly version of zrender when publishing nightly echarts

### DIFF
--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -28,13 +28,14 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly
         run: |
-          npm i
+          node build/nightly/prepare.js --next
           npm i zrender@npm:zrender-nightly@next
+          npm ci
           npm ls zrender
+          node build/nightly/post.js
           npm run release
           npm run test
           npm run test:dts
-          node build/prepareNightly.js --next
           npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -28,7 +28,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly
         run: |
-          npm ci
+          npm i
+          npm i zrender@npm:zrender-nightly@next
+          npm ls zrender
           npm run release
           npm run test
           npm run test:dts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,13 +25,14 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly
         run: |
-          npm i
+          node build/nightly/prepare.js
           npm i zrender@npm:zrender-nightly
+          npm ci
           npm ls zrender
+          node build/nightly/post.js
           npm run release
           npm run test
           npm run test:dts
-          node build/prepareNightly.js
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly
         run: |
-          npm ci
+          npm i
+          npm i zrender@npm:zrender-nightly
+          npm ls zrender
           npm run release
           npm run test
           npm run test:dts

--- a/build/nightly/post.js
+++ b/build/nightly/post.js
@@ -1,0 +1,30 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+const fs = require('fs');
+
+const root = __dirname + '/../../';
+const echartsPkg = JSON.parse(fs.readFileSync(root + 'package.json'), 'utf-8');
+const zrenderPkg = JSON.parse(fs.readFileSync(root + 'node_modules/zrender/package.json', 'utf-8'));
+
+const echartsCorePath = root + 'src/core/echarts.ts';
+const echartsCoreFile = fs.readFileSync(echartsCorePath, 'utf-8')
+    .replace(/export const version = '\S+'/, `export const version = '${echartsPkg.version}'`)
+    .replace(/(export const dependencies = {\s+zrender: ')\S+('\s+})/, `$1${zrenderPkg.version}$2`);
+fs.writeFileSync(echartsCorePath, echartsCoreFile, 'utf-8');

--- a/build/nightly/prepare.js
+++ b/build/nightly/prepare.js
@@ -19,7 +19,7 @@
 
 
 const fs = require('fs');
-const packageJsonPath = __dirname + '/../package.json';
+const packageJsonPath = __dirname + '/../../package.json';
 const nightlyPackageName = 'echarts-nightly';
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
@@ -57,8 +57,7 @@ packageJson.version = updateVersion(packageJson.version);
 
 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');
 
-
-const readmePath = __dirname + '/../README.md';
+const readmePath = __dirname + '/../../README.md';
 const readmeAttention = `<h3>
 <p><em>⚠️ ATTENTION PLEASE</em></p>
 <p><em>This is nightly build of Apache ECharts. Please DON't use it in your production environment.</em></p>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

To make the changes available in time, always install the latest nightly version of zrender when publishing nightly echarts.
