### PR TITLE
feat(dataView): add dataViewOpend and dataViewClosed event, close #17840

### DIFF
--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -324,6 +324,9 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
             api.dispatchAction({
                 type: 'hideTip'
             });
+            api.dispatchAction({
+                type: 'openDataView'
+            });
         });
 
         const container = api.getDom();
@@ -390,6 +393,9 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
         function close() {
             container.removeChild(root);
             self._dom = null;
+            api.dispatchAction({
+                type: 'closeDataView'
+            });
         }
         addEventListener(closeButton, 'click', close);
 
@@ -533,5 +539,15 @@ echarts.registerAction({
         series: newSeriesOptList
     }, payload.newOption));
 });
+
+echarts.registerAction(
+    { type: 'openDataView', event: 'dataViewOpend' },
+    function noop() { }
+);
+
+echarts.registerAction(
+    { type: 'closeDataView', event: 'dataViewClosed' },
+    function noop() { }
+);
 
 export default DataView;

--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -30,6 +30,8 @@ import { addEventListener } from 'zrender/src/core/event';
 import Axis from '../../../coord/Axis';
 import Cartesian2D from '../../../coord/cartesian/Cartesian2D';
 import { warn } from '../../../util/log';
+// eslint-disable-next-line no-duplicate-imports
+import { noop } from 'zrender/src/core/util';
 
 /* global document */
 
@@ -325,7 +327,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
                 type: 'hideTip'
             });
             api.dispatchAction({
-                type: 'openDataView'
+                type: 'showDataView'
             });
         });
 
@@ -394,7 +396,7 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
             container.removeChild(root);
             self._dom = null;
             api.dispatchAction({
-                type: 'closeDataView'
+                type: 'hideDataView'
             });
         }
         addEventListener(closeButton, 'click', close);
@@ -541,13 +543,13 @@ echarts.registerAction({
 });
 
 echarts.registerAction(
-    { type: 'openDataView', event: 'dataViewOpend' },
-    function noop() { }
+    { type: 'showDataView', event: 'dataViewShowed' },
+    noop
 );
 
 echarts.registerAction(
-    { type: 'closeDataView', event: 'dataViewClosed' },
-    function noop() { }
+    { type: 'hideDataView', event: 'dataViewHidden' },
+    noop
 );
 
 export default DataView;

--- a/test/dataview-event.html
+++ b/test/dataview-event.html
@@ -44,19 +44,19 @@
             ]
         };
 
+        chart.setOption(option);
+
         chart.on('dataViewChanged', function (params) {
             console.log('dataViewChanged', params)
         });
 
-        chart.on('dataViewOpend', function (params) {
-            console.log('dataViewOpend', params)
+        chart.on('dataViewShowed', function (params) {
+            console.log('dataViewShowed', params)
         });
 
-        chart.on('dataViewClosed', function (params) {
-            console.log('dataViewClosed', params)
+        chart.on('dataViewHidden', function (params) {
+            console.log('dataViewHidden', params)
         });
-
-        chart.setOption(option);
     </script>
 </body>
 

--- a/test/dataview-event.html
+++ b/test/dataview-event.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="lib/reset.css" />
+    <style>
+        #main {
+            width: 1200px;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="main"></div>
+
+    <!-- please run npm run build/watch -->
+    <script src="../dist/echarts.js"></script>
+    <script>
+        const chart = echarts.init(document.getElementById("main"));
+
+        var option = {
+            toolbox: {
+                feature: {
+                    dataView: {
+                        show: true
+                    }
+                }
+            },
+            xAxis: {
+                type: 'category',
+                data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+            },
+            yAxis: {
+                type: 'value'
+            },
+            series: [
+                {
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line'
+                }
+            ]
+        };
+
+        chart.on('dataViewChanged', function (params) {
+            console.log('dataViewChanged', params)
+        });
+
+        chart.on('dataViewOpend', function (params) {
+            console.log('dataViewOpend', params)
+        });
+
+        chart.on('dataViewClosed', function (params) {
+            console.log('dataViewClosed', params)
+        });
+
+        chart.setOption(option);
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

add toolbox enter and close event listener

### Fixed issues

<!--
- #xxxx: ...
-->

#17840

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Open and close dataview without event listening

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The API look like

```js
chart.on('dataViewOpend', function (params) {
  console.log('dataViewOpend', params)
});

chart.on('dataViewClosed', function (params) {
  console.log('dataViewClosed', params)
});
```

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information