### PR TITLE
fix(legend): inherit legend rich text color from legend's options

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -413,16 +413,18 @@ class LegendView extends ComponentView {
             content = formatter(name);
         }
 
-        const inactiveColor = legendItemModel.get('inactiveColor');
+        const textColor = isSelected
+            ? textStyleModel.getTextColor() : legendItemModel.get('inactiveColor');
+
         itemGroup.add(new graphic.Text({
             style: createTextStyle(textStyleModel, {
                 text: content,
                 x: textX,
                 y: itemHeight / 2,
-                fill: isSelected ? textStyleModel.getTextColor() : inactiveColor,
+                fill: textColor,
                 align: textAlign,
                 verticalAlign: 'middle'
-            })
+            }, {inheritColor: textColor})
         }));
 
         // Add a invisible rect to increase the area of mouse hover

--- a/test/legend-style.html
+++ b/test/legend-style.html
@@ -36,6 +36,7 @@ under the License.
 
         <div id="main1"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
 
         <script>
             function getData(seriesId) {
@@ -275,5 +276,60 @@ under the License.
             });
         });
         </script>
+
+
+    <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                textStyle: {
+                    color: 'green'
+                },
+                legend: {
+                    data: ['Line A', 'Line B'],
+                    inactiveColor: 'gray',
+                    selected: { 'Line A': false, 'Line B': true },
+                    textStyle: {
+                        color: 'red',
+                        rich: {
+                            bold: {
+                                color: 'inherit',
+                            },
+                        },
+                    },
+                    formatter: function (name) {
+                        return `{bold|${name}}`
+                    }
+                },
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'Line A',
+                        type: 'line',
+                        data: [69, 50],
+                    },
+                    {
+                        name: 'Line B',
+                        type: 'line',
+                        data: [120, 130]
+                    },
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main3', {
+                title: [
+                    '**Legend rich text should inherit color from legend option**',
+                    'Line A: gray text',
+                    'Line B: red text',
+                ],
+                option: option
+            });
+        });
+    </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Inherit the legend's rich text color from the legend's options.


### Fixed issues

- #18196

## Details

### Before: What was the problem?

Rich text within the legend was inheriting color from the theme instead of the colors configured in the legend.



### After: How does it behave after the fixing?

The rich text within a legend is inheriting now the colors from the legend's configuration (`legend.textStyle.color` when the legend item is active and `legend.inactiveColor` when inactive). However, user is still able to set color in rich options which will override `legend.textStyle.color`.

The problem was fixed by specifying `inheritColor` option in `createTextStyle` function.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
