### PR TITLE
fix(type): add overflow property to AxisLabelBaseOption interface. close #17363

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -22,6 +22,7 @@ import {
     AreaStyleOption, ComponentOption, ColorString,
     AnimationOptionMixin, Dictionary, ScaleDataValue, CommonAxisPointerOption
 } from '../util/types';
+import { TextStyleProps } from 'zrender/src/graphic/Text';
 
 
 export const AXIS_TYPES = {value: 1, category: 1, time: 1, log: 1} as const;
@@ -230,6 +231,7 @@ interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     hideOverlap?: boolean;
     // Color can be callback
     color?: ColorString | ((value?: string | number, index?: number) => ColorString)
+    overflow?: TextStyleProps['overflow']
 }
 interface AxisLabelOption<TType extends OptionAxisType> extends AxisLabelBaseOption {
     formatter?: LabelFormatters[TType]


### PR DESCRIPTION
Co-authored-by: Giulio Mazzanti <gmazzanti@protonmail.com>

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

~~This PR sets the correct interface that AxisLabelBaseOption extends, changing it from TextCommonOption to LabelOption.~~

This PR adds the overflow property to the AxisLabelBaseOption interface.


### Fixed issues

- #17363 : ...



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

The overflow property on xAxis.axisLabel works fine as you can see from this demo: [Chart demo](https://echarts.apache.org/examples/en/editor.html?c=line-simple&lang=ts&code=PYBwLglsB2AEC8sDeAoWtJgDYFMBcya6GOAHmAQOQDKYOIsAMhNDpUQL4A0RYwwWSCAKpiGAE4QA5lJziqAQ1IQAzu3TciuWdAAmIoul0KwCggG0adBrQXiwlLrCv1YAWQi7duR89quAUT1KAF1OHnQpSX1CMVwAMwpnAGYAUkdDWEkpAAskygAWdIjiACNgMD4AWyo0jLEAYxhTFkYFUpwsAjBxAFcccN5-LHLSAzF4nBNe8XxYsVgVBQA3HABBFQBJKoVZEQ5Mg40S0jXlFXHiMABPEDnKBpMcKWBxa_riY1MLSjcYX0oABV-jhQWDwRDIVDoQCAOo4XQAwE5XoAgBikgB1BMWN60FCJXQSlUbQ6XVECwA7p4wDkCMkAAyE4jAVbieJYYCUqg9PGPOgfMQsOjiZYKLqwBmHQboa5nVSXdA3O5UMVYfrqWCadAqOQQHAXWDmTIUsTQBRVe7-GymeyCq63e5YFhsZk66xUFS2hxu2BfMxGgCMACYmbBA8lg05AwzA9HkgUnABOMPBxlOYMxsJibXEU3Ec2WqjW9yebyuzJKx1UZ2se3u-hUKplny-_0WYOhjMADijsFDcf7CYzKacBXTsAKWcOzPz6ELVussCCiN9yqdLvriw9zhwwTbJgD5gKAFYw-O-wVY2OT4nYCfR_eJyfpzmiGEOABuIA)

The actual issue is with the type of `xAxis.axisLabel` (`AxisLabelBaseOption`) ~~that is extending `TextCommonOption` insted of `LabelOption` which is already extending `TextCommonOption`~~  which is missing the `overflow` property, resulting in a type error if We try to use that property in a typescript file.

~~If We look at the documentation We can see that the overflow property is available with all the others properties inside  `LabelOption` https://echarts.apache.org/zh/option.html#xAxis.axisLabel.overflow~~

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://user-images.githubusercontent.com/38522984/197174968-b78b7fe5-d551-46e9-a458-51058b3f27fb.png)


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

After setting the correct type We can use  the `overflow` property on  xAxis.axisLabel without getting a type error.

~~The issue was fixed by changing the interface that `AxisLabelBaseOption` was extending from `TextCommonOption` to `LabelOption`, as wrote before `LabelOption` is already extending `TextCommonOption`.
I have also removed from `AxisLabelBaseOption` the property that were already available in `LabelOption`.~~
The issue was fixed by adding the `overflow` property to `AxisLabelBaseOption`, copying the type of `overflow` from `TextStyleProps`.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
