### PR TITLE
fix(type): allow passing `null` to the parameters of `init` function

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -2638,8 +2638,8 @@ const DOM_ATTRIBUTE_KEY = '_echarts_instance_';
  * @param opts.useDirtyRect Enable dirty rectangle rendering or not.
  */
 export function init(
-    dom: HTMLElement,
-    theme?: string | object,
+    dom?: HTMLElement | null,
+    theme?: string | object | null,
     opts?: EChartsInitOpts
 ): EChartsType {
     const isClient = !(opts && opts.ssr);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

update `init` function type signature so it can be identical to official document

### Fixed issues

<!--
- #xxxx: ...
-->

According to the official document, we can pass `null` to the first or the second parameter. However, the type signature disallow pass `null`

https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/

https://echarts.apache.org/handbook/en/how-to/cross-platform/server/#server-side-rendering

![image](https://user-images.githubusercontent.com/14963619/234901342-c2a06e12-7e18-42bc-8f46-a1670429bc03.png)

![image](https://user-images.githubusercontent.com/14963619/234901521-0d5679d3-02ef-46e1-bcca-9d7a366ce2e2.png)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
