### PR TITLE
export CallbackDataParams from util/types

### DIFF
--- a/src/export/api/helper.ts
+++ b/src/export/api/helper.ts
@@ -128,3 +128,5 @@ export function createTextStyle(
     opts = opts || {};
     return innerCreateTextStyle(textStyleModel, null, null, opts.state !== 'normal');
 }
+
+export { CallbackDataParams } from "../../util/types";

--- a/src/export/api/helper.ts
+++ b/src/export/api/helper.ts
@@ -37,7 +37,7 @@ import SeriesModel from '../../model/Series';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
 import { getECData } from '../../util/innerStore';
 import { createTextStyle as innerCreateTextStyle } from '../../label/labelStyle';
-import { DisplayState, TextCommonOption } from '../../util/types';
+import { CallbackDataParams, DisplayState, TextCommonOption } from '../../util/types';
 
 /**
  * Create a multi dimension List structure from seriesModel.
@@ -129,4 +129,4 @@ export function createTextStyle(
     return innerCreateTextStyle(textStyleModel, null, null, opts.state !== 'normal');
 }
 
-export { CallbackDataParams } from "../../util/types";
+export {CallbackDataParams};


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?

Export out CallbackDataParams from src/util/types as part of public API for use by consumers.

### Fixed issues

None for this specific type, but I can create one (there are other types I'd love to be exported as well if a single issue with all the requests is preferred)

<!--
- #xxxx: ...
-->

## Details

### Before: What was the problem?

We have a ECharts react wrapper component in this project https://github.com/perses/perses where we are re-defining this type, see [interface defined here](https://github.com/perses/perses/blob/v0.29.1/ui/components/src/EChart/EChart.tsx#L21-L34).

echarts-for-react has a [similar issue](https://github.com/hustcc/echarts-for-react/blob/e33247b9b8f55e53e8fa3a02bf92643877366559/src/types.ts#L65), but they opted to not define the callback types explicitly, which will not work for our project since we have stricter eslint settings.

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![echarts_import_callback_error](https://github.com/apache/echarts/assets/9369625/dce964a4-069b-431f-8cac-a55bafdea51c)

### After: How does it behave after the fixing?

Type is exported as part of public API.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Exporting some of the other types we've redefined would also be really helpful 🙏 , what is the general rule for what can be exported as part of the public API?
