### PR TITLE
feat(tooltip): support relative length units for font-size. close #18253

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -153,7 +153,7 @@ function assembleFont(textStyleModel: Model<TooltipOption['textStyle']>): string
 
     fontSize
         // @ts-ignore, leave it to the tooltip refactor.
-        && cssText.push('line-height:' + Math.round(fontSize * 3 / 2) + 'px');
+        && cssText.push('line-height:1.5');
 
     const shadowColor = textStyleModel.get('textShadowColor');
     const shadowBlur = textStyleModel.get('textShadowBlur') || 0;

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -51,19 +51,22 @@ function getTooltipTextStyle(
     valueStyle: TextStyle
 } {
     const nameFontColor = textStyle.color || '#6e7079';
-    const nameFontSize = textStyle.fontSize || 12;
+    let nameFontSize = textStyle.fontSize || '12px';
     const nameFontWeight = textStyle.fontWeight || '400';
     const valueFontColor = textStyle.color || '#464646';
-    const valueFontSize = textStyle.fontSize || 14;
+    let valueFontSize = textStyle.fontSize || '14px';
     const valueFontWeight = textStyle.fontWeight || '900';
 
     if (renderMode === 'html') {
+        nameFontSize = isNaN(Number(nameFontSize)) ? String(nameFontSize) : `${nameFontSize}px`;
+        valueFontSize = isNaN(Number(valueFontSize)) ? String(valueFontSize) : `${valueFontSize}px`;
+
         // `textStyle` is probably from user input, should be encoded to reduce security risk.
         return {
             // eslint-disable-next-line max-len
-            nameStyle: `font-size:${encodeHTML(nameFontSize + '')}px;color:${encodeHTML(nameFontColor)};font-weight:${encodeHTML(nameFontWeight + '')}`,
+            nameStyle: `font-size:${encodeHTML(nameFontSize)};color:${encodeHTML(nameFontColor)};font-weight:${encodeHTML(nameFontWeight + '')}`,
             // eslint-disable-next-line max-len
-            valueStyle: `font-size:${encodeHTML(valueFontSize + '')}px;color:${encodeHTML(valueFontColor)};font-weight:${encodeHTML(valueFontWeight + '')}`
+            valueStyle: `font-size:${encodeHTML(valueFontSize)};color:${encodeHTML(valueFontColor)};font-weight:${encodeHTML(valueFontWeight + '')}`
         };
     }
     else {

--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -612,11 +612,12 @@ export function getFont(
     ecModel: GlobalModel
 ) {
     const gTextStyleModel = ecModel && ecModel.getModel('textStyle');
+    const fontSize = opt.fontSize || gTextStyleModel && gTextStyleModel.getShallow('fontSize') || '12px';
     return trim([
         // FIXME in node-canvas fontWeight is before fontStyle
         opt.fontStyle || gTextStyleModel && gTextStyleModel.getShallow('fontStyle') || '',
         opt.fontWeight || gTextStyleModel && gTextStyleModel.getShallow('fontWeight') || '',
-        (opt.fontSize || gTextStyleModel && gTextStyleModel.getShallow('fontSize') || 12) + 'px',
+        isNaN(Number(fontSize)) ? String(fontSize) : `${fontSize}px`,
         opt.fontFamily || gTextStyleModel && gTextStyleModel.getShallow('fontFamily') || 'sans-serif'
     ].join(' '));
 }

--- a/test/tooltip-textStyle-fontSize.html
+++ b/test/tooltip-textStyle-fontSize.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <!-- <script src="ut/lib/canteen.js"></script> -->
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+<style>
+</style>
+
+
+
+<div id="main0"></div>
+
+
+<div id="main1"></div>
+
+
+<div id="main2"></div>
+
+
+
+
+
+
+<script>
+require(['echarts'/*, 'map/js/china' */], function (echarts) {
+    var option;
+
+    option = {
+        xAxis: {},
+        yAxis: {},
+        tooltip: {
+            textStyle: {
+                fontSize: '1.5vh'
+            },
+            alwaysShowContent: true
+        },
+        series: {
+            type: 'line',
+            data: [[11, 22], [33, 44]]
+        }
+    };
+
+    var chart = testHelper.create(echarts, 'main0', {
+        title: [
+            'trigger: **"item"**',
+            'renderMode: **"html"**',
+            'It should have font size being 1.5vh'
+        ],
+        option: option
+    });
+
+    chart.dispatchAction({
+        type: 'showTip',
+        seriesIndex: 0,
+        dataIndex: 0
+    });
+});
+</script>
+
+<script>
+require(['echarts'/*, 'map/js/china' */], function (echarts) {
+    var option;
+
+    option = {
+        xAxis: {},
+        yAxis: {},
+        tooltip: {
+            textStyle: {
+                fontSize: 24
+            },
+            formatter: '{a}: {c}',
+            alwaysShowContent: true
+        },
+        series: {
+            type: 'line',
+            data: [[11, 22], [33, 44]]
+        }
+    };
+
+    var chart = testHelper.create(echarts, 'main1', {
+        title: [
+            'trigger: **"item"**',
+            'renderMode: **"html"**',
+            'It has custom formatter and should have font size being 24px'
+        ],
+        option: option
+    });
+
+    chart.dispatchAction({
+        type: 'showTip',
+        seriesIndex: 0,
+        dataIndex: 0
+    });
+});
+</script>
+
+<script>
+require(['echarts'/*, 'map/js/china' */], function (echarts) {
+    var option;
+
+    option = {
+        xAxis: {},
+        yAxis: {},
+        tooltip: {
+            textStyle: {
+                fontSize: '1.5rem'
+            },
+            formatter: '{a}: {c}',
+            alwaysShowContent: true,
+        },
+        series: {
+            type: 'line',
+            data: [[11, 22], [33, 44]]
+        }
+    };
+
+    var chart = testHelper.create(echarts, 'main2', {
+        title: [
+            'trigger: **"item"**',
+            'renderMode: **"html"**',
+            'It has custom formatter and should have font size being 1.5rem'
+        ],
+        option: option
+    });
+
+    chart.dispatchAction({
+        type: 'showTip',
+        seriesIndex: 0,
+        dataIndex: 0
+    });
+});
+</script>
+
+</body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Supports relative length units in the `tooltip` component option `textStyle.fontSize`, when the tooltip option `renderMode` is equal 'html'.


### Fixed issues

[#18253](https://github.com/apache/echarts/issues/18253)


## Details

### Before: What was the problem?

Functions that resolve the font-size append 'px' string to any given value.

![image](https://user-images.githubusercontent.com/30146267/218317643-3a875d96-7e50-4958-8e81-12c1f4cf5494.png)



### After: How does it behave after the fixing?

`Tooltip` supports all known units and is displayed correctly.
 
![image](https://user-images.githubusercontent.com/30146267/218317853-d17be776-4068-441e-b7fe-62c1800d70f7.png)



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`tooltip-textStyle-fontSize.html`


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
