### PR TITLE
fix(Axis): axisTick.interval work correct

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -297,12 +297,13 @@ function fixOnBandTicksCoords(
         return;
     }
 
+    const intervalIsAutoMode = axis.getTickModel().get('interval') === 'auto';
+
     const axisExtent = axis.getExtent();
     let last;
     let diffSize;
     if (ticksLen === 1) {
-        ticksCoords[0].coord = axisExtent[0];
-        last = ticksCoords[1] = {coord: axisExtent[0]};
+        ticksCoords[0].coord -= axis.getBandWidth() / 2;
     }
     else {
         const crossLen = ticksCoords[ticksLen - 1].tickValue - ticksCoords[0].tickValue;
@@ -312,13 +313,21 @@ function fixOnBandTicksCoords(
             ticksItem.coord -= shift / 2;
         });
 
-        const dataExtent = axis.scale.getExtent();
-        diffSize = 1 + dataExtent[1] - ticksCoords[ticksLen - 1].tickValue;
+        // auto mode: need push a normal tick
+        // function mode: last tick depend on function return value
+        // number mode: last tick depend on number
+        if (intervalIsAutoMode) {
+            const dataExtent = axis.scale.getExtent();
+            diffSize = 1 + dataExtent[1] - ticksCoords[ticksLen - 1].tickValue;
 
-        last = {coord: ticksCoords[ticksLen - 1].coord + shift * diffSize};
+            last = {coord: ticksCoords[ticksLen - 1].coord + shift * diffSize};
 
-        ticksCoords.push(last);
+            ticksCoords.push(last);
+        }
     }
+
+    // TODO: use array.at(-1) when lib target es2022
+    last = ticksCoords[ticksCoords.length - 1];
 
     const inverse = axisExtent[0] > axisExtent[1];
 

--- a/src/coord/axisTickLabelBuilder.ts
+++ b/src/coord/axisTickLabelBuilder.ts
@@ -344,6 +344,12 @@ function makeLabelsByNumericCategoryInterval(axis: Axis, categoryInterval: numbe
     const labelModel = axis.getLabelModel();
     const result: (MakeLabelsResultObj | number)[] = [];
 
+    // onBand mode, need one more tick
+    // |---1---|---2---|---3---|---4---| need 5 tick
+    if (axis.onBand && ordinalExtent[1]) {
+        ordinalExtent[1]++;
+    }
+
     // TODO: axisType: ordinalTime, pick the tick from each month/day/year/...
 
     const step = Math.max((categoryInterval || 0) + 1, 1);
@@ -411,7 +417,17 @@ function makeLabelsByCustomizedCategoryInterval(axis: Axis, categoryInterval: Ca
     const labelFormatter = makeLabelFormatter(axis);
     const result: (MakeLabelsResultObj | number)[] = [];
 
-    zrUtil.each(ordinalScale.getTicks(), function (tick) {
+    const originTicks = ordinalScale.getTicks();
+    // onBand mode, need one more tick
+    if (axis.onBand && originTicks.length) {
+        // TODO: use array.at(-1) when lib target es2022
+        const lastTicks = originTicks[originTicks.length - 1];
+        originTicks.push({
+            ...lastTicks,
+            value: lastTicks.value + 1
+        });
+    }
+    zrUtil.each(originTicks, function (tick) {
         const rawLabel = ordinalScale.getLabel(tick);
         const tickValue = tick.value;
         if (categoryInterval(tick.value, rawLabel)) {

--- a/test/axis-axisTick-interval.html
+++ b/test/axis-axisTick-interval.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+        <div id="main1"></div>
+
+
+        <div id="main2"></div>
+
+
+        <div id="main3"></div>
+
+
+        <div id="main4"></div>
+
+
+        <div id="main5"></div>
+
+
+        <div id="main6"></div>
+
+
+        <div id="main7"></div>
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: (index, value) => {
+                            return value === 'Thu'
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'axis.axisTick.interval using function with only one tick',
+                    'notice: boundaryGap: true mode,  have [data.length + 1] tick',
+                    ' interval with call [data.length + 1] times. last tick also effect by interval'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: 2,
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'axis.axisTick.interval using number',
+                    'notice: last tick also effect by interval'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: (index, value) => {
+                            return index > 2
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: [
+                    'axis.axisTick.interval using function with 5 tick'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    boundaryGap: false,
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: (index, value) => {
+                            return value === 'Thu'
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main3', {
+                title: [
+                    'boundaryGap: false, mode',
+                    'axis.axisTick.interval using function with only one tick'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    boundaryGap: false,
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: (index, value) => {
+                            return 2
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main4', {
+                title: [
+                    'boundaryGap: false, mode',
+                    'axis.axisTick.interval using number'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    boundaryGap: false,
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: (index, value) => {
+                            return index > 2
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main5', {
+                title: [
+                    'boundaryGap: false, mode',
+                    'axis.axisTick.interval using function with 4 tick. have [data.length] tick'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    boundaryGap: false,
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    axisTick: {
+                        interval: 'auto',
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main6', {
+                title: [
+                    'boundaryGap: false, mode',
+                    'axis.axisTick.interval using auto'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+            var data = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data,
+                    axisTick: {
+                        interval: (index, value) => {
+                            return index === data.length
+                        },
+                        inside: true,
+                        length: 500
+                    }
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    type: 'bar'
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main7', {
+                title: [
+                    'only effect last tick',
+                    'boundaryGap: true mode, will have [data.length + 1] tick',
+                    'axis.axisTick.interval will call [data.length + 1] times'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
axisTick.interval work correct. 
onBand mode, we has one more tick. and this tick should aeffected by interval.


### Fixed issues
#17967 
<!--
- 
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

tick always at axisExtent[0] when interval funciton return array of length one . 

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
