### PR TITLE
fix(pie): fix `center` may not be converted to correct point when coordinate system is specified

### DIFF
--- a/src/chart/pie/pieLayout.ts
+++ b/src/chart/pie/pieLayout.ts
@@ -41,14 +41,12 @@ export function getBasicPieLayout(seriesModel: PieSeriesModel, api: ExtensionAPI
     Pick<SectorShape, 'cx' | 'cy' | 'r' | 'r0'> {
     const viewRect = getViewRect(seriesModel, api);
 
+    // center can be string or number when coordinateSystem is specified
     let center = seriesModel.get('center');
     let radius = seriesModel.get('radius');
 
     if (!zrUtil.isArray(radius)) {
         radius = [0, radius];
-    }
-    if (!zrUtil.isArray(center)) {
-        center = [center, center];
     }
     const width = parsePercent(viewRect.width, api.getWidth());
     const height = parsePercent(viewRect.height, api.getHeight());
@@ -66,6 +64,9 @@ export function getBasicPieLayout(seriesModel: PieSeriesModel, api: ExtensionAPI
         cy = point[1] || 0;
     }
     else {
+        if (!zrUtil.isArray(center)) {
+            center = [center, center];
+        }
         cx = parsePercent(center[0], width) + viewRect.x;
         cy = parsePercent(center[1], height) + viewRect.y;
     }

--- a/test/pie-coordinate-system.html
+++ b/test/pie-coordinate-system.html
@@ -31,13 +31,329 @@ under the License.
         <style>
         </style>
 
-        <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
         <div id="main4"></div>
         <div id="main5"></div>
         <div id="main6"></div>
+        <div id="main7"></div>
+        <div id="main8"></div>
+        <div id="main9"></div>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var pieRadius = 20;
+                var option = {
+                    calendar: {
+                        top: 'middle',
+                        left: 'center',
+                        cellSize: pieRadius * 3,
+                        orient: 'vertical',
+                        range: ['2022-05']
+                    },
+                    tooltip: {},
+                    series: [
+                        {
+                            type: 'pie',
+                            name: 'Calendar',
+                            coordinateSystem: 'calendar',
+                            radius: pieRadius,
+                            // center is date when displayed on calendar
+                            center: '2022-05-16',
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ],
+                            label: {
+                                show: false
+                            }
+                        },
+                        {
+                            type: 'pie',
+                            name: 'Calendar',
+                            coordinateSystem: 'calendar',
+                            radius: pieRadius,
+                            center: '2022-05-05',
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ],
+                            label: {
+                                show: false
+                            }
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'main1', {
+                    title: ['Pie series on Calendar'],
+                    option: option
+                })
+
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+                'map/js/china'
+            ], function (echarts) {
+                var option = {
+                    geo: {
+                        map: 'china',
+                        roam: true
+                    },
+                    tooltip: {},
+                    series: [
+                        {
+                            type: 'pie',
+                            name: 'Geo',
+                            coordinateSystem: 'geo',
+                            radius: 20,
+                            center: [120, 30],
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ]
+                        },
+                        {
+                            type: 'pie',
+                            name: 'Geo',
+                            coordinateSystem: 'geo',
+                            radius: 20,
+                            center: '北京',
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'main2', {
+                    title: ['Pie series on Geo Map'],
+                    option: option
+                })
+
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+                'data/svg/Map_of_Iceland.svg'
+            ], function (echarts, svg) {
+                echarts.registerMap('Map_of_Iceland', {
+                    svg: svg
+                });
+                var option = {
+                    geo: {
+                        map: 'Map_of_Iceland',
+                        roam: true,
+                    },
+                    tooltip: {},
+                    series: [
+                        {
+                            type: 'pie',
+                            name: 'Geo SVG',
+                            coordinateSystem: 'geo',
+                            radius: 20,
+                            center: [1062, 955],
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'main3', {
+                    title: ['Pie series on Geo SVG'],
+                    option: option
+                })
+
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    tooltip: {},
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'category',
+                        data: ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+                    },
+                    series: [
+                        {
+                            type: 'pie',
+                            name: 'Cartesian2D(Category Axes)',
+                            coordinateSystem: 'cartesian2d',
+                            radius: 20,
+                            center: ['Tue', 'E'],
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'main4', {
+                    title: ['Pie series on Cartesian2D', 'Category Axes'],
+                    option: option
+                })
+
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    tooltip: {},
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                            type: 'pie',
+                            name: 'Cartesian2D(category axis & value axis)',
+                            coordinateSystem: 'cartesian2d',
+                            radius: 20,
+                            center: ['Tue', 230],
+                            data: [
+                                { value: 1048, name: 'A' },
+                                { value: 735, name: 'B' },
+                                { value: 580, name: 'C' },
+                                { value: 484, name: 'D' },
+                                { value: 300, name: 'E' }
+                            ]
+                        },
+                        {
+                            // currently it needs data to calculate axis extend
+                            data: [150, 230, 224, 218, 135, 147, 260],
+                            type: 'line',
+                            showSymbol: false,
+                            lineStyle: {
+                                width: 0
+                            }
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'main5', {
+                    title: ['Pie series on Cartesian2D', 'category axis & value axis (not perfectly supported)'],
+                    option: option
+                })
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+                'data/usa.json'
+            ], function (echarts, usaJSON) {
+                echarts.registerMap('USA', usaJSON, {
+                    Alaska: {
+                        left: -131,
+                        top: 25,
+                        width: 15
+                    },
+                    Hawaii: {
+                        left: -110,
+                        top: 28,
+                        width: 5
+                    },
+                    'Puerto Rico': {
+                        left: -76,
+                        top: 26,
+                        width: 2
+                    }
+                });
+
+                function randomPieSeries(center, radius) {
+                    const data = ['A', 'B', 'C', 'D'].map((t) => {
+                        return {
+                            value: Math.round(Math.random() * 100),
+                            name: 'Category ' + t
+                        };
+                    });
+                    return {
+                        type: 'pie',
+                        coordinateSystem: 'geo',
+                        tooltip: {
+                            formatter: '{b}: {c} ({d}%)'
+                        },
+                        label: {
+                            show: false
+                        },
+                        labelLine: {
+                            show: false
+                        },
+                        animationDuration: 0,
+                        radius,
+                        center,
+                        data
+                    };
+                }
+
+                var option = {
+                    geo: {
+                        map: 'USA',
+                        roam: true,
+                        itemStyle: {
+                            areaColor: '#e7e8ea'
+                        }
+                    },
+                    tooltip: {},
+                    legend: {},
+                    series: [
+                        randomPieSeries([-86.753504, 33.01077], 15),
+                        randomPieSeries([-116.853504, 39.8], 25),
+                        randomPieSeries([-99, 31.5], 30),
+                        // This name string should work
+                        randomPieSeries('Alaska', 20)
+                    ]
+                };
+
+                testHelper.create(echarts, 'main7', {
+                    title: ['Pie series on Geo Map', 'A pie series should be displayed at `**Alaska**`'],
+                    option: option
+                });
+            });
+        </script>
 
         <script src="https://api.map.baidu.com/api?v=2.0&ak=KOmVjPVUAey1G2E8zNhPiuQ6QiEmAwZu"></script>
         <script>
@@ -85,7 +401,7 @@ under the License.
                     ]
                 };
 
