### PR TITLE
feat(dataZoom): allow customizing `borderRadius` of the move handle

### DIFF
--- a/src/component/dataZoom/SliderZoomModel.ts
+++ b/src/component/dataZoom/SliderZoomModel.ts
@@ -28,6 +28,10 @@ import {
 } from '../../util/types';
 import { inheritDefaultOption } from '../../util/component';
 
+type MoveHandleStyle = ItemStyleOption & {
+    borderRadius?: number | number[]
+};
+
 export interface SliderDataZoomOption extends DataZoomOption, BoxLayoutOptionMixin {
 
     show?: boolean
@@ -91,7 +95,7 @@ export interface SliderDataZoomOption extends DataZoomOption, BoxLayoutOptionMix
      * Icon to indicate it is a draggable panel.
      */
     moveHandleIcon?: string
-    moveHandleStyle?: ItemStyleOption
+    moveHandleStyle?: MoveHandleStyle
     /**
      * Height of handle rect. Can be a percent string relative to the slider height.
      */
@@ -110,7 +114,7 @@ export interface SliderDataZoomOption extends DataZoomOption, BoxLayoutOptionMix
     textStyle?: LabelOption
 
     /**
-     * If eable select by brushing
+     * If enable select by brushing
      */
     brushSelect?: boolean
 
@@ -118,7 +122,7 @@ export interface SliderDataZoomOption extends DataZoomOption, BoxLayoutOptionMix
 
     emphasis?: {
         handleStyle?: ItemStyleOption
-        moveHandleStyle?: ItemStyleOption
+        moveHandleStyle?: MoveHandleStyle
     }
 }
 
@@ -183,7 +187,8 @@ class SliderZoomModel extends DataZoomModel<SliderDataZoomOption> {
         moveHandleIcon: 'path://M-320.9-50L-320.9-50c18.1,0,27.1,9,27.1,27.1V85.7c0,18.1-9,27.1-27.1,27.1l0,0c-18.1,0-27.1-9-27.1-27.1V-22.9C-348-41-339-50-320.9-50z M-212.3-50L-212.3-50c18.1,0,27.1,9,27.1,27.1V85.7c0,18.1-9,27.1-27.1,27.1l0,0c-18.1,0-27.1-9-27.1-27.1V-22.9C-239.4-41-230.4-50-212.3-50z M-103.7-50L-103.7-50c18.1,0,27.1,9,27.1,27.1V85.7c0,18.1-9,27.1-27.1,27.1l0,0c-18.1,0-27.1-9-27.1-27.1V-22.9C-130.9-41-121.8-50-103.7-50z',
         moveHandleStyle: {
             color: '#D2DBEE',
-            opacity: 0.7
+            opacity: 0.7,
+            borderRadius: [0, 0, 2, 2]
         },
 
         showDetail: true,

--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -788,7 +788,9 @@ class SliderZoomView extends DataZoomView {
                 x: segIntervals[i],
                 y: 0,
                 width: segIntervals[i + 1] - segIntervals[i],
-                height: size[1]
+                height: size[1],
+                // prevent shadow from overflow when `borderRadius` is set
+                r: this.dataZoomModel.get('borderRadius') || 0
             });
         }
 

