### PR TITLE
fix(core): use `!=` to check if series is excluded as native map returns `undefined` rather than `null`

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -137,8 +137,6 @@ declare let global: any;
 
 type ModelFinder = modelUtil.ModelFinder;
 
-const hasWindow = typeof window !== 'undefined';
-
 export const version = '5.4.0';
 
 export const dependencies = {
@@ -417,7 +415,7 @@ class ECharts extends Eventful<ECEventDefinition> {
         if (__DEV__) {
             const root = (
                 /* eslint-disable-next-line */
-                hasWindow ? window : global
+                env.hasGlobalWindow ? window : global
             ) as any;
 
             defaultRenderer = root.__ECHARTS__DEFAULT__RENDERER__ || defaultRenderer;
@@ -705,7 +703,7 @@ class ECharts extends Eventful<ECEventDefinition> {
     getDevicePixelRatio(): number {
         return (this._zr.painter as CanvasPainter).dpr
             /* eslint-disable-next-line */
-            || (hasWindow && window.devicePixelRatio) || 1;
+            || (env.hasGlobalWindow && window.devicePixelRatio) || 1;
     }
 
     /**

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1580,7 +1580,7 @@ class ECharts extends Eventful<ECEventDefinition> {
 
             // If dispatchAction before setOption, do nothing.
             ecModel && ecModel.eachComponent(condition, function (model) {
-                const isExcluded = excludeSeriesIdMap && excludeSeriesIdMap.get(model.id) !== null;
+                const isExcluded = excludeSeriesIdMap && excludeSeriesIdMap.get(model.id) != null;
                 if (isExcluded) {
                     return;
                 };
@@ -1624,7 +1624,7 @@ class ECharts extends Eventful<ECEventDefinition> {
             }, ecIns);
 
             ecModel && ecModel.eachComponent(condition, function (model) {
-                const isExcluded = excludeSeriesIdMap && excludeSeriesIdMap.get(model.id) !== null;
+                const isExcluded = excludeSeriesIdMap && excludeSeriesIdMap.get(model.id) != null;
                 if (isExcluded) {
                     return;
                 };

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -112,7 +112,7 @@ import {
 import Displayable from 'zrender/src/graphic/Displayable';
 import { seriesSymbolTask, dataSymbolTask } from '../visual/symbol';
 import { getVisualFromData, getItemVisualFromData } from '../visual/helper';
-import { deprecateLog, deprecateReplaceLog, error } from '../util/log';
+import { deprecateLog, deprecateReplaceLog, error, warn } from '../util/log';
 import { handleLegacySelectEvents } from '../legacy/dataSelectAction';
 
 import { registerExternalTransform } from '../data/helper/transform';
@@ -974,7 +974,7 @@ class ECharts extends Eventful<ECEventDefinition> {
                     }
                     else {
                         if (__DEV__) {
-                            console.warn(key + ': ' + (view
+                            warn(key + ': ' + (view
                                 ? 'The found component do not support containPoint.'
                                 : 'No view mapping to the found component.'
                             ));
@@ -983,7 +983,7 @@ class ECharts extends Eventful<ECEventDefinition> {
                 }
                 else {
                     if (__DEV__) {
-                        console.warn(key + ': containPoint is not supported');
+                        warn(key + ': containPoint is not supported');
                     }
                 }
             }, this);
@@ -1018,7 +1018,7 @@ class ECharts extends Eventful<ECEventDefinition> {
 
         if (__DEV__) {
             if (!seriesModel) {
-                console.warn('There is no specified seires model');
+                warn('There is no specified series model');
             }
         }
 
@@ -1113,7 +1113,7 @@ class ECharts extends Eventful<ECEventDefinition> {
                         // be missed, otherwise there is no way to distinguish source component.
                         // See `dataFormat.getDataParams`.
                         if (!isGlobalOut && !(model && view)) {
-                            console.warn('model or view can not be found by params');
+                            warn('model or view can not be found by params');
                         }
                     }
 
@@ -1304,7 +1304,7 @@ class ECharts extends Eventful<ECEventDefinition> {
         this.hideLoading();
         if (!loadingEffects[name]) {
             if (__DEV__) {
-                console.warn('Loading effects ' + name + ' not exists.');
+                warn('Loading effects ' + name + ' not exists.');
             }
             return;
         }
@@ -1863,7 +1863,7 @@ class ECharts extends Eventful<ECEventDefinition> {
             }
 
             if (__DEV__) {
-                console.warn(
+                warn(
                     'No coordinate system that supports ' + methodName + ' found by the given finder.'
                 );
             }
@@ -2594,7 +2594,7 @@ const MOUSE_EVENT_NAMES: ZRElementEventName[] = [
 
 function disposedWarning(id: string): void {
     if (__DEV__) {
-        console.warn('Instance ' + id + ' has been disposed');
+        warn('Instance ' + id + ' has been disposed');
     }
 }
 
@@ -2655,7 +2655,7 @@ export function init(
         const existInstance = getInstanceByDom(dom);
         if (existInstance) {
             if (__DEV__) {
-                console.warn('There is a chart instance already initialized on the dom.');
+                warn('There is a chart instance already initialized on the dom.');
             }
             return existInstance;
         }
@@ -2668,7 +2668,7 @@ export function init(
                     || (!dom.clientHeight && (!opts || opts.height == null))
                 )
             ) {
-                console.warn('Can\'t get DOM width or height. Please check '
+                warn('Can\'t get DOM width or height. Please check '
                 + 'dom.clientWidth and dom.clientHeight. They should not be 0.'
                 + 'For example, you may need to call this in the callback '
                 + 'of window.onload.');


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

- fix: use `!=` to check if series is excluded as native map returns `undefined` rather than `null`
- chore: use hasGlobalWindow constant from env util
- chore: use warn util instead of `console.warn`

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/area-stack.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
