### PR TITLE
fix(api): only deprecate disConnect but not disconnect

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -2724,17 +2724,15 @@ export function connect(groupId: string | EChartsType[]): string {
     return groupId as string;
 }
 
-/**
- * @deprecated
- */
-export function disConnect(groupId: string): void {
+export function disconnect(groupId: string): void {
     connectedGroups[groupId] = false;
 }
 
 /**
  * Alias and backward compatibility
+ * @deprecated
  */
-export const disconnect = disConnect;
+export const disConnect = disconnect;
 
 /**
  * Dispose a chart instance


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Make `disconnect` no longer marked as deprecated.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<img width="367" alt="image" src="https://github.com/apache/echarts/assets/1726061/33b13209-ef23-4606-b841-472d44c4bb1d">

### After: How does it behave after the fixing?

<img width="375" alt="image" src="https://github.com/apache/echarts/assets/1726061/71c637e7-22b7-4cc7-b783-f5c8689a469c">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
