### PR TITLE
fix(axis): show last tick for single data #18453

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -302,7 +302,7 @@ function fixOnBandTicksCoords(
     let diffSize;
     if (ticksLen === 1) {
         ticksCoords[0].coord = axisExtent[0];
-        last = ticksCoords[1] = {coord: axisExtent[0]};
+        last = ticksCoords[1] = {coord: axisExtent[1]};
     }
     else {
         const crossLen = ticksCoords[ticksLen - 1].tickValue - ticksCoords[0].tickValue;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Show last tick for single data

### Fixed issues

#18453

## Details

### Before: What was the problem?

No last tick when data length is 1.



### After: How does it behave after the fixing?

Has last tick when data length is 1.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- The first test case in `axis-extrema.html`

I've run visual tests for all cases and saw no problems.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
