### PR TITLE
feat(treemap): add scaleLimit to limit the zooming. close #14599

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -238,7 +238,6 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
     };
 
     static defaultOption: TreemapSeriesOption = {
-        coordinateSystem: 'view',
         // Disable progressive rendering
         progressive: 0,
         // size: ['80%', '80%'],            // deprecated, compatible with ec2.

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -232,6 +232,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
     private _idIndexMap: zrUtil.HashMap<number>;
     private _idIndexMapCount: number;
 
+    zoom: number;
     zoomLimit: {
         max?: number;
         min?: number;

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -45,6 +45,7 @@ import SeriesData from '../../data/SeriesData';
 import { normalizeToArray } from '../../util/model';
 import { createTooltipMarkup } from '../../component/tooltip/tooltipMarkup';
 import enableAriaDecalForTree from '../helper/enableAriaDecalForTree';
+import View from '../../coord/View';
 
 // Only support numeric value.
 type TreemapSeriesDataValue = number | number[];
@@ -217,6 +218,8 @@ export interface TreemapSeriesOption
 
 class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
 
+    coordinateSystem: View;
+
     static type = 'series.treemap';
     type = TreemapSeriesModel.type;
 
@@ -233,6 +236,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
     private _idIndexMapCount: number;
 
     static defaultOption: TreemapSeriesOption = {
+        coordinateSystem: 'view',
         // Disable progressive rendering
         progressive: 0,
         // size: ['80%', '80%'],            // deprecated, compatible with ec2.
@@ -250,6 +254,8 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
                                             // to align specialized icon. ▷▶❒❐▼✚
 
         zoomToNodeRatio: 0.32 * 0.32,
+
+        zoom: 1,
 
         roam: true,
         nodeClick: 'zoomToNode',
@@ -504,6 +510,10 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
 
     enableAriaDecal() {
         enableAriaDecalForTree(this);
+    }
+
+    setZoom(zoom: number) {
+        this.option.zoom = zoom;
     }
 }
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -45,7 +45,6 @@ import SeriesData from '../../data/SeriesData';
 import { normalizeToArray } from '../../util/model';
 import { createTooltipMarkup } from '../../component/tooltip/tooltipMarkup';
 import enableAriaDecalForTree from '../helper/enableAriaDecalForTree';
-import View from '../../coord/View';
 
 // Only support numeric value.
 type TreemapSeriesDataValue = number | number[];
@@ -218,8 +217,6 @@ export interface TreemapSeriesOption
 
 class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
 
-    coordinateSystem: View;
-
     static type = 'series.treemap';
     type = TreemapSeriesModel.type;
 
@@ -234,6 +231,11 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
     private _viewRoot: TreeNode;
     private _idIndexMap: zrUtil.HashMap<number>;
     private _idIndexMapCount: number;
+
+    zoomLimit: {
+        max?: number;
+        min?: number;
+    };
 
     static defaultOption: TreemapSeriesOption = {
         coordinateSystem: 'view',
@@ -255,7 +257,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
 
         zoomToNodeRatio: 0.32 * 0.32,
 
-        zoom: 1,
+        scaleLimit: null,
 
         roam: true,
         nodeClick: 'zoomToNode',
@@ -510,10 +512,6 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
 
     enableAriaDecal() {
         enableAriaDecalForTree(this);
-    }
-
-    setZoom(zoom: number) {
-        this.option.zoom = zoom;
     }
 }
 

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -483,10 +483,7 @@ class TreemapView extends ChartView {
             controller = this._controller = new RoamController(api.getZr());
             controller.enable(this.seriesModel.get('roam'));
             controller.on('pan', bind(this._onPan, this));
-            controller.on('zoom', bind((e) => {
-                roamHelper.updateViewOnZoom(controllerHost, e.scale, e.originX, e.originY);
-                this._onZoom(e);
-            }, this));
+            controller.on('zoom', bind(this._onZoom, this));
         }
 
         if (!controllerHost) {
@@ -561,6 +558,7 @@ class TreemapView extends ChartView {
             const rect = new BoundingRect(
                 rootLayout.x, rootLayout.y, rootLayout.width, rootLayout.height
             );
+            roamHelper.updateViewOnZoom(this._controllerHost, e.scale, e.originX, e.originY);
             // const layoutInfo = this.seriesModel.layoutInfo;
 
             // Transform mouse coord from global to containerGroup.

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -559,7 +559,10 @@ class TreemapView extends ChartView {
             );
 
             // scaleLimit
-            const zoomLimit = controllerHost.zoomLimit;
+            let zoomLimit = null;
+            if (controllerHost) {
+                zoomLimit = controllerHost.zoomLimit;
+            }
 
             let newZoom = controllerHost.zoom = controllerHost.zoom || 1;
             newZoom *= zoomDelta;

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -493,10 +493,7 @@ class TreemapView extends ChartView {
             controllerHost = this._controllerHost = {
                 target: this.group
             } as RoamControllerHost;
-            this.seriesModel.setZoom(this.seriesModel.get('zoom'));
-            this.seriesModel.coordinateSystem.zoomLimit = this.seriesModel.get('scaleLimit');
             controllerHost.zoomLimit = this.seriesModel.get('scaleLimit');
-            controllerHost.zoom = this.seriesModel.coordinateSystem.getZoom();
         }
 
         const rect = new BoundingRect(0, 0, api.getWidth(), api.getHeight());

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -560,11 +560,10 @@ class TreemapView extends ChartView {
 
             // scaleLimit
             let zoomLimit = null;
-            if (controllerHost) {
-                zoomLimit = controllerHost.zoomLimit;
-            }
+            const _controllerHost = controllerHost ? controllerHost : this._controllerHost;
+            zoomLimit = _controllerHost.zoomLimit;
 
-            let newZoom = controllerHost.zoom = controllerHost.zoom || 1;
+            let newZoom = _controllerHost.zoom = _controllerHost.zoom || 1;
             newZoom *= zoomDelta;
             if (zoomLimit) {
                 const zoomMin = zoomLimit.min || 0;
@@ -574,8 +573,8 @@ class TreemapView extends ChartView {
                     zoomMin
                 );
             }
-            const zoomScale = newZoom / controllerHost.zoom;
-            controllerHost.zoom = newZoom;
+            const zoomScale = newZoom / _controllerHost.zoom;
+            _controllerHost.zoom = newZoom;
             const layoutInfo = this.seriesModel.layoutInfo;
 
             // Transform mouse coord from global to containerGroup.

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -32,7 +32,6 @@ import * as helper from '../helper/treeHelper';
 import Breadcrumb from './Breadcrumb';
 import RoamController, { RoamEventParams, RoamControllerHost } from '../../component/helper/RoamController';
 import * as roamHelper from '../../component/helper/roamHelper';
-import View from '../../coord/View';
 import BoundingRect, { RectLike } from 'zrender/src/core/BoundingRect';
 // import * as matrix from 'zrender/src/core/matrix';
 import * as animationUtil from '../../util/animation';
@@ -185,8 +184,6 @@ class TreemapView extends ChartView {
         }
 
         this.seriesModel = seriesModel;
-        this.seriesModel.coordinateSystem = new View();
-
         this.api = api;
         this.ecModel = ecModel;
 

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -274,6 +274,14 @@ class TreemapView extends ChartView {
         this._oldTree = thisTree;
         this._storage = thisStorage;
 
+        if (this._controllerHost) {
+            const _oldRootLayout = this.seriesModel.layoutInfo;
+            const rootLayout = thisTree.root.getLayout();
+            if (rootLayout.width === _oldRootLayout.width && rootLayout.height === _oldRootLayout.height) {
+                this._controllerHost.zoom = 1;
+            }
+        }
+
         return {
             lastsForAnimation,
             willDeleteEls,
@@ -488,7 +496,7 @@ class TreemapView extends ChartView {
             controllerHost.zoomLimit = this.seriesModel.get('scaleLimit');
             controllerHost.zoom = this.seriesModel.get('zoom');
             controller.on('pan', bind(this._onPan, this));
-            controller.on('zoom', bind((e) => this._onZoom(e, controllerHost), this));
+            controller.on('zoom', bind(this._onZoom, this));
         }
 
         const rect = new BoundingRect(0, 0, api.getWidth(), api.getHeight());
@@ -535,7 +543,7 @@ class TreemapView extends ChartView {
         }
     }
 
-    private _onZoom(e: RoamEventParams['zoom'], controllerHost?: RoamControllerHost) {
+    private _onZoom(e: RoamEventParams['zoom']) {
         let mouseX = e.originX;
         let mouseY = e.originY;
         const zoomDelta = e.scale;
@@ -560,7 +568,7 @@ class TreemapView extends ChartView {
 
             // scaleLimit
             let zoomLimit = null;
-            const _controllerHost = controllerHost ? controllerHost : this._controllerHost;
+            const _controllerHost = this._controllerHost;
             zoomLimit = _controllerHost.zoomLimit;
 
             let newZoom = _controllerHost.zoom = _controllerHost.zoom || 1;

--- a/test/treemap-scaleLimit.html
+++ b/test/treemap-scaleLimit.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <style>
+        .chart {
+            width: 100%;
+            height: 50%;
+        }
+    </style>
+    
+    <body>
+        <div>scaleLimit: { max: 1, min: 0.5 }</div>
+        <div id="main1" class="chart"></div>
+        <div id="main2" class="chart"></div>
+        <script>
+    
+            require([
+                'echarts'
+            ], function (echarts) {
+    
+                var chart = echarts.init(document.getElementById('main1'), null, {
+    
+                });
+    
+                chart.setOption({
+    
+                    series: [
+                        {
+                            name: '矩形树图scaleLimit',
+                            type: 'treemap',
+                            roam: 'zoom',
+                            scaleLimit: {
+                                max: 1,
+                                min: 0.5
+                            },
+                            label: {
+                                emphasis: {
+                                    show: true
+                                }
+                            },
+                            levels: [
+                                {
+                                    itemStyle: {
+                                        normal: {
+                                            borderWidth: 15,
+                                            gapWidth: 30,
+                                            borderColor: '#999'
+                                        }
+                                    }
+                                },
+                                {
+                                    itemStyle: {
+                                        normal: {
+                                            borderWidth: 15,
+                                            gapWidth: 40,
+                                            borderColor: '#333'
+                                        }
+                                    }
+                                },
+                                {
+                                    itemStyle: {
+                                        normal: {
+                                            borderWidth: 10,
+                                            borderColor: '#555570'
+                                        }
+                                    }
+                                }
+                            ],
+                            data: [
+                                {
+                                    name: '三星',
+                                    value: 6,
+                                },
+                                {
+                                    name: '小米',
+                                    value: 4,
+                                    children: [
+                                        {
+                                            name: '小米0',
+                                            value: 10,
+                                            children: [
+                                                {
+                                                    itemStyle: {
+                                                        normal: {
+                                                            color: 'yellow'
+                                                        }
+                                                    },
+                                                    name: '小尺',
+                                                    value: 400
+                                                },
+                                                {
+                                                    name: '小寸',
+                                                    value: 200
+                                                },
+                                                {
+                                                    name: '小光年',
+                                                    value: 100
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            name: '小米1',
+                                            value: 4
+                                        },
+                                        {
+                                            name: '小米2',
+                                            value: 4
+                                        }
+                                    ]
+                                },
+                                {
+                                    name: '中兴',
+                                    value: 1
+                                }
+                            ]
+                        }
+                    ]
+                });
+                
+                var chart1 = echarts.init(document.getElementById('main2'));
+                option = {
+                    series: [{
+                        emphasis: {
+                            label: {
+                                show: true,
+                                formatter() {
+                                    return 11111;
+                                }
+                            }
+                        },
+                        type: 'treemap',
+                        data: [{
+                            name: 'nodeA',            // First tree
+                            value: 10,
+                            children: [{
+                                name: 'nodeAa',       // First leaf of first tree
+                                value: 4
+                            }, {
+                                name: 'nodeAb',       // Second leaf of first tree
+                                value: 6
+                            }]
+                        }]
+                    }]
+                };
+
+                chart1.setOption(option);
+                });
+    
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add `scaleLimit` option to allow limiting the zooming in treemap.


### Fixed issues

[#14599](https://github.com/apache/echarts/issues/14599)


## Details

### Before: What was the problem?

We don't have any limitation for zooming in treemap.



### After: How does it behave after the fixing?

Support `scaleLimit` in treemap series, as graph series, tree series, geo component did.

Like [scaleLimit in geo](https://echarts.apache.org/en/option.html#geo.scaleLimit)



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`treemap-scaleLimit.html`



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
