### PR TITLE
fix(type): add `string` & `number` type into the `center` option of pie series

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -100,13 +100,15 @@ export interface PieDataItemOption extends
 export interface PieSeriesOption extends
     Omit<SeriesOption<PieStateOption<PieCallbackDataParams>, ExtraStateOption>, 'labelLine'>,
     PieStateOption<PieCallbackDataParams>,
-    CircleLayoutOptionMixin,
+    Omit<CircleLayoutOptionMixin, 'center'>,
     BoxLayoutOptionMixin,
     SeriesEncodeOptionMixin {
 
     type?: 'pie'
 
     roseType?: 'radius' | 'area'
+
+    center?: string | number | (string | number)[]
 
     clockwise?: boolean
     startAngle?: number


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

#17132 added support for setting the coordinate system of pie series but it didn't update the type of the `center` option.
This PR is to add the missing `number` & `string` type into the `center` option.

### Fixed issues

- #17132

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
