### PR TITLE
chore: update `jest-canvas-mock` to fix test fails in node v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Fetch commit count
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
+          node-version: ${{ matrix.node-version }}
+
       - name: Setup and publish nightly
         run: |
           node build/nightly/prepare.js --next

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,14 +15,17 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
+          node-version: ${{ matrix.node-version }}
+
       - name: Setup and publish nightly
         run: |
           node build/nightly/prepare.js

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "globby": "11.0.0",
         "husky": "^4.2.5",
         "jest": "^26.6.1",
-        "jest-canvas-mock": "^2.2.0",
+        "jest-canvas-mock": "^2.5.0",
         "jshint": "2.13.5",
         "magic-string": "^0.25.7",
         "open": "6.4.0",
@@ -7419,9 +7419,9 @@
       }
     },
     "node_modules/jest-canvas-mock": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz",
-      "integrity": "sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.0.tgz",
+      "integrity": "sha512-s2bmY2f22WPMzhB2YA93kiyf7CAfWAnV/sFfY9s48IVOrGmwui1eSFluDPesq1M+7tSC1hJAit6mzO0ZNXvVBA==",
       "dev": true,
       "dependencies": {
         "cssfontparser": "^1.2.1",
@@ -19442,9 +19442,9 @@
       }
     },
     "jest-canvas-mock": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz",
-      "integrity": "sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.0.tgz",
+      "integrity": "sha512-s2bmY2f22WPMzhB2YA93kiyf7CAfWAnV/sFfY9s48IVOrGmwui1eSFluDPesq1M+7tSC1hJAit6mzO0ZNXvVBA==",
       "dev": true,
       "requires": {
         "cssfontparser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "globby": "11.0.0",
     "husky": "^4.2.5",
     "jest": "^26.6.1",
-    "jest-canvas-mock": "^2.2.0",
+    "jest-canvas-mock": "^2.5.0",
     "jshint": "2.13.5",
     "magic-string": "^0.25.7",
     "open": "6.4.0",


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others


### What does this PR do?

The unit test always [fails](https://github.com/apache/echarts/actions/runs/4752590603/jobs/8444308558#step:4:286)  in node v18 due to the `jest-canvas-mock` dependency.

As per the release note, it has been fixed since [v2.4.0](https://github.com/hustcc/jest-canvas-mock/releases/tag/v2.4.0). See also hustcc/jest-canvas-mock#91 

