### PR TITLE
修复：Sankey桑基图Label Value总是undefined的问题。

### DIFF
--- a/src/chart/sankey/SankeyView.ts
+++ b/src/chart/sankey/SankeyView.ts
@@ -273,7 +273,8 @@ class SankeyView extends ChartView {
                 {
                     labelFetcher: seriesModel,
                     labelDataIndex: node.dataIndex,
-                    defaultText: node.id
+                    labelValue: layout.value,
+                    defaultText: node.id                    
                 }
             );
 

--- a/src/chart/sankey/SankeyView.ts
+++ b/src/chart/sankey/SankeyView.ts
@@ -274,7 +274,7 @@ class SankeyView extends ChartView {
                     labelFetcher: seriesModel,
                     labelDataIndex: node.dataIndex,
                     labelValue: layout.value,
-                    defaultText: node.id                    
+                    defaultText: node.id
                 }
             );
 

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -94,6 +94,7 @@ interface SetLabelStyleOpt<TLabelDataIndex> extends TextCommonParams {
     };
     labelDataIndex?: TLabelDataIndex;
     labelDimIndex?: number;
+    labelValue?: number;
 
     /**
      * Inject a setter of text for the text animation case.
@@ -135,9 +136,17 @@ function getLabelText<TLabelDataIndex>(
     const labelFetcher = opt.labelFetcher;
     const labelDataIndex = opt.labelDataIndex;
     const labelDimIndex = opt.labelDimIndex;
+    const labelValue = opt.labelValue;
     const normalModel = stateModels.normal;
     let baseText;
+    let extendParams = null;
     if (labelFetcher) {
+        if (labelValue != undefined && labelValue != null) {
+            extendParams = {
+                interpolatedValue: labelValue
+            };
+        }
+
         baseText = labelFetcher.getFormattedLabel(
             labelDataIndex, 'normal',
             null,
@@ -145,7 +154,7 @@ function getLabelText<TLabelDataIndex>(
             normalModel && normalModel.get('formatter'),
             interpolatedValue != null ? {
                 interpolatedValue: interpolatedValue
-            } : null
+            } : extendParams
         );
     }
     if (baseText == null) {

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -139,22 +139,13 @@ function getLabelText<TLabelDataIndex>(
     const labelValue = opt.labelValue;
     const normalModel = stateModels.normal;
     let baseText;
-    let extendParams = null;
     if (labelFetcher) {
-        if (labelValue != undefined && labelValue != null) {
-            extendParams = {
-                interpolatedValue: labelValue
-            };
-        }
-
         baseText = labelFetcher.getFormattedLabel(
             labelDataIndex, 'normal',
             null,
             labelDimIndex,
             normalModel && normalModel.get('formatter'),
-            interpolatedValue != null ? {
-                interpolatedValue: interpolatedValue
-            } : extendParams
+             {interpolatedValue: retrieve2(interpolatedValue, labelValue)}
         );
     }
     if (baseText == null) {

--- a/test/sankey-labelValue.html
+++ b/test/sankey-labelValue.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body, #main {
+                margin: 0;
+                width: 100%;
+                height: 100vh;
+            }
+        </style>
+
+        <div id="main"></div>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var chart = echarts.init(document.querySelector("#main"), 'dark');
+                window.onresize = chart.resize;
+
+                const sankeyData = [
+                    {source: 'EasyGrid Energy', target: 'Chip Industry', value: 860},
+                    {source: 'EasyGrid Energy', target: 'Industrial Internet', value: 1600},
+                    {source: 'EG Green Energy', target: 'Chip Industry', value: 2600},
+                    {source: 'EG Green Energy', target: 'IOT', value: 500},
+
+                    {source: 'Industrial Internet', target: 'IOT', value: 800},
+                    {source: 'Industrial Internet', target: 'Intelligent Manufacturing', value: 600},
+
+                    {source: 'Chip Industry', target: 'Chip Manufacturing', value: 1600},
+                    {source: 'Chip Industry', target: 'Chip Package', value: 1200},
+                    {source: 'Chip Industry', target: 'Chip Design', value: 600},
+
+                    {source: 'Chip Manufacturing', target: '5mm', value: 600},
+                    {source: 'Chip Manufacturing', target: '10mm', value: 500},
+                    {source: 'Chip Manufacturing', target: '15mm', value: 500}
+                ];
+
+                var option = {
+                    title: {text: 'The values of Label and Tooltip are the same',padding: 20},
+                    series: [{
+                        type: 'sankey',
+                        layout: 'none',
+                        lineStyle: {color: 'gradient', curveness: 0.5},
+                        emphasis: {focus: 'adjacency'},
+                        data: getNames(),
+                        links: sankeyData
+                    }],
+                    tooltip: {trigger: 'item', triggerOn: 'mousemove'},
+                    label: {
+                        formatter: (params) => {
+                            return params.name + ' ' + params.value + 'kW·h';
+                        }
+                    }
+                };
+
+                chart.setOption(option);
+
+                function getNames() {
+                    return sankeyData.reduce((names, item) => {
+                        if (-1 == names.indexOf(item.source)) {
+                            names.push(item.source);
+                        }
+                        if (-1 == names.indexOf(item.target)) {
+                            names.push(item.target);
+                        }
+                        return names;
+                    }, []).map(item => {return {name:item}});
+                }
+            });
+        </script>
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

fix: The Label Value of Sankey Chart is always an undefined problem.
【中文】解决：桑基图Label Value总是undefined的问题。

### Fixed issues

- #18212 


## Details

### Before: What was the problem?

Bug 请看下图：
![bug](https://user-images.githubusercontent.com/98680646/216040822-8210be3c-9cea-4e8a-aa9f-2d8be0624158.png)


### After: How does it behave after the fixing?

修复之后效果如下：
![fixed](https://user-images.githubusercontent.com/98680646/216040853-6a13935e-b198-4cfc-8f55-d0b05719ec14.png)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
