### PR TITLE
fix(dataset): object source contains `length` breaks render

### DIFF
--- a/src/data/Source.ts
+++ b/src/data/Source.ts
@@ -19,7 +19,7 @@
 
 import {
     isTypedArray, HashMap, clone, createHashMap, isArray, isObject, isArrayLike,
-    hasOwn, assert, each, map, isNumber, isString
+    hasOwn, assert, each, map, isNumber, isString, keys
 } from 'zrender/src/core/util';
 import {
     SourceFormat, SeriesLayoutBy, DimensionDefinition,
@@ -405,11 +405,7 @@ function objectRowsCollectDimensions(data: OptionSourceDataObjectRows): Dimensio
     let obj;
     while (firstIndex < data.length && !(obj = data[firstIndex++])) {} // jshint ignore: line
     if (obj) {
-        const dimensions: DimensionDefinitionLoose[] = [];
-        each(obj, function (value, key) {
-            dimensions.push(key);
-        });
-        return dimensions;
+        return keys(obj);
     }
 }
 

--- a/test/dataset-category.html
+++ b/test/dataset-category.html
@@ -47,6 +47,7 @@ under the License.
         <div id="category-no-encode-has-axis-data"></div>
         <div id="category"></div>
         <div id="two-value-axes"></div>
+        <div id="object-source"></div>
         <div id="empty-data"></div>
         <div id="empty-source"></div>
         <div id="dynamic-category"></div>
@@ -671,7 +672,45 @@ under the License.
 
 
 
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
 
+                var option = {
+                    "dataset": {
+                        "source": [
+                            {
+                                "elevation_above_sea_level": 4,
+                                "length": 1,
+                                "width": 4
+                            }
+                        ]
+                    },
+
+                    "xAxis": {
+                        "type": "value"
+                    },
+                    "yAxis": {
+                        "type": "value"
+                    },
+                    "series": [
+                        {
+                            "type": "line",
+                            "encode": {
+                                "x": "length",
+                                "y": "elevation_above_sea_level"
+                            }
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'object-source', {
+                    title: "object source that contains 'length' won't break render",
+                    option: option
+                });
+            });
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Replace `each` by `keys` to retrive correct dimension from object source.



### Fixed issues

- close #18050


## Details

### Before: What was the problem?

<img width="749" alt="Screenshot 2023-02-16 at 00 16 32" src="https://user-images.githubusercontent.com/20318608/219086747-98aeef3a-b130-4c74-9b02-cfe37a927632.png">




### After: How does it behave after the fixing?

<img width="763" alt="Screenshot 2023-02-16 at 00 15 57" src="https://user-images.githubusercontent.com/20318608/219086801-64fd2d15-9e89-4280-a85a-946c1c2791ce.png">



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs


`test/dataset-category.html`

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
