### PR TITLE
feat(line): line segment styling

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -39,9 +39,9 @@ import {
 import SeriesData from '../../data/SeriesData';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import type Polar from '../../coord/polar/Polar';
-import {createSymbol, ECSymbol} from '../../util/symbol';
-import {Group} from '../../util/graphic';
-import {LegendIconParams} from '../../component/legend/LegendModel';
+import { createSymbol, ECSymbol } from '../../util/symbol';
+import { Group } from '../../util/graphic';
+import { LegendIconParams } from '../../component/legend/LegendModel';
 
 type LineDataValue = OptionDataValue | OptionDataValue[];
 
@@ -51,6 +51,13 @@ interface LineStateOptionMixin {
         scale?: boolean | number
     }
 }
+
+interface LineSegmentCallBackParams {
+    dataIndex: number,
+    dataVal: number
+}
+
+type LineSegmentOption = [number, number] | ((params: LineSegmentCallBackParams) => boolean);
 
 export interface LineStateOption<TCbParams = never> {
     itemStyle?: ItemStyleOption<TCbParams>
@@ -120,6 +127,17 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption<CallbackD
     data?: (LineDataValue | LineDataItemOption)[]
 
     triggerLineEvent?: boolean
+
+    linePieces?: {
+        segment: LineSegmentOption,
+        lineStyle: LineStyleOption,
+        areaStyle: AreaStyleOption
+    }[]
+
+    connectNullStyle?: {
+        lineStyle: LineStyleOption,
+        areaStyle: AreaStyleOption
+    }
 }
 
 class LineSeriesModel extends SeriesModel<LineSeriesOption> {
@@ -174,11 +192,11 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
             scale: true
         },
         // areaStyle: {
-            // origin of areaStyle. Valid values:
-            // `'auto'/null/undefined`: from axisLine to data
-            // `'start'`: from min to data
-            // `'end'`: from data to max
-            // origin: 'auto'
+        // origin of areaStyle. Valid values:
+        // `'auto'/null/undefined`: from axisLine to data
+        // `'start'`: from min to data
+        // `'end'`: from data to max
+        // origin: 'auto'
         // },
         // false, 'start', 'end', 'middle'
         step: false,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [X] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR will add line segment styling to line chart.

### Fixed issues

<!--
- #xxxx: ...
-->
https://github.com/apache/echarts/issues/17138

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
We cannot set segment styles for a line chart, so the entire line has to use the same style, making it monotonous. To achieve this effect, we need to increase the complexity of the configuration, which is not elegant. Therefore, at the source code level, we need to implement this effect to provide users with a direct configuration option to easily configure such segmented effects.


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
Users can configure segment styles like this
```js
{
    linePieces: [
         { 
              segment: [1, 3],
              lineStyle: {
                   type: "solid",
                   color: 'red'
              }
         },
        {
             segment: ({dataIndex})= dataIndex >= 6 && dataIndex <= 9,
             lineStyle: {
                   type: "dashed",
                   color: 'cyan',
                   width:'4'
             }
        }
    ]
}
```
The effect will be like this：
![image](https://user-images.githubusercontent.com/103579791/206901898-c777567a-3c53-4e46-9db4-a54001819235.png)

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [X] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
