### PR TITLE
feat[gauge]: add formatter in array form

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -31,7 +31,7 @@ import SeriesData from '../../data/SeriesData';
 import Sausage from '../../util/shape/sausage';
 import {createSymbol} from '../../util/symbol';
 import ZRImage from 'zrender/src/graphic/Image';
-import { extend, isFunction, isString, isNumber, each } from 'zrender/src/core/util';
+import { extend, isFunction, isString, isNumber, each, isArray} from 'zrender/src/core/util';
 import {setCommonECData} from '../../util/innerStore';
 import { normalizeArcAngles } from 'zrender/src/core/PathProxy';
 
@@ -674,7 +674,10 @@ class GaugeView extends ChartView {
                     seriesModel.get(['progress', 'show']) ? data.getItemVisual(idx, 'style').fill : autoColor
                 ) as string;
                 const labelEl = newDetailEls[idx];
-                const formatter = itemDetailModel.get('formatter');
+                let formatter = itemDetailModel.get('formatter');
+                if (isArray(formatter)) {
+                    formatter = formatter[idx];
+                }
                 labelEl.attr({
                     z2: showPointerAbove ? 0 : 2,
                     style: createTextStyle(itemDetailModel, {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Enrich the type of this Formatter so that it can support arrays.


### Fixed issues

- #18021: [...](https://github.com/apache/echarts/issues/18021)


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
i've a gauge with two values
https://echarts.apache.org/examples/en/editor.html?c=gauge-multi-title
it would be nice if i'm able to add a suffix for both values with different units in the formatter.
e.g. formatter: ["{value1} °C" , "{value2} H%"]
![~OT9R1JKMQ72TK `Q87@}OQ](https://user-images.githubusercontent.com/73587626/209341631-f43deb77-a662-4fa8-8e47-971ebcf8b171.png)




### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://user-images.githubusercontent.com/73587626/209341708-d3b4338a-5e4d-4544-a627-8b4fc8d84396.png)




## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