-                var chart = testHelper.create(echarts, 'main0', {
+                var chart = testHelper.create(echarts, 'main8', {
                     title: ['Pie series on BMap'],
                     option: option,
                     buttons: [{
@@ -144,238 +460,12 @@ under the License.
                     ]
                 };
 
-                testHelper.create(echarts, 'main1', {
+                testHelper.create(echarts, 'main9', {
                     title: ['Pie series on AMap'],
                     option: option
-                })
-
-            });
-        </script>
-
-        <script>
-            require([
-                'echarts'
-            ], function (echarts) {
-                var pieRadius = 20;
-                var option = {
-                    calendar: {
-                        top: 'middle',
-                        left: 'center',
-                        cellSize: pieRadius * 3,
-                        orient: 'vertical',
-                        range: ['2022-05']
-                    },
-                    tooltip: {},
-                    series: [
-                        {
-                            type: 'pie',
-                            name: 'Calendar',
-                            coordinateSystem: 'calendar',
-                            radius: pieRadius,
-                            // center is date when displayed on calendar
-                            center: '2022-05-16',
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ],
-                            label: {
-                                show: false
-                            }
-                        },
-                        {
-                            type: 'pie',
-                            name: 'Calendar',
-                            coordinateSystem: 'calendar',
-                            radius: pieRadius,
-                            center: '2022-05-05',
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ],
-                            label: {
-                                show: false
-                            }
-                        }
-                    ]
-                };
-
-                testHelper.create(echarts, 'main2', {
-                    title: ['Pie series on Calendar'],
-                    option: option
-                })
-
-            });
-        </script>
-
-        <script>
-            require([
-                'echarts',
-                'map/js/china'
-            ], function (echarts) {
-                var option = {
-                    geo: {
-                        map: 'china',
-                        roam: true
-                    },
-                    tooltip: {},
-                    series: [
-                        {
-                            type: 'pie',
-                            name: 'Geo',
-                            coordinateSystem: 'geo',
-                            radius: 20,
-                            center: [120, 30],
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ]
-                        }
-                    ]
-                };
-
-                testHelper.create(echarts, 'main3', {
-                    title: ['Pie series on Geo Map'],
-                    option: option
-                })
-
-            });
-        </script>
-
-        <script>
-            require([
-                'echarts',
-                'data/svg/Map_of_Iceland.svg'
-            ], function (echarts, svg) {
-                echarts.registerMap('Map_of_Iceland', {
-                    svg: svg
                 });
-                var option = {
-                    geo: {
-                        map: 'Map_of_Iceland',
-                        roam: true,
-                    },
-                    tooltip: {},
-                    series: [
-                        {
-                            type: 'pie',
-                            name: 'Geo SVG',
-                            coordinateSystem: 'geo',
-                            radius: 20,
-                            center: [1062, 955],
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ]
-                        }
-                    ]
-                };
-
-                testHelper.create(echarts, 'main4', {
-                    title: ['Pie series on Geo SVG'],
-                    option: option
-                })
 
             });
         </script>
