### PR TITLE
Feat funnel new style

### DIFF
--- a/src/chart/funnel/FunnelSeries.ts
+++ b/src/chart/funnel/FunnelSeries.ts
@@ -76,6 +76,8 @@ export interface FunnelDataItemOption
         width?: number | string
         height?: number | string
     }
+
+    rateItemStyle?: ItemStyleOption
 }
 
 export interface FunnelSeriesOption

--- a/src/chart/funnel/FunnelSeries.ts
+++ b/src/chart/funnel/FunnelSeries.ts
@@ -61,6 +61,7 @@ export interface FunnelCallbackDataParams extends CallbackDataParams {
 }
 export interface FunnelStateOption<TCbParams = never> {
     itemStyle?: ItemStyleOption<TCbParams>
+    rateItemStyle?: ItemStyleOption<TCbParams>
     label?: FunnelLabelOption
     labelLine?: LabelLineOption
     rateLabel?: FunnelRateLabelOption

--- a/src/chart/funnel/FunnelView.ts
+++ b/src/chart/funnel/FunnelView.ts
@@ -241,11 +241,14 @@ function RatePiece(
     polygon: graphic.Polygon = new graphic.Polygon()
 ): graphic.Polygon {
     const seriesModel = data.hostModel;
+    const itemModel = data.getItemModel<FunnelDataItemOption>(idx);
     const layout = data.getItemLayout(idx);
-    const opacity = 0.5;
     const style = data.getItemVisual(idx, 'style');
+    const rateItemStyle = itemModel.getModel('rateItemStyle').getItemStyle();
+    const combineStyle = zrUtil.extend({ ...style }, rateItemStyle);
+    const opacity = rateItemStyle.opacity || 0.5;
 
-    polygon.useStyle(style);
+    polygon.useStyle(combineStyle);
     polygon.style.lineJoin = 'round';
 
     if (!firstCreate) {
@@ -279,7 +282,6 @@ function RatePiece(
         }, seriesModel, idx);
     }
 
-    const itemModel = data.getItemModel<FunnelDataItemOption>(idx);
     const rateFetcher = {
         getFormattedLabel: rateLabelFetcher.getFormattedLabel.bind(
             { hostModel: data.hostModel, layout }
@@ -292,7 +294,7 @@ function RatePiece(
         {
             labelFetcher: rateFetcher,
             labelDataIndex: idx,
-            defaultOpacity: style.opacity,
+            defaultOpacity: rateItemStyle.opacity,
             defaultText: layout.rate
         },
         {

--- a/src/chart/funnel/funnelLayout.ts
+++ b/src/chart/funnel/funnelLayout.ts
@@ -246,14 +246,8 @@ function labelLayout(data: SeriesData) {
     });
 }
 
-function overAllRateLabelLayout(data: SeriesData, indices: number[]) {
-    data.each(function (idx) {
-        if (idx !== indices[indices.length - 1]) {
-            return;
-        }
-        const layout = data.getItemLayout(idx);
+function overAllRateLabelLayout(layout: any) {
         const points = layout.ratePoints;
-
         const isLabelInside = true;
 
         const textX = (points[0][0] + points[1][0] + points[2][0] + points[3][0]) / 4;
@@ -267,7 +261,6 @@ function overAllRateLabelLayout(data: SeriesData, indices: number[]) {
             textAlign: textAlign,
             inside: isLabelInside
         };
-    });
 }
 
 export default function funnelLayout(ecModel: GlobalModel, api: ExtensionAPI) {
@@ -533,7 +526,8 @@ export default function funnelLayout(ecModel: GlobalModel, api: ExtensionAPI) {
 
         labelLayout(data);
         if (showRate && !dynamicHeight) {
-            overAllRateLabelLayout(data, indices);
+            const overAllLayout = data.getItemLayout(indices[indices.length - 1]);
+            overAllRateLabelLayout(overAllLayout);
         }
     });
 }

--- a/test/funnel-showRate.html
+++ b/test/funnel-showRate.html
@@ -17,17 +17,17 @@ under the License.
 
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <script src="lib/simpleRequire.js"></script>
-    <script src="lib/config.js"></script>
-    <script src="lib/dat.gui.min.js"></script>
-    <script src="lib/testHelper.js"></script>
-    <link rel="stylesheet" href="lib/reset.css">
-</head>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/dat.gui.min.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css">
+    </head>
 
-<body>
-    <style>
+    <body>
+        <style>
         html,
         body,
         #main {
@@ -41,8 +41,8 @@ under the License.
             position: relative;
         }
     </style>
-    <div id="main"></div>
-    <script>
+        <div id="main"></div>
+        <script>
         const itemStyle = {
             normal: {
                 borderWidth: 0
@@ -94,7 +94,7 @@ under the License.
                         color: 'red'
                     },
                     data: [
-                        { value: 60, name: '访问' },
+                        { value: 60, name: '访问', rateItemStyle:{color:'cyan'} },
                         { value: 40, name: '咨询' },
                         { value: 20, name: '订单' },
                         { value: 80, name: '点击' },
@@ -104,14 +104,14 @@ under the License.
             ]
         }
     </script>
-    <script>
+        <script>
         require([
             'echarts'
         ], function (echarts) {
             const chart = testHelper.create(echarts, 'main', {
                 title: [
                     'show rate between each data',
-                    '1. invalid when dynamicHeight or dynamciArea is true',
+                    '1. invalid when dynamicHeight is true',
                     '2. different with other mapping mode ,default exitWidth is 100% in this mode',
                     '3. if you want make top piece a trapezoidal, set exitWidth a val between 0% and 99%',
                     `4. the label of rate piece sholud be set by rateLabel.formatter,it can be a formatt string like previous, 
@@ -154,6 +154,6 @@ under the License.
                 .onChange(update);
         })
     </script>
-</body>
+    </body>
 
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

- [x] Add a property to flatten the funnel exit based on the existing funnel style.
- [x] Add a dynamic height prop
 
### Fixed issues

<!--
- #xxxx: ...
-->
#14863
#16445
#17566

## Details

### Before: What was the problem?
The following is the current style of funnel diagram, and you can see that there is a lot of room to expand the function of funnel diagram such as flatten the top and so on.
![image](https://user-images.githubusercontent.com/103579791/188363325-8ce349a2-48e2-46bd-814a-d859769f700a.png)

### After: How does it behave after the fixing?
To preserve the original style, the new style needs to be set with new options.
1. If you want to flatten the top to represent none zero value, please set `exitWidth` as `100%`.
![image](https://user-images.githubusercontent.com/103579791/188363775-742112da-8d8b-4826-b7e2-4ced428c41fc.png)
2. If you want data dynamic mapping on the height， please set `dynamicHeight` as `true`.
![image](https://user-images.githubusercontent.com/103579791/188364524-0e7014df-126a-4e57-95f6-9e7dc3d95e15.png)## Document Info
3. If you want the previous funnel to be a little bit thicker, please set `minSize` as a percentage string between 0% and 100% such as `'33%'`.
![image](https://user-images.githubusercontent.com/103579791/188364986-3c85f794-b91d-4754-927d-bea05430a9ff.png)
4. If you want to show the conversion rate between each of the data in Figure 1, please set `showRate` as true.
![image](https://user-images.githubusercontent.com/103579791/188365250-2d8f6513-b80a-4a6c-8201-2c2585104f17.png)
5. If you want make the previous funnel last piece a trapezoidal, plese set `exitWidth`  as a percentage string between 0% and 100% such as `'33%'`.
![image](https://user-images.githubusercontent.com/103579791/188365603-26d85b87-d1e2-425b-801a-a05c54aff975.png)

### More: New attribute explanation
1. `exitWidth`, this property is to set the top width of the top funnel block, taking the bottom width of the piece as the base. Application scenarios: figure 1 and figure 5. Invalid when `dynamicArea` is valid;
2. `dynamicHeight`, this property will let each data take it's funnel piece height.
3. `thickDegree`, this property is control then thick degree of then dynamic height funnel, if you set this prop greater than 0% ,the funnel will thicker than default.
4. `showRate`, this property will show rate pieces between each data, invalid when dynamicHeight or dynamicArea is true.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#xxx

## related doc pr https://github.com/apache/echarts-doc/pull/281

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs
Please refer to test/funnel.html
N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
