### PR TITLE
chore: update deprecated npm `prepublish` hook to `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build:extension": "node build/build.js --type extension",
     "dev:fast": "node build/build-i18n.js && node build/dev-fast.js",
     "dev": "npx -y concurrently -n build,server \"npm run dev:fast\" \"npx -y http-server -c-1 -s -o test\"",
-    "prepublish": "npm run build:lib",
+    "prepare": "npm run build:lib",
     "release": "npm run build:lib && npm run build:i18n && npm run build && npm run build:esm && npm run build:extension",
     "help": "node build/build.js --help",
     "test:visual": "node test/runTest/server.js",


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Update deprecated npm `prepublish` hook in favor of  `prepare`. See also ecomfe/zrender#998.