-
-        <script>
-            require([
-                'echarts'
-            ], function (echarts) {
-                var option = {
-                    tooltip: {},
-                    xAxis: {
-                        type: 'category',
-                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-                    },
-                    yAxis: {
-                        type: 'category',
-                        data: ['A', 'B', 'C', 'D', 'E', 'F', 'G']
-                    },
-                    series: [
-                        {
-                            type: 'pie',
-                            name: 'Cartesian2D(Category Axes)',
-                            coordinateSystem: 'cartesian2d',
-                            radius: 20,
-                            center: ['Tue', 'E'],
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ]
-                        }
-                    ]
-                };
-
-                testHelper.create(echarts, 'main5', {
-                    title: ['Pie series on Cartesian2D', 'Category Axes'],
-                    option: option
-                })
-
-            });
-        </script>
-
-        <script>
-            require([
-                'echarts'
-            ], function (echarts) {
-                var option = {
-                    tooltip: {},
-                    xAxis: {
-                        type: 'category',
-                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-                    },
-                    yAxis: {
-                        type: 'value'
-                    },
-                    series: [
-                        {
-                            type: 'pie',
-                            name: 'Cartesian2D(category axis & value axis)',
-                            coordinateSystem: 'cartesian2d',
-                            radius: 20,
-                            center: ['Tue', 230],
-                            data: [
-                                { value: 1048, name: 'A' },
-                                { value: 735, name: 'B' },
-                                { value: 580, name: 'C' },
-                                { value: 484, name: 'D' },
-                                { value: 300, name: 'E' }
-                            ]
-                        },
-                        {
-                            // currently it needs data to calculate axis extend
-                            data: [150, 230, 224, 218, 135, 147, 260],
-                            type: 'line',
-                            showSymbol: false,
-                            lineStyle: {
-                                width: 0
-                            }
-                        }
-                    ]
-                };
-
-                testHelper.create(echarts, 'main6', {
-                    title: ['Pie series on Cartesian2D', 'category axis & value axis (not perfectly supported)'],
-                    option: option
-                })
-            });
-        </script>
-
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix a bug that exists in #17132 (v5.4.0)

Due to being normalized to an array, the `center` may not be converted to the correct point when the coordinate system is specified. For example, just like the LngLat array, `center: 'Beijing'` should also be converted to the correct pixel when using the `geo` coordinate system.

### Fixed issues

- #17132

## Details

### Before: What was the problem?

<img src="https://user-images.githubusercontent.com/26999792/201906230-e7ee9232-1bde-43d3-bf87-8b0339ef5931.png" width="600">

### After: How does it behave after the fixing?

<img src="https://user-images.githubusercontent.com/26999792/201906034-585483a4-80a6-403c-bdef-c77fbadcc029.png" width="600">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the 2nd and 7th `test/pie-coordinate-system.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
