### PR TITLE
fix(type): fix wrong type for data item value of the `parallel` series.

### DIFF
--- a/src/chart/parallel/ParallelSeries.ts
+++ b/src/chart/parallel/ParallelSeries.ts
@@ -55,7 +55,7 @@ export interface ParallelStateOption<TCbParams = never> {
 
 export interface ParallelSeriesDataItemOption extends ParallelStateOption,
     StatesOptionMixin<ParallelStateOption, ParallelStatesMixin> {
-    value?: ParallelSeriesDataValue[]
+    value?: ParallelSeriesDataValue
 }
 export interface ParallelSeriesOption extends
     SeriesOption<ParallelStateOption<CallbackDataParams>, ParallelStatesMixin>,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixed datatype of Typescript in echarts/src/chart/parallel/ParallelSeries.ts file for 
value? : ParallelSeriesDataValue[] 
to
value?: ParallelSeriesDataValue



### Fixed issues

<!--
- #xxxx: ...
-->
#18411 


## Details

The issue is fixed as discuss in dscussion

### Before: What was the problem?
The typescript compiler shows an error when creating a ParallelSeriesOption


<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?
The typescript compiler will not show error when creating a ParallelSeriesOption

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
