### PR TITLE
fix(type): add `undefined` to the return type of `graphic.clipRectByRect` function

### DIFF
--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -446,7 +446,7 @@ export function clipPointsByRect(points: vector.VectorArray[], rect: ZRRectLike)
 /**
  * Return a new clipped rect. If rect size are negative, return undefined.
  */
-export function clipRectByRect(targetRect: ZRRectLike, rect: ZRRectLike): ZRRectLike {
+export function clipRectByRect(targetRect: ZRRectLike, rect: ZRRectLike): ZRRectLike | undefined {
     const x = mathMax(targetRect.x, rect.x);
     const x2 = mathMin(targetRect.x + targetRect.width, rect.x + rect.width);
     const y = mathMax(targetRect.y, rect.y);


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Add `| undefined` to return type of `graphic.clipRectByRect`.



### Fixed issues

## Details

### Before: What was the problem?

`graphic.clipRectByRect` can return undefined, but this is not reflected in it's type signature.



### After: How does it behave after the fixing?

`graphic.clipRectByRect` has `undefined` as a possible return type.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
