### PR TITLE
fix: candlestick red-green bug

### DIFF
--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -113,13 +113,13 @@ class CandlestickSeriesModel extends SeriesModel<CandlestickSeriesOption> {
         clip: true,
 
         itemStyle: {
-            color: '#eb5454', // positive
-            color0: '#47b262', // negative
-            borderColor: '#eb5454',
-            borderColor0: '#47b262',
+            color: '#47b262', // positive
+            color0: '#eb5454', // negative
+            borderColor: '#47b262',
+            borderColor0: '#eb5454',
             borderColorDoji: null, // when close === open
-            // borderColor: '#d24040',
-            // borderColor0: '#398f4f',
+            // borderColor: '#398f4f',
+            // borderColor0: '#d24040',
             borderWidth: 1
         },
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Changes the colour of the candle to the correct colour: rise - green, fall - red (original bug - colours mixed up).



### Fixed issues

The colours have been swapped. 


## Details

### Before: What was the problem?

A positive candle (itemStyle: color) was marked in red, a falling candle in green (itemStyle:color0).

![image](https://user-images.githubusercontent.com/28907659/220855441-9b2da27f-597b-4159-81c3-7044abe572d1.png)



### After: How does it behave after the fixing?

The right way: up is green, down is red.
![image](https://user-images.githubusercontent.com/28907659/220856132-5e16528a-a0e4-46e4-b4c2-f82c5b536274.png)




## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
