### PR TITLE
fix(DataZoom): dataZoom filter stack data unexpected(#18850)

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -341,6 +341,16 @@ class AxisProxy {
                         const range: Dictionary<[number, number]> = {};
                         range[dim] = valueWindow;
 
+                        /**
+                         * @see https://github.com/apache/echarts/issues/18850
+                         * use the raw data to reset the range, in case some data are filtered because of nagetive value in stackData
+                         */
+                        seriesData.each((idx) => {
+                            const item = Number(seriesData.getRawDataItem(idx));
+                            range[dim][0] = Math.min(range[dim][0], item);
+                            range[dim][1] = Math.max(range[dim][1], item);
+                        });
+
                         // console.time('select');
                         seriesData.selectRange(range);
                         // console.timeEnd('select');


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Correct the value window before `seriesData.selectRange`. Use the raw data to recalculate the value window, only in this case.

If you think this hotfix is not safe enough, i would love to make it better.

### Fixed issues
#18850
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
When config series `{stack: 'Total', stackStrategy: 'all',}` and `toolbox.feature.dataZoom: {} `, fill series data array with some nagative and positive number (like [2, -3, -14]), the value window may smaller then the max number in series data array. This value window problem is due to `stack`. So in this case, the number beyond this inappropriate value window will be filtered.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/25790538/42ca1e29-713b-4ced-bd4f-8f826b8d66a5)



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
All data show up in right way.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/25790538/bc271740-d364-40da-9015-f99dd1b5e200)



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
