### PR TITLE
fix(type): fix `treePathInfo` is missing in the type of sunburst formatter callback

### DIFF
--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -50,7 +50,7 @@ interface SunburstItemStyleOption<TCbParams = never> extends ItemStyleOption<TCb
     borderRadius?: (number | string)[] | number | string
 }
 
-interface SunburstLabelOption extends Omit<SeriesLabelOption, 'rotate' | 'position'> {
+interface SunburstLabelOption extends Omit<SeriesLabelOption<SunburstDataParams>, 'rotate' | 'position'> {
     rotate?: 'radial' | 'tangential' | number
     minAngle?: number
     silent?: boolean
@@ -77,8 +77,8 @@ export interface SunburstStateOption<TCbParams = never> {
 }
 
 export interface SunburstSeriesNodeItemOption extends
-    SunburstStateOption<CallbackDataParams>,
-    StatesOptionMixin<SunburstStateOption<CallbackDataParams>, SunburstStatesMixin>,
+    SunburstStateOption<SunburstDataParams>,
+    StatesOptionMixin<SunburstStateOption<SunburstDataParams>, SunburstStatesMixin>,
     OptionDataItemObject<OptionDataValue>
 {
     nodeClick?: 'rootToNode' | 'link' | false
@@ -92,8 +92,9 @@ export interface SunburstSeriesNodeItemOption extends
 
     cursor?: string
 }
-export interface SunburstSeriesLevelOption
-    extends SunburstStateOption, StatesOptionMixin<SunburstStateOption, SunburstStatesMixin> {
+export interface SunburstSeriesLevelOption extends
+    SunburstStateOption<SunburstDataParams>,
+    StatesOptionMixin<SunburstStateOption<SunburstDataParams>, SunburstStatesMixin> {
 
     radius?: (number | string)[]
     /**
@@ -118,7 +119,8 @@ interface SortParam {
     getValue(): number
 }
 export interface SunburstSeriesOption extends
-    SeriesOption<SunburstStateOption, SunburstStatesMixin>, SunburstStateOption,
+    SeriesOption<SunburstStateOption<SunburstDataParams>, SunburstStatesMixin>,
+    SunburstStateOption<SunburstDataParams>,
     SunburstColorByMixin,
     CircleLayoutOptionMixin {
 
@@ -141,6 +143,8 @@ export interface SunburstSeriesOption extends
     nodeClick?: 'rootToNode' | 'link' | false
 
     renderLabelForZeroData?: boolean
+
+    data?: SunburstSeriesNodeItemOption[]
 
     levels?: SunburstSeriesLevelOption[]
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1064,8 +1064,8 @@ export interface LabelOption extends TextCommonOption {
     rich?: Dictionary<TextCommonOption>
 }
 
-export interface SeriesLabelOption extends LabelOption {
-    formatter?: string | LabelFormatterCallback<CallbackDataParams>
+export interface SeriesLabelOption<T extends CallbackDataParams = CallbackDataParams> extends LabelOption {
+    formatter?: string | LabelFormatterCallback<T>
 }
 
 /**


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

- fix `treePathInfo` is missing in the type of formatter callback
- add missing type definition for the `data` option

### Fixed issues

- #18308

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

```ts
const option: echarts.EChartsOption = {
    series: [{
        type: 'sunburst',
        levels: [
            {
                label: {
                    formatter(p) {
                        const { treePathInfo } = params
                        return ''
                    }
                }
            }
        ],
        label: {
            formatter(params) {
                const { treePathInfo } = params
                return ''
            }
        },
        data: [
            {
                label: {
                    formatter(params) {
                        const { treePathInfo } = params
                        return ''
                    }
                }
            }
        ]
    }]
};
```

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
