### PR TITLE
feat(toolbox): support action "saveAsImage" #18121

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -19,6 +19,8 @@
 
 /* global Uint8Array, document */
 
+import * as echarts from '../../../core/echarts';
+import ToolboxView from '../ToolboxView';
 import env from 'zrender/src/core/env';
 import { ToolboxFeature, ToolboxFeatureOption } from '../featureManager';
 import { ZRColor } from '../../../util/types';
@@ -146,5 +148,16 @@ class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
         return defaultOption;
     }
 }
+
+echarts.registerAction(
+    'saveAsImage',
+    function (payload, ecModel, api) {
+        const toolboxModel = ecModel.getComponent('toolbox');
+        if (toolboxModel) {
+            ((api.getViewOfComponentModel(toolboxModel) as ToolboxView)._features?.saveAsImage as SaveAsImage)
+                ?.onclick(ecModel, api);
+        }
+    }
+);
 
 export default SaveAsImage;

--- a/test/toolbox-saveImage-action.html
+++ b/test/toolbox-saveImage-action.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            #button {
+                margin: 10px;
+            }
+        </style>
+
+        <button id="button">Save as image</button>
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                toolbox: {
+                    feature: {
+                        saveAsImage: {
+                            show: true,
+                            title: 'Save as image'
+                        }
+                    },
+                },
+                xAxis: {},
+                yAxis: {},
+                series: {
+                    type: 'line',
+                    data: [[11, 22], [33, 44]]
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Click the button to dispatch the "saveAsImage" action',
+                    'An image should be saved as in the "saveAsImage" icon of the toolbox was clicked'
+                ],
+                option: option
+            });
+
+            document.getElementById('button').addEventListener('click', () => {
+                chart.dispatchAction({
+                    type: 'saveAsImage'
+                })
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Support a new action "saveAsImage"



### Fixed issues

#18121 


## Details

### Before: What was the problem?

In order to manually save the chart as an image, the coder has to use getConnectedDataURL API + some self-implementing download methods, which is quite inconvenient since we already have saveAsImage feature in toolbox.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

You can simply do the whole thing in one line:
```
chart.dispatchAction({type: 'saveAsImage'})
```


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

check `test/toolbox-saveImage-action.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
