### PR TITLE
fix(stack): revert pr #17809

### DIFF
--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -131,8 +131,8 @@ function calculateStack(stackInfoList: StackInfo[]) {
                         stackStrategy === 'all' // single stack group
                         || (stackStrategy === 'positive' && val > 0)
                         || (stackStrategy === 'negative' && val < 0)
-                        || (stackStrategy === 'samesign' && sum > 0 && val > 0) // All positive stack
-                        || (stackStrategy === 'samesign' && sum < 0 && val < 0) // All negative stack
+                        || (stackStrategy === 'samesign' && sum >= 0 && val > 0) // All positive stack
+                        || (stackStrategy === 'samesign' && sum <= 0 && val < 0) // All negative stack
                     ) {
                         // The sum has to be very small to be affected by the
                         // floating arithmetic problem. An incorrect result will probably


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Revert pr #17809 because #17801 is not a bug but not used correctly.

v5.3.3 introduced a new option [stackStrategy](https://echarts.apache.org/zh/option.html#series-bar.stackStrategy), and if a series should always stack from 0 rather than other series, it should be set to `'negative'` or `'positive'`. If not set, the default value is `'samesign'` and the data should be stacked on other series no matter the other part of the series is positive or negative.

### Fixed issues

PR #17809 makes the test case `axis-filter-extent2.html` fail and was found before new version release.

## Details

### Before: What was the problem?

`axis-filter-extent2.html` fails.

### After: How does it behave after the fixing?

`axis-filter-extent2.html` doesn't fail and developers should set `stackStrategy: 'negative'` in cases like #17801 or #17942. A working demo is [here](https://echarts.apache.org/examples/zh/editor.html?c=bar-y-category&code=PYBwLglsB2AEC8sDeAoWszGAG0iAXMmuhgE4QDmFApqYQOQCGAHhAM70A0x6L7ACsAjQwtQqhIkwATxDUGbABaMAJsADu9HrAC-xHd3TZqNaCvHaVjMI0IBtev1LAAZhDBdY9AKLM50NmoOTi8ASWgAY2AAW2p6AF19Q1gKcnMiSWMXMAYAZgBSLm1yCkUcrwAWQuT0ACNgMExovOrtKJFGYQAZRlrqbEIwUgBXaiTiZgBBVjZ7bQlJDFl5LwA3RmxRrUk9dHjk6Wn2OckFyRk5BgjrE2BSaSLF2D42ABUICIBrCyf0JQ1CC4NoFtOgDKDYFYbPZ6ABZGCeeivLYhegAdWoKkRr0UwwS2l2sH2xEC5CCJ1g8wh0EYsQY4SisUeiwuK3otUYpGZkjYNi-DFeDQ23JI2F6_R-v3-6kGIzGT3BT2o0RAyjYxwyvxcwAiw1mXlJECC20WisWUNssDsAEYQrbYLkAKx2xI7GqayQ0uleXz-QLBCGshgcrnuv5875eQU2bAi8OML4AZSGNwo0gY0BM1ggqziYdgYr6Aw9i2lstG-fQIGA6sgMAYWQ8ELNkmVqsY6v1Z0W2t1-vohuNzfzFvsAFp7WOAEwABhCc9gE9dJEJiR0AG4gA).

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
