### PR TITLE
fix(tree): change symbol type. close #17946

### DIFF
--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -82,7 +82,7 @@ export interface TreeSeriesLeavesOption
 
 export interface TreeSeriesOption extends
     SeriesOption<TreeSeriesStateOption, TreeStatesMixin>, TreeSeriesStateOption,
-    SymbolOptionMixin, BoxLayoutOptionMixin, RoamOptionMixin {
+    SymbolOptionMixin<CallbackDataParams>, BoxLayoutOptionMixin, RoamOptionMixin {
     type?: 'tree'
 
     layout?: 'orthogonal' | 'radial'


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Fix typescript error when providing a callback to the `symbol` property of the tree series.

## Details

### Before: What was the problem?

When providing a callback to the `symbol` property of the tree series, the following typescript error appeared:

![image](https://user-images.githubusercontent.com/71984989/207968928-183b6c2e-bf6f-4e39-8353-c28af7760b20.png)

Callback function itself was working, but type definition was wrong.

This was happening because `TreeSeriesOption` extended `SymbolOptionMixin` instead of `SymbolOptionMixin<CallbackDataParams>` interface.




### After: How does it behave after the fixing?

Now it is possible to provide a callback to the tree series `symbol` without typescript errors.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
