### PR TITLE
fix: sometime el.parent has null value

### DIFF
--- a/src/animation/customGraphicTransition.ts
+++ b/src/animation/customGraphicTransition.ts
@@ -223,13 +223,13 @@ export function applyLeaveTransition(
             // TODO Data index?
             const config = getElementAnimationConfig('update', el, elOption, animatableModel, 0);
             config.done = () => {
-                parent.remove(el);
+                parent && parent.remove(el);
                 onRemove && onRemove();
             };
             el.animateTo(leaveToProps, config);
         }
         else {
-            parent.remove(el);
+            parent && parent.remove(el);
             onRemove && onRemove();
         }
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This PR fix unhandled exception





### Fixed issues

<!--
- applyLeaveTransition: check "parent" value and if it is not empty then run ```parent.remove(el)```
-->


## Details

### Before: What was the problem?

Description is here - https://github.com/apache/echarts/issues/18889



### After: How does it behave after the fixing?

Unhandled exception should gone.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
