### PR TITLE
fix(axis): containLabel work with multi axis without offset. fix #18077

### DIFF
--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -186,19 +186,33 @@ class Grid implements CoordinateSystemMaster {
 
         // Minus label size
         if (isContainLabel) {
+            const multiAxisOffsetMap = {
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+            }
             each(axesList, function (axis) {
                 if (!axis.model.get(['axisLabel', 'inside'])) {
                     const labelUnionRect = estimateLabelUnionRect(axis);
                     if (labelUnionRect) {
                         const dim: 'height' | 'width' = axis.isHorizontal() ? 'height' : 'width';
                         const margin = axis.model.get(['axisLabel', 'margin']);
-                        gridRect[dim] -= labelUnionRect[dim] + margin;
+                        const axisSpace = labelUnionRect[dim] + margin
+                        gridRect[dim] -= axisSpace;
+
                         if (axis.position === 'top') {
-                            gridRect.y += labelUnionRect.height + margin;
+                            gridRect.y += axisSpace;
                         }
                         else if (axis.position === 'left') {
-                            gridRect.x += labelUnionRect.width + margin;
+                            gridRect.x += axisSpace;
                         }
+
+                        const autoOffset = multiAxisOffsetMap[axis.position];
+                        if(!axis.model.get(['offset'])) {
+                            axis.model.mergeOption({offset: autoOffset}, axis.model.ecModel);
+                        }
+                        multiAxisOffsetMap[axis.position] += axisSpace;
                     }
                 }
             });

--- a/test/axis-containLabel.html
+++ b/test/axis-containLabel.html
@@ -40,6 +40,7 @@ under the License.
 
         <div class="chart" id="main0"></div>
         <div class="chart" id="main1"></div>
+        <div class="chart" id="main2"></div>
 
 
 
@@ -298,7 +299,89 @@ under the License.
 
 
 
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var colors = ['#5470C6', '#91CC75', '#EE6666'];
+                var option = {
+                    color: colors,
+                    legend: {
+                        data: ['Evaporation', 'Precipitation', 'Temperature']
+                    },
+                    grid: {
+                        left: 10,
+                        right: 10,
+                        containLabel: true
+                    },
+                    xAxis: [
+                        {
+                            type: 'category',
+                            // prettier-ignore
+                            data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value',
+                            name: 'Evaporation',
+                            position: 'left',
+                            axisLabel: {
+                                formatter: '{value} ml'
+                            }
+                        },
+                        {
+                            type: 'value',
+                            name: 'Precipitation',
+                            position: 'right',
+                            axisLabel: {
+                                formatter: '{value} ml'
+                            }
+                        },
+                        {
+                            type: 'value',
+                            name: '温度',
+                            position: 'right',
+                            axisLabel: {
+                                formatter: '{value} °C'
+                            }
+                        }
+                    ],
+                    series: [
+                        {
+                            name: 'Evaporation',
+                            type: 'bar',
+                            yAxisIndex: 0,
+                            data: [
+                                2.0, 4.9, 7.0, 23.2, 25.6, 76.7, 135.6, 162.2, 32.6, 20.0, 6.4, 3.3
+                            ]
+                        },
+                        {
+                            name: 'Precipitation',
+                            type: 'bar',
+                            yAxisIndex: 1,
+                            data: [
+                                2.6, 5.9, 9.0, 26.4, 28.7, 70.7, 175.6, 182.2, 48.7, 18.8, 6.0, 2.3
+                            ]
+                        },
+                        {
+                            name: 'Temperature',
+                            type: 'line',
+                            yAxisIndex: 2,
+                            data: [2.0, 2.2, 3.3, 4.5, 6.3, 10.2, 20.3, 23.4, 23.0, 16.5, 12.0, 6.2]
+                        }
+                    ]
+                };
 
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'containLabel with multi axis without offset'
+                    ],
+                    option: option,
+                    info: {grid: option.grid, yAxis: option.yAxis},
+                });
+            });
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fix #18077 .

grid.containLabel will work better when multi axis.


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
If you don‘t provide yAxis.offset, labels will overlay.
 But every yAxis will take extra space in grid when grid.containLabel is true.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="808" alt="image" src="https://user-images.githubusercontent.com/12808432/208414830-1a9c8316-a6d9-403c-b2d2-3b359d5a9a2b.png">



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

In `grid.containLabel` logic, if axis.offset is not provided, it will calc by `labelUnionRect`.


<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="894" alt="image" src="https://user-images.githubusercontent.com/12808432/208415356-65e116fc-6e5e-4b17-b436-6ffa41bfef0e.png">



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

