### PR TITLE
fix(dataZoom): fallback to extent start/end when parsed value or percent is invalid.

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -189,8 +189,13 @@ class AxisProxy {
 
             // valueWindow[idx] = round(boundValue);
             // percentWindow[idx] = round(boundPercent);
-            valueWindow[idx] = boundValue;
-            percentWindow[idx] = boundPercent;
+            // fallback to extent start/end when parsed value or percent is invalid
+            valueWindow[idx] = boundValue == null || isNaN(boundValue)
+                ? dataExtent[idx]
+                : boundValue;
+            percentWindow[idx] = boundPercent == null || isNaN(boundPercent)
+                ? percentExtent[idx]
+                : boundPercent;
         });
 
         asc(valueWindow);

--- a/test/axis-lastLabel.html
+++ b/test/axis-lastLabel.html
@@ -130,10 +130,6 @@ under the License.
                 'echarts'
             ], function (rainfallData, echarts) {
 
-                var chart = echarts.init(document.getElementById('chart0'), null, {
-
-                });
-
                 var option = {
                     tooltip : {
                         trigger: 'axis'
@@ -203,10 +199,6 @@ under the License.
                 'data/rainfall.json.js',
                 'echarts'
             ], function (rainfallData, echarts) {
-
-                var chart = echarts.init(document.getElementById('chart1'), null, {
-
-                });
 
                 var option = {
                     tooltip : {
@@ -289,10 +281,6 @@ under the License.
                 'echarts'
             ], function (rainfallData, echarts) {
 
-                var chart = echarts.init(document.getElementById('chart1'), null, {
-
-                });
-
                 var option = {
                     tooltip: {
                         trigger: 'axis'
@@ -300,8 +288,15 @@ under the License.
                     dataZoom: {
                         show: true,
                         realtime: true,
-                        startValue: '2009-09-20 12:00',
-                        end: 100
+                        // The `startValue` does not exist in the categories as it's splitted by '-' rather than '/'
+                        // It will fallback to the first category
+                        // The same to `endValue` / `end` / `start`
+                        startValue: '2009-07-20 12:00',
+                        // the `endValue` should work
+                        endValue: '2009/8/20 12:00',
+                        // start: 50,
+                        // end: 60,
+                        // end: 'aaaa'
                     },
                     xAxis: {
                         axisTick: {
@@ -371,10 +366,6 @@ under the License.
                 'data/rainfall.json.js',
                 'echarts'
             ], function (rainfallData, echarts) {
-
-                var chart = echarts.init(document.getElementById('chart1'), null, {
-
-                });
 
                 var option = {
                     tooltip : {


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the `dataZoom` can't render when `start/end/startValue/endValue` doesn't exist in the axis categories or is invalid value. 

### Fixed issues

N.A.

## Details

### Before: What was the problem?

<img src="https://user-images.githubusercontent.com/26999792/202427811-7b79c138-af54-4ed7-86fc-139e830851c2.png" width="400">

### After: How does it behave after the fixing?

Fallback to extent start/end when parsed value or percent is invalid.

<img src="https://user-images.githubusercontent.com/26999792/202427898-80809cbb-526f-4ca2-95fd-e36fbecd157a.png" width="400">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the 4th case in `test/axis-lastLabel.html` 

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