--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -603,7 +603,8 @@ class SliderZoomView extends DataZoomView {
             this._handleHeight = parsePercent(handleSize, this._size[1]);
             this._handleWidth = bRect.width / bRect.height * this._handleHeight;
 
-            path.setStyle(dataZoomModel.getModel('handleStyle').getItemStyle());
+            const handleStyleModel = dataZoomModel.getModel('handleStyle');
+            path.setStyle(handleStyleModel.getItemStyle());
             path.style.strokeNoScale = true;
             path.rectHover = true;
 
@@ -611,7 +612,7 @@ class SliderZoomView extends DataZoomView {
             enableHoverEmphasis(path);
 
             const handleColor = dataZoomModel.get('handleColor' as any); // deprecated option
-            // Compatitable with previous version
+            // Compatible with previous version
             if (handleColor != null) {
                 path.style.fill = handleColor;
             }
@@ -640,11 +641,12 @@ class SliderZoomView extends DataZoomView {
         let actualMoveZone: Displayable = filler;
         if (brushSelect) {
             const moveHandleHeight = parsePercent(dataZoomModel.get('moveHandleSize'), size[1]);
+            const moveHandleStyleModel = dataZoomModel.getModel('moveHandleStyle');
             const moveHandle = displayables.moveHandle = new graphic.Rect({
-                style: dataZoomModel.getModel('moveHandleStyle').getItemStyle(),
+                style: moveHandleStyleModel.getItemStyle(),
                 silent: true,
                 shape: {
-                    r: [0, 0, 2, 2],
+                    r: moveHandleStyleModel.get('borderRadius'),
                     y: size[1] - 0.5,
                     height: moveHandleHeight
                 }
@@ -659,9 +661,15 @@ class SliderZoomView extends DataZoomView {
             moveHandleIcon.silent = true;
             moveHandleIcon.y = size[1] + moveHandleHeight / 2 - 0.5;
 
-            moveHandle.ensureState('emphasis').style = dataZoomModel.getModel(
-                ['emphasis', 'moveHandleStyle']
-            ).getItemStyle();
+            const moveHandleEmphasisStyle = dataZoomModel.getModel(['emphasis', 'moveHandleStyle']);
+            const moveHandleEmphasisState = moveHandle.ensureState('emphasis');
+            moveHandleEmphasisState.style = moveHandleEmphasisStyle.getItemStyle();
+            const moveHandleEmphasisBorderRadius = moveHandleEmphasisStyle.get('borderRadius');
+            if (moveHandleEmphasisBorderRadius != null) {
+                moveHandleEmphasisState.shape = {
+                    r: moveHandleEmphasisBorderRadius
+                };
+            }
 
             const moveZoneExpandSize = Math.min(size[1] / 2, Math.max(moveHandleHeight, 10));
             actualMoveZone = displayables.moveZone = new graphic.Rect({

--- a/test/dataZoom-clip.html
+++ b/test/dataZoom-clip.html
@@ -96,7 +96,17 @@ under the License.
                         type: 'slider',
                         filterMode: 'none',
                         start: 5,
-                        end: 40
+                        end: 40,
+                        borderRadius: 20,
+                        moveHandleSize: 14,
+                        moveHandleStyle: {
+                            borderRadius: 8
+                        },
+                        emphasis: {
+                            moveHandleStyle: {
+                                borderRadius: 0
+                            }
+                        }
                     }],
                     series: [{
                         type: 'line',


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

1. Add a new option `borderRadius` for `moveHandleStyle` to allow customizing the border radius of the move handle

2. Fix a bug that the datazoom shadow may overflow when `borderRadius` is set.

| [Before](https://echarts.apache.org/examples/editor.html?c=area-simple&code=DYUwLgBARghgziCBeCBqAdiA7hAIjMEACgEYBOANgA4AaCMugZgEoBuAKFEgHtN8BPZBABMAFggAqCIwoAGWZIgl5sjlwgATAohQBtALprwmgjCG6AsgQAWAOgBOMdBu4BbIs0WN5h9gDNuewgidQBLIRJWCHCAHhEVVWjUVE8Ab3YICAA3GCD0bhwUTBx8QiIiWAQ0FF4QAWY2DJNCWwAHAFc4ayJdfKxbAHNwADF24GAATRBcjzo-wfALXjBuz1QlOYKFsFLiZn1bACtuUPQiAHIAenOGjkytMBg2zu6rFYdududyt7tHZzcHggAFoILJbABWTxSYQKdYPGC6cKgkj6W7sAC-7G4rTAoV4QnSmTA3G4wDxrQAXBAiZkIGB7KEBkN7NTzjAAB6hODnGhNTKtbhwUJ43jUvxfADGovQwVxaX5dPs4Ha9llulxulk-jo52UAFJzr46RAsZkMXziSLQNTaZlQH4wGzJSB0IR7LzFYQOU6IOcADK5IYQACCyrMAGFrLkwOcmhamiSyVBuBzbYq_NMwKqQOmTfdTAAtUmuPP5zL8ENcuAASWcIDTfvymDj5YT5eVcBJytt7fzcBgWRAIdrrhgQ17irNpstEA5Ve5ZeJ_Faub9ku0A0C_E9JpTXy09n4AHEYFSIH4YMAELOC49qQ8QPHZ5Xq0v6Su1-ccsB2iBd3S-7OLkJ5ntSWq6sosiGvoz5NAixZuOBip2nSXYxtSsK3nSroaNS3jYZklyXBAXQwC4ODcEO9h-MABRwIqmQpvYGggPYABK5GhJ0mGyIRzQwAAQjAkoANYDPYnzOO-Jq5NMADKYD8DaNKMfmkpkoEzr8E4rblqaanTuaTQ6k0CCMiAcDISaqGZOgMCuF-wwwKJiClDAAEmkpq5ssApz_vxcD8K4KbAGyzYBWpA6uK0fnoAMvlgGAUCeXSIogK4inKWutl0hpdGsn69gDFARDCBCEJ0AA7HxSiMCQzB6SafayeGWUqblmT5VpEDFBAICStG9hgHAgyOK01ihJKtj-v5uTHo4GihK6YBELV610CQdC6GpNm7fm3B-H4CC-nx-0mt1hXnMVpXlZVSgQrQEDUI150zm9nUHUdJ3Ultb1dZpV03WVFXVbVJD1a9-l0kZ-ZooZ_EIg-phTiZmKsEAA) | [After](https://echarts.apache.org/examples/editor.html?c=area-simple&code=DYUwLgBARghgziCBeCBqAdiA7hAIjMEACgEYBOANgA4AaCMugZgEoBuAKFEgHtN8BPZBABMAFggAqCIwoAGWZIgl5sjlwgATAohQBtALprwmgjCG6AsgQAWAOgBOMdBu4BbIs0WN5h9gDNuewgidQBLIRJWCHCAHhEVVWjUVE8Ab3YICAA3GCD0bhwUTBx8QiIiWAQ0FF4QAWY2DJNCWwAHAFc4ayJdfKxbAHNwADF24GAATRBcjzo-wfALXjBuz1QlOYKFsFLiZn1bACtuUPQiAHIAenOGjkytMBg2zu6rFYdududyt7tHZzcHggAFoILJbABWTxSYQKdYPGC6cKgkj6W7sAC-7G4rTAoV4QnSmTA3G4wDxrQAXBAiZkIGB7KEBkN7NTzjAAB6hODnGhNTKtbhwUJ43jUvxfADGovQwVxaX5dPs4Ha9llulxulk-jo52UAFJzr46RAsZkMXziSLQNTaZlQH4wGzJSB0IR7LzFYQOU6IOcADK5IYQACCyrMAGFrLkwOcmhamiSyVBuBzbYq_NMwKqQOmTfdTAAtUmuPP5zL8ENcuAASWcIDTfvymDj5YT5eVcBJytt7fzcBgWRAIdrrhgQ17irNpstEA5Ve5ZeJ_Faub9ku0A0C_E9JpTXy09n4AHEYFSIH4YMAELOC49qQ8QPHZ5Xq0v6Su1-ccsB2iBd3S-7OLkJ5ntSWq6sosiGvoz5NAixZuOBip2nSXYxtSsK3nSroaNS3jYZklyXBAXQwC4ODcEO9h-MABRwIqmQpvYGggPYABK5GhJ0mGyIRzQwAAQjAkoANYDPYnzOO-Jq5NMADKYD8DaNKMfmkpkoEzr8E4rblqaanTuaTQ6k0CCMiAcDISaqGZOgMCuF-wwwKJiClDAAEmkpq5ssApz_vxcD8K4KbAGyzYBWpA6uK0fnoAMvlgGAUCeXSIogK4inKWutl0hpdGsn69gDFARDCBCEJ0AA7HxSiMCQzB6SafayeGWUqblmT5VpEDFBAICStG9hgHAgyOK01ihJKtj-v5uTHo4GihK6YBELV610CQdC6GpNm7fm3B-H4CC-nx-0mt1hXnMVpXlZVSgQrQEDUI150zm9nUHUdJ3Ultb1dZpV03WVFXVbVJD1a9-l0kZ-ZooZ_EIg-phTiZmKsEAA&version=PR-18959) |
| :----: | :----: |
| ![](https://github.com/apache/echarts/assets/26999792/fae69cc4-0704-41ee-a3b2-c305cb901ec5) | |

### Fixed issues

- Resolves #18958

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the above demos or `test/dataZoom-clip.html`.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
