### PR TITLE
Fix #18206 - [Feature] Enable indicators Radar charts to invert their axis

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -31,8 +31,6 @@ import Model from '../model/Model';
 import { AxisBaseOption, CategoryAxisBaseOption, OptionAxisType } from './axisCommonTypes';
 import { AxisBaseModel } from './AxisBaseModel';
 
-const NORMALIZED_EXTENT = [0, 1] as [number, number];
-
 interface TickCoord {
     coord: number;
     // That is `scaleTick.value`.
@@ -129,7 +127,7 @@ class Axis {
             fixExtentWithBands(extent, (scale as OrdinalScale).count());
         }
 
-        return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
+        return linearMap(data, this._getNormalizedExtent(), extent, clamp);
     }
 
     /**
@@ -144,7 +142,7 @@ class Axis {
             fixExtentWithBands(extent, (scale as OrdinalScale).count());
         }
 
-        const t = linearMap(coord, extent, NORMALIZED_EXTENT, clamp);
+        const t = linearMap(coord, extent, this._getNormalizedExtent(), clamp);
 
         return this.scale.scale(t);
     }
@@ -174,7 +172,7 @@ class Axis {
 
         const tickModel = opt.tickModel || this.getTickModel();
         const result = createAxisTicks(this, tickModel as AxisBaseModel);
-        const ticks = result.ticks;
+        const ticks = this.inverse ? result.ticks.reverse() : result.ticks;
 
         const ticksCoords = map(ticks, function (tickVal) {
             return {
@@ -267,6 +265,10 @@ class Axis {
      */
     calculateCategoryInterval(): ReturnType<typeof calculateCategoryInterval> {
         return calculateCategoryInterval(this);
+    }
+
+    _getNormalizedExtent(): [number, number] {
+        return this.inverse ? [1, 0] : [0, 1];
     }
 
 }

--- a/src/coord/radar/Radar.ts
+++ b/src/coord/radar/Radar.ts
@@ -67,6 +67,7 @@ class Radar implements CoordinateSystem, CoordinateSystemMaster {
             indicatorAxis.name = indicatorModel.get('name');
             // Inject model and axis
             indicatorAxis.model = indicatorModel;
+            indicatorAxis.inverse = indicatorModel.get('inverse');
             indicatorModel.axis = indicatorAxis;
             this.dimensions.push(dim);
             return indicatorAxis;

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -50,8 +50,8 @@ export interface RadarIndicatorOption {
     min?: number
     max?: number
     color?: ColorString
-
     axisType?: 'value' | 'log'
+    inverse?: boolean
 }
 
 export interface RadarOption extends ComponentOption, CircleLayoutOptionMixin {
@@ -146,7 +146,8 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
                 nameGap: nameGap,
                 // min: 0,
                 nameTextStyle: iNameTextStyle,
-                triggerEvent: triggerEvent
+                triggerEvent: triggerEvent,
+                inverse: indicatorOpt.inverse
             } as InnerIndicatorAxisOption, false);
             if (zrUtil.isString(nameFormatter)) {
                 const indName = innerIndicatorOpt.name;

--- a/test/radar-inverse.html
+++ b/test/radar-inverse.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option;
+
+            option = {
+                title: {
+                    text: 'Inverse Radar Test'
+                },
+                tooltip: {},
+                legend: {
+                    data: ['Player 1', 'Player 2']
+                },
+                radar: {
+                    name: {
+                        textStyle: {
+                            color: '#fff',
+                            backgroundColor: '#999',
+                            borderRadius: 3,
+                            padding: [3, 5]
+                    }
+                    },
+                    indicator: [
+                        { name: 'Speed'},
+                        { name: 'Reaction'},
+                        { name: 'Power'},
+                        { name: 'Cost £m', inverse: true, min: 4, max: 0},
+                        { name: 'Stamina'},
+                    ],
+                            axisLabel: {
+                                show: true,
+                                textStyle: {
+                                    color: 'red'
+                                }
+                            },
+                },
+                series: [{
+                    name: 'Player 1 vs Plauer 2',
+                    type: 'radar',
+                    data : [
+                        {
+                            value : [9, 6, 7, 2, 5],
+                            name : 'Player 1'
+                        },
+                        {
+                            value : [7, 3, 10, 0, 9],
+                            name : 'Player 2'
+                        }
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Inverse axis',
+                    'From case feature https://github.com/apache/echarts/issues/18206'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

This PR adds the ability to 'inverse' any of the axis on a radar chart


### Fixed issues

https://github.com/apache/echarts/issues/18206


## Details

### Before: What was the problem?

Previously a radar chart could look like so:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/314046/224830185-d08977d5-97ac-4c8d-8f48-4db451fb017f.png">
However, you may which the cost to actually reflect negatively, the more expensive it is.

### After: How does it behave after the fixing?

<img width="457" alt="image" src="https://user-images.githubusercontent.com/314046/224830407-68ea033b-5d5a-4d87-9ea1-3d4fbe82fd28.png">
Now this single axis is inverted, where the cheaper the cost, the better it appears on the radar chart.


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Related test cases or examples to use the new APIs

A test case has been added here: test/radar-inverse.html

The API to inverse an indicator axis works by simply adding `inverse: true` like this:
```
...
indicator: [
    { name: 'Speed'},
    { name: 'Reaction'},
    { name: 'Power'},
    { name: 'Cost £m', inverse: true, min: 4, max: 0},
    { name: 'Stamina'},
],
...
```
