### PR TITLE
fix(legend): inherit color of legend. close #18196

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -422,7 +422,7 @@ class LegendView extends ComponentView {
                 fill: isSelected ? textStyleModel.getTextColor() : inactiveColor,
                 align: textAlign,
                 verticalAlign: 'middle'
-            })
+            },{inheritColor: isSelected ? textStyleModel.getTextColor() : inactiveColor})
         }));
 
         // Add a invisible rect to increase the area of mouse hover


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
Fix the problem that rich text not inheriting color propert of legend configuration

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
#18196 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
The rich text is not inheriting property of legend config

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![test1](https://user-images.githubusercontent.com/90558243/228247026-bf1e4cfb-dc22-4798-82ce-2b9b8d24345c.png)




### After: How does it behave after the fixing?

The rich text is inheriting color property of legend config

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![test2](https://user-images.githubusercontent.com/90558243/228247335-3fac6e46-688b-48ee-801a-6a449d1f4d60.png)



## Document Info

One of the following should be checked.

- [X] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
