### PR TITLE
fix(data): change deprecated `map.data.hasOwnProperty` to `map.hasKey`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.0"
+        "zrender": "npm:zrender-nightly@^5.4.1-dev.20221104"
       },
       "devDependencies": {
         "@babel/code-frame": "7.10.4",
@@ -13341,9 +13341,10 @@
       "optional": true
     },
     "node_modules/zrender": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.0.tgz",
-      "integrity": "sha512-rOS09Z2HSVGFs2dn/TuYk5BlCaZcVe8UDLLjj1ySYF828LATKKdxuakSZMvrDz54yiKPDYVfjdKqcX8Jky3BIA==",
+      "name": "zrender-nightly",
+      "version": "5.4.1-dev.20221104",
+      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.4.1-dev.20221104.tgz",
+      "integrity": "sha512-FigVUqINkG/qOxCGi9oYO3raMxEked55dnCAx3Gc47DKePVibOXhVeIqSCdPlu9wUJat6L9A5Jm/ImpoC8DH7A==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -24157,9 +24158,9 @@
       }
     },
     "zrender": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.0.tgz",
-      "integrity": "sha512-rOS09Z2HSVGFs2dn/TuYk5BlCaZcVe8UDLLjj1ySYF828LATKKdxuakSZMvrDz54yiKPDYVfjdKqcX8Jky3BIA==",
+      "version": "npm:zrender-nightly@5.4.1-dev.20221104",
+      "resolved": "https://registry.npmjs.org/zrender-nightly/-/zrender-nightly-5.4.1-dev.20221104.tgz",
+      "integrity": "sha512-FigVUqINkG/qOxCGi9oYO3raMxEked55dnCAx3Gc47DKePVibOXhVeIqSCdPlu9wUJat6L9A5Jm/ImpoC8DH7A==",
       "requires": {
         "tslib": "2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "tslib": "2.3.0",
-    "zrender": "5.4.0"
+    "zrender": "npm:zrender-nightly@^5.4.1-dev.20221104"
   },
   "devDependencies": {
     "@babel/code-frame": "7.10.4",

--- a/src/data/helper/createDimensions.ts
+++ b/src/data/helper/createDimensions.ts
@@ -114,7 +114,7 @@ export default function prepareSeriesDataSchema(
     const resultList: SeriesDimensionDefine[] = [];
     const dimCount = getDimCount(source, sysDims, dimsDef, opt.dimensionsCount);
 
-    // Try to ignore unsed dimensions if sharing a high dimension datastore
+    // Try to ignore unused dimensions if sharing a high dimension datastore
     // 30 is an experience value.
     const omitUnusedDimensions = opt.canOmitUnusedDimensions && shouldOmitUnusedDimensions(dimCount);
 
@@ -188,7 +188,7 @@ export default function prepareSeriesDataSchema(
         });
     });
 
-    // Apply templetes and default order from `sysDims`.
+    // Apply templates and default order from `sysDims`.
     let availDimIdx = 0;
     each(sysDims, function (sysDimItemRaw) {
         let coordDim: DimensionName;
@@ -368,7 +368,7 @@ function removeDuplication(result: SeriesDimensionDefine[]) {
 // But
 // (1) custom series should be considered. where other dims
 // may be visited.
-// (2) sometimes user need to calcualte bubble size or use visualMap
+// (2) sometimes user need to calculate bubble size or use visualMap
 // on other dimensions besides coordSys needed.
 // So, dims that is not used by system, should be shared in data store?
 function getDimCount(
@@ -399,10 +399,9 @@ function genCoordDimName(
     map: HashMap<unknown, DimensionName>,
     fromZero: boolean
 ) {
-    const mapData = map.data;
-    if (fromZero || mapData.hasOwnProperty(name)) {
+    if (fromZero || map.hasKey(name)) {
         let i = 0;
-        while (mapData.hasOwnProperty(name + i)) {
+        while (map.hasKey(name + i)) {
             i++;
         }
         name += i;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

ecomfe/zrender#966 has refactored the HashMap, which prefers the native built-in `Map`. It causes the `HashMap.data.hasOwnProperty` to be not working. So this PR is to change it to `map.hasKey`.

### Fixed issues

Fix failed unit test `test/ut/spec/data/createDimensions.test.ts`

Failed information: https://github.com/apache/echarts/actions/runs/3368150373/jobs/5586364387

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [x] This PR depends on ZRender changes (ecomfe/zrender#971).

### Related test cases or examples to use the new APIs

Please refer to `test/ut/spec/data/createDimensions.test.ts`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
