### PR TITLE
fix(dataStack): zero is neither positive nor negative stack, close #1…

### DIFF
--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -131,8 +131,8 @@ function calculateStack(stackInfoList: StackInfo[]) {
                         stackStrategy === 'all' // single stack group
                         || (stackStrategy === 'positive' && val > 0)
                         || (stackStrategy === 'negative' && val < 0)
-                        || (stackStrategy === 'samesign' && sum >= 0 && val > 0) // All positive stack
-                        || (stackStrategy === 'samesign' && sum <= 0 && val < 0) // All negative stack
+                        || (stackStrategy === 'samesign' && sum > 0 && val > 0) // All positive stack
+                        || (stackStrategy === 'samesign' && sum < 0 && val < 0) // All negative stack
                     ) {
                         // The sum has to be very small to be affected by the
                         // floating arithmetic problem. An incorrect result will probably


### PR DESCRIPTION
…7801

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fix dataStack error when data is zero


### Fixed issues

<!--
- #xxxx: ...
-->

#17801 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![problem](https://user-images.githubusercontent.com/52627267/197103633-a281858f-4810-4c1d-a0c7-48faa9ebbeef.png)

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

zero is neither positive nor negative stack

![image](https://user-images.githubusercontent.com/32701177/197218539-051449a6-dac9-413b-8c8f-2316d03bbabe.png)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
