### PR TITLE
fix(lines): add missing `function` callback into `lineStyle.color` for lines series.

### DIFF
--- a/src/chart/lines/LinesSeries.ts
+++ b/src/chart/lines/LinesSeries.ts
@@ -93,8 +93,8 @@ export interface LinesStateOption<TCbParams = never> {
     label?: SeriesLineLabelOption
 }
 
-export interface LinesDataItemOption extends LinesStateOption<CallbackDataParams>,
-    StatesOptionMixin<LinesStateOption<CallbackDataParams>, LinesStatesMixin> {
+export interface LinesDataItemOption extends LinesStateOption,
+    StatesOptionMixin<LinesStateOption, LinesStatesMixin> {
     name?: string
 
     fromName?: string
@@ -111,7 +111,7 @@ export interface LinesDataItemOption extends LinesStateOption<CallbackDataParams
 }
 
 export interface LinesSeriesOption
-    extends SeriesOption<LinesStateOption, LinesStatesMixin>, LinesStateOption,
+    extends SeriesOption<LinesStateOption, LinesStatesMixin>, LinesStateOption<CallbackDataParams>,
     SeriesOnCartesianOptionMixin, SeriesOnGeoOptionMixin, SeriesOnPolarOptionMixin,
     SeriesOnCalendarOptionMixin, SeriesLargeOptionMixin {
 

--- a/src/chart/lines/LinesView.ts
+++ b/src/chart/lines/LinesView.ts
@@ -106,7 +106,7 @@ class LinesView extends ChartView {
 
         const lineDraw = this._updateLineDraw(data, seriesModel);
 
-        lineDraw.incrementalPrepareUpdate(data);
+        lineDraw.incrementalPrepareUpdate(data as any);
 
         this._clearLayer(api);
 
@@ -118,7 +118,7 @@ class LinesView extends ChartView {
         seriesModel: LinesSeriesModel,
         ecModel: GlobalModel
     ) {
-        this._lineDraw.incrementalUpdate(taskParams, seriesModel.getData());
+        this._lineDraw.incrementalUpdate(taskParams, seriesModel.getData() as any);
 
         this._finished = taskParams.end === seriesModel.getData().count();
     }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

- Add missing `function` callback into `lineStyle.color` for lines series.
- Remove unsupported `function` callback from `lineStyle.color` in states

### Fixed issues

- Resolves #17767

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
