### PR TITLE
chore(workflow): fix wrong env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
   teardown-preview:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'apache' && github.event.action == 'closed' && github.pull_request.merged != true }}
+    if: ${{ github.repository_owner == 'apache' && github.event.action == 'closed' && github.event.pull_request.merged != true }}
     continue-on-error: true
     steps:
       - name: Install action dependencies


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others


### What does this PR do?

Fix the wrong environment variable `github.pull_request.merged` -> `github.event.pull_request.merged` in #18803.
