### PR TITLE
chore: add PR preview workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           body: |
             <!-- ECHARTS_PR_PREVIEW -->
-            The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?pr=${{ github.event.number }}@${{ env.GH_SHA_SHORT }}
+            The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?version=PR-${{ github.event.number }}@${{ env.GH_SHA_SHORT }}
           body-include: '<!-- ECHARTS_PR_PREVIEW -->'
           number: ${{ github.event.number }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,15 @@ name: Node CI
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   lint:
+    if: ${{ github.event.action != 'closed' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -54,6 +59,7 @@ jobs:
         run: npm run checktype
 
   build:
+    if: ${{ github.event.action != 'closed' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -81,11 +87,89 @@ jobs:
         if: steps.cache-dep.outputs.cache-hit != 'true'
         run: npm ci
 
+      - name: Unit Test
+        run: npm run test
+
       - name: Build release
         run: npm run release
 
       - name: Test generated DTS
         run: npm run test:dts
 
-      - name: Unit Test
-        run: npm run test
+      - name: Pack npm tarball
+        id: pack-tarball
+        run: |
+          export NPM_PKG_DIR='.npm-pkg'
+          mkdir $NPM_PKG_DIR
+          npm pack -pack-destination $NPM_PKG_DIR
+          cd $NPM_PKG_DIR
+          find . -type f -regex ".*\.tgz" -exec tar xvzf {} \;
+          echo "PR_DIST_DIR=$NPM_PKG_DIR/package" >> $GITHUB_OUTPUT
+          echo "PR_DIST_CACHE_KEY=echarts-pr-dist-cache-${{ github.event.number }}@${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Cache PR dist files
+        uses: actions/cache@v3
+        id: cache-pr-dist
+        with:
+          key: ${{ steps.pack-tarball.outputs.PR_DIST_CACHE_KEY }}
+          path: ${{ steps.pack-tarball.outputs.PR_DIST_DIR }}
+
+    outputs:
+      PR_DIST_CACHE_KEY: ${{ steps.pack-tarball.outputs.PR_DIST_CACHE_KEY }}
+      PR_DIST_DIR: ${{ steps.pack-tarball.outputs.PR_DIST_DIR }}
+
+  pr-preview:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'apache'  && needs.build.result == 'success' }}
+    needs: ['build']
+
+    steps:
+      - name: Fetch cached PR dist files
+        uses: actions/cache@v3
+        with:
+          key: ${{ needs.build.outputs.PR_DIST_CACHE_KEY }}
+          path: ${{ needs.build.outputs.PR_DIST_DIR }}
+          fail-on-cache-miss: true
+
+      - name: Deploy dist files
+        run: |
+          cd ${{ needs.build.outputs.PR_DIST_DIR }}
+          export SURGE_DOMAIN='https://echarts-pr-${{ github.event.number }}.surge.sh'
+          npx surge --project ./ --domain $SURGE_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Install action dependencies
+        run: |
+          mkdir .actions
+          cd .actions
+          git clone --depth=1 https://github.com/actions-cool/maintain-one-comment.git
+
+          echo "GH_SHA_SHORT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+
+      - name: Create comment for PR preview
+        uses: ./.actions/maintain-one-comment
+        with:
+          body: |
+            <!-- ECHARTS_PR_PREVIEW -->
+            The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?pr=${{ github.event.number }}@${{ env.GH_SHA_SHORT }}
+          body-include: '<!-- ECHARTS_PR_PREVIEW -->'
+          number: ${{ github.event.number }}
+
+  teardown-preview:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'apache' && github.event.action == 'closed' && github.pull_request.merged != true }}
+    continue-on-error: true
+    steps:
+      - name: Install action dependencies
+        run: git clone --depth=1 https://github.com/actions-cool/maintain-one-comment.git
+
+      - name: Delete PR preview comment
+        uses: ./maintain-one-comment
+        with:
+          body-include: '<!-- ECHARTS_PR_PREVIEW -->'
+          delete: true
+          number: ${{ github.event.number }}
+
+      - name: Teardown closed PR preview
+        run: |
+          export SURGE_DOMAIN='https://echarts-pr-${{ github.event.number }}.surge.sh'
+          npx surge teardown $SURGE_DOMAIN --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others


### What does this PR do?

Generate a link for directly previewing the changes in ECharts example editor.

![image](https://github.com/apache/echarts/assets/26999792/9a631df9-2740-40fc-8f62-c50e629bc280)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

- [x] Need to create and set a repository secret `SURGE_TOKEN`
- [ ] Add support for using PR build version for ECharts example editor 