### PR TITLE
Change separators according to German language

### DIFF
--- a/src/i18n/langDE.ts
+++ b/src/i18n/langDE.ts
@@ -134,8 +134,8 @@ export default {
             withName: 'die Daten für {name} sind {value}',
             withoutName: '{value}',
             separator: {
-                middle: ',',
-                end: '.'
+                middle: '.',
+                end: ','
             }
         }
     }


### PR DESCRIPTION
In German numbers are separated opposite to English: 1.000.000,101

Source: I'm a native speaker, but also https://learn.microsoft.com/en-us/globalization/locale/number-formatting#the-character-used-as-the-decimal-separator

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fix German number separator 


## Details

### Before: What was the problem?

Number separator for German was wrong.



### After: How does it behave after the fixing?

Number separator for German is correct



## Document Info

One of the following should be checked.

- [X] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
