### PR TITLE
fix(tooltip): fix tooltip arrow may cover the content when border is wide

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -93,7 +93,7 @@ function assembleArrow(
 
     const borderStyle = `${borderColor} solid ${borderWidth}px;`;
     const styleCss = [
-        `position:absolute;width:${arrowSize}px;height:${arrowSize}px;`,
+        `position:absolute;width:${arrowSize}px;height:${arrowSize}px;z-index:-1;`,
         `${positionStyle};${transformStyle};`,
         `border-bottom:${borderStyle}`,
         `border-right:${borderStyle}`,

--- a/test/runTest/actions/__meta__.json
+++ b/test/runTest/actions/__meta__.json
@@ -188,6 +188,7 @@
   "tooltip-axisPointer2": 2,
   "tooltip-cascade": 4,
   "tooltip-component": 6,
+  "tooltip-domnode": 1,
   "tooltip-event": 1,
   "tooltip-link": 2,
   "tooltip-rich": 1,

--- a/test/runTest/actions/tooltip-domnode.json
+++ b/test/runTest/actions/tooltip-domnode.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"mousemove","time":593,"x":436,"y":371},{"type":"mousemove","time":792,"x":433,"y":361},{"type":"screenshot","time":1688}],"scrollY":1726,"scrollX":0,"timestamp":1667738018652}]

--- a/test/tooltip-domnode.html
+++ b/test/tooltip-domnode.html
@@ -36,6 +36,7 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
+        <div id="main4"></div>
         <script>
             require(['echarts'/*, 'map/js/china' */], function (echarts) {
                 var option;
@@ -152,6 +153,33 @@ under the License.
                 var chart = testHelper.create(echarts, 'main3', {
                     title: [
                         'Tooltip should show nothing',
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option;
+
+                option = {
+                    xAxis: {},
+                    yAxis: {},
+                    series: {
+                        type: 'line',
+                        data: [[11, 22], [33, 44], [55, 66]]
+                    },
+                    tooltip: {
+                        position: 'top',
+                        borderWidth: 40,
+                        formatter: '{a}<br>Data is {c}'
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main4', {
+                    title: [
+                        'Tooltip arrow shouldn\'t cover the content',
                     ],
                     option: option
                 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix a bug that the tooltip arrow may cover the content when its border is wide

### Fixed issues

N.A.


## Comparison

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26999792/200171602-22e152cf-4101-4b12-81c3-c98b8d3c5345.png) | ![image](https://user-images.githubusercontent.com/26999792/200171508-bffac19c-188f-4197-99e5-db97f7c288ff.png) |


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last case in `test/tooltip-domnode.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
