### PR TITLE
feat(custom-series): add `seriesData` and `seriesDataItem` to `renderItem` callback

### DIFF
--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -30,6 +30,7 @@ import {
     DimensionLoose,
     ItemStyleOption,
     LabelOption,
+    OptionDataItem,
     OptionDataValue,
     OrdinalRawValue,
     ParsedValue,
@@ -308,6 +309,9 @@ export interface CustomSeriesRenderItemParams {
 
     dataIndexInside: number;
     dataInsideLength: number;
+
+    seriesData: SeriesData<CustomSeriesModel>;
+    seriesDataItem: OptionDataItem;
 
     actionType?: string;
 }

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -635,7 +635,8 @@ function makeRenderItem(
         seriesIndex: customSeries.seriesIndex,
         coordSys: prepareResult.coordSys,
         dataInsideLength: data.count(),
-        encode: wrapEncodeDef(customSeries.getData())
+        encode: wrapEncodeDef(customSeries.getData()),
+        seriesData: data
     } as CustomSeriesRenderItemParams;
 
     // If someday intending to refactor them to a class, should consider do not
@@ -692,6 +693,7 @@ function makeRenderItem(
 
         return renderItem && renderItem(
             defaults({
+                seriesDataItem: data.getRawDataItem(dataIndexInside),
                 dataIndexInside: dataIndexInside,
                 dataIndex: data.getRawIndex(dataIndexInside),
                 // Can be used for optimization when zoom or roam.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR adds `seriesData` and `seriesDataItem` to the `renderItem` callback to allow users to retrieve extra information such as `name` from the data source.


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
Impossible to retrieve data beyond what is in the `value` field of each data item.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Without breaking the current implementation, this simply allows the user to retrieve the current item raw data from within the renderItem callback.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
