### PR TITLE
fix(endLabel): endLabel fail with null data #18839

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -1300,7 +1300,7 @@ class LineView extends ChartView {
             }
             if (valueAnimation) {
                 const inner = labelInner(endLabel);
-                if (inner && typeof inner.setLabelText === 'function') {
+                if (typeof inner.setLabelText === 'function') {
                     inner.setLabelText(value);
                 }
             }

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -1299,7 +1299,10 @@ class LineView extends ChartView {
                 });
             }
             if (valueAnimation) {
-                labelInner(endLabel).setLabelText(value);
+                const inner = labelInner(endLabel);
+                if (inner && typeof inner.setLabelText === 'function') {
+                    inner.setLabelText(value);
+                }
             }
         }
     }

--- a/test/line-endLabel.html
+++ b/test/line-endLabel.html
@@ -36,7 +36,7 @@ under the License.
                 height: 1000px;
                 margin-bottom: 30px;
             }
-            #main2, #main3 {
+            #main2, #main3, #main4 {
                 width: 100%;
                 height: 300px;
                 margin-bottom: 30px;
@@ -129,6 +129,7 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
+        <div id="main4"></div>
 
         <script>
 
@@ -427,6 +428,47 @@ under the License.
                         }
                     }],
                     animationDuration: 0
+                };
+                chart.setOption(option);
+
+            })
+
+        </script>
+
+        <script>
+
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main4'));
+                var option = {
+                    title: [{
+                        text: 'endLabel should not fail with null data',
+                        textAlign: 'center',
+                        left: '50%',
+                        top: 0
+                    }],
+                    xAxis: [{
+                        data: ['a', 'b']
+                    }],
+                    yAxis: [{
+                    }],
+                    series: [{
+                        type: 'line',
+                        data: [1, 2],
+                        endLabel: {
+                            show: true
+                        }
+                    }, {
+                        type: 'line',
+                        data: [null, '-'],
+                        endLabel: {
+                            show: true
+                        }
+                    }],
+                    animationDuration: 5000
                 };
                 chart.setOption(option);
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Check `setLabelText` exists before calling.

### Fixed issues

#18839


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`endLabel` fail when data contain `null` or `'-'`.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`endLabel` not fail when data contain `null` or `'-'`.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
