### PR TITLE
fix(sunburst): `radial` rotation label might upside down

### DIFF
--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -32,6 +32,7 @@ import { getSectorCornerRadius } from '../helper/pieHelper';
 import {createOrUpdatePatternFromDecal} from '../../util/decal';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { saveOldStyle } from '../../animation/basicTransition';
+import { normalizeRadian } from 'zrender/src/contain/util';
 
 const DEFAULT_SECTOR_Z = 2;
 const DEFAULT_TEXT_Z = 4;
@@ -251,8 +252,8 @@ class SunburstPiece extends graphic.Sector {
             const rotateType = getLabelAttr(labelStateModel, 'rotate');
             let rotate = 0;
             if (rotateType === 'radial') {
-                rotate = -midAngle;
-                if (rotate < -Math.PI / 2 || rotate > Math.PI / 2) {
+                rotate = normalizeRadian(-midAngle);
+                if (((rotate > Math.PI / 2 && rotate <= Math.PI) || (rotate > Math.PI && rotate <= Math.PI * 1.5))) {
                     rotate += Math.PI;
                 }
             }

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -253,7 +253,7 @@ class SunburstPiece extends graphic.Sector {
             let rotate = 0;
             if (rotateType === 'radial') {
                 rotate = normalizeRadian(-midAngle);
-                if (((rotate > Math.PI / 2 && rotate <= Math.PI) || (rotate > Math.PI && rotate <= Math.PI * 1.5))) {
+                if (((rotate > Math.PI / 2 && rotate <= Math.PI * 1.5))) {
                     rotate += Math.PI;
                 }
             }

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -252,7 +252,7 @@ class SunburstPiece extends graphic.Sector {
             let rotate = 0;
             if (rotateType === 'radial') {
                 rotate = -midAngle;
-                if (rotate < -Math.PI / 2) {
+                if (rotate < -Math.PI / 2 || rotate > Math.PI / 2) {
                     rotate += Math.PI;
                 }
             }

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -211,19 +211,23 @@ under the License.
             });
 
             var config = {
-                startAngle: 0
+                startAngle: 0,
+                clockwise: true
             };
 
             function update() {
                 chart.setOption({
                     series: [{
-                        startAngle: config.startAngle
+                        startAngle: config.startAngle,
+                        clockwise: config.clockwise
                     }]
                 });
             }
 
             var gui = new dat.GUI();
                 gui.add(config, 'startAngle', 0, 360)
+                    .onChange(update);
+                gui.add(config, 'clockwise')
                     .onChange(update);
         });
     </script>

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -28,6 +28,7 @@ under the License.
         <script src="lib/jquery.min.js"></script>
         <script src="lib/facePrint.js"></script>
         <script src="lib/testHelper.js"></script>
+        <script src="lib/dat.gui.min.js"></script>
         <!-- <script src="ut/lib/canteen.js"></script> -->
         <link rel="stylesheet" href="lib/reset.css" />
     </head>
@@ -37,8 +38,8 @@ under the License.
 
 
 
-        <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main0"></div>
 
 
 
@@ -188,7 +189,7 @@ under the License.
             option = {
                 series: {
                     type: 'sunburst',
-                    startAngle: 180,
+                    startAngle: 0,
                     // emphasis: {
                     //     focus: 'ancestor'
                     // },
@@ -201,13 +202,29 @@ under the License.
             };
             var chart = testHelper.create(echarts, 'main1', {
                 title: [
-                    'Put label in the center if it\'s a circle'
+                    'Label rotation under different startAngle '
                 ],
-                option: option
-                // height: 300,
+                option: option,
+                height: 600,
                 // buttons: [{text: 'btn-txt', onclick: function () {}}],
                 // recordCanvas: true,
             });
+
+            var config = {
+                startAngle: 0
+            };
+
+            function update() {
+                chart.setOption({
+                    series: [{
+                        startAngle: config.startAngle
+                    }]
+                });
+            }
+
+            var gui = new dat.GUI();
+                gui.add(config, 'startAngle', 0, 360)
+                    .onChange(update);
         });
     </script>
 

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -38,6 +38,7 @@ under the License.
 
 
         <div id="main0"></div>
+        <div id="main1"></div>
 
 
 
@@ -111,6 +112,104 @@ under the License.
             });
         });
         </script>
+
+    <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var chart = echarts.init(document.getElementById('main1'));
+
+            var data = [
+                {
+                    name: 'Grandpa',
+                    children: [
+                        {
+                            name: 'Uncle Leo',
+                            value: 15,
+                            children: [
+                                {
+                                    name: 'Cousin Jack',
+                                    value: 2
+                                },
+                                {
+                                    name: 'Cousin Mary',
+                                    value: 5,
+                                    children: [
+                                        {
+                                            name: 'Jackson',
+                                            value: 2
+                                        }
+                                    ]
+                                },
+                                {
+                                    name: 'Cousin Ben',
+                                    value: 4
+                                }
+                            ]
+                        },
+                        {
+                            name: 'Father',
+                            value: 10,
+                            children: [
+                                {
+                                    name: 'Me',
+                                    value: 5
+                                },
+                                {
+                                    name: 'Brother Peter',
+                                    value: 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    name: 'Nancy',
+                    children: [
+                        {
+                            name: 'Uncle Nike',
+                            children: [
+                                {
+                                    name: 'Cousin Betty',
+                                    value: 1
+                                },
+                                {
+                                    name: 'Cousin Jenny',
+                                    value: 2
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+            ];
+            option = {
+                series: {
+                    type: 'sunburst',
+                    startAngle: 180,
+                    // emphasis: {
+                    //     focus: 'ancestor'
+                    // },
+                    data: data,
+                    radius: [0, '90%'],
+                    label: {
+                        rotate: 'radial'
+                    }
+                }
+            };
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Put label in the center if it\'s a circle'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+    </script>
 
 
     </body>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?


`sunbrust` label might upside down under `radial` rotation


### Fixed issues

- Close #18023 


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="666" alt="Screenshot 2023-02-04 at 15 31 48" src="https://user-images.githubusercontent.com/20318608/216755089-3dfa7364-1373-485b-8f86-5a8c25f5365e.png">


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="458" alt="Screenshot 2023-02-04 at 15 31 36" src="https://user-images.githubusercontent.com/20318608/216755100-828b7187-5490-44f0-a524-33d0202bc74f.png">



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in https://github.com/apache/echarts-doc/pull/337



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`sunburst-label.html`


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
