### PR TITLE
feat(legend): add itemGap control in different direction

### DIFF
--- a/src/component/legend/LegendModel.ts
+++ b/src/component/legend/LegendModel.ts
@@ -185,7 +185,7 @@ export interface LegendOption extends ComponentOption, LegendStyleOption,
      * Gap between each legend item.
      * @default 10
      */
-    itemGap?: number
+    itemGap?: number | number[]
     /**
      * Width of legend symbol
      */

--- a/src/component/legend/ScrollableLegendView.ts
+++ b/src/component/legend/ScrollableLegendView.ts
@@ -276,8 +276,14 @@ class ScrollableLegendView extends LegendView {
         // Layout container group based on 0.
         const containerPos = [0, 0];
         const controllerPos = [-controllerRect.x, -controllerRect.y];
+        const direction = legendModel.get('orient', true);
+
+        const itemGapList = layoutUtil.normalizeGap(legendModel.get('itemGap', true));
+        const itemGap = direction === 'horizontal' ? itemGapList[0] : itemGapList[1];
+
+
         const pageButtonGap = zrUtil.retrieve2(
-            legendModel.get('pageButtonGap', true), legendModel.get('itemGap', true)
+            legendModel.get('pageButtonGap', true), itemGap
         );
 
         // Place containerGroup and controllerGroup and contentGroup.

--- a/src/util/layout.ts
+++ b/src/util/layout.ts
@@ -54,15 +54,30 @@ export const HV_NAMES = [
     ['height', 'top', 'bottom']
 ] as const;
 
+export function normalizeGap(gap: number | number[]): [number, number] {
+    let gapList = gap;
+
+    if (typeof gapList === 'number') {
+        gapList = [gapList, gapList];
+    }
+    else if (gapList.length <= 1) {
+        gapList = [gapList[0] ?? 0, gapList[1] ?? 0];
+    }
+
+    return [gapList[0], gapList[1]];
+}
+
 function boxLayout(
     orient: 'horizontal' | 'vertical',
     group: Group,
-    gap: number,
+    gap: number | number[],
     maxWidth?: number,
     maxHeight?: number
 ) {
     let x = 0;
     let y = 0;
+
+    const gapList = normalizeGap(gap);
 
     if (maxWidth == null) {
         maxWidth = Infinity;
@@ -87,7 +102,7 @@ function boxLayout(
             if (nextX > maxWidth || (child as NewlineElement).newline) {
                 x = 0;
                 nextX = moveX;
-                y += currentLineMaxSize + gap;
+                y += currentLineMaxSize + gapList[1];
                 currentLineMaxSize = rect.height;
             }
             else {
@@ -100,7 +115,7 @@ function boxLayout(
             nextY = y + moveY;
             // Wrap when width exceeds maxHeight or meet a `newline` group
             if (nextY > maxHeight || (child as NewlineElement).newline) {
-                x += currentLineMaxSize + gap;
+                x += currentLineMaxSize + gapList[0];
                 y = 0;
                 nextY = moveY;
                 currentLineMaxSize = rect.width;
@@ -119,8 +134,8 @@ function boxLayout(
         child.markRedraw();
 
         orient === 'horizontal'
-            ? (x = nextX + gap)
-            : (y = nextY + gap);
+            ? (x = nextX + gapList[0])
+            : (y = nextY + gapList[1]);
     });
 }
 

--- a/test/legend-item-gap.html
+++ b/test/legend-item-gap.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <!-- <script src="ut/lib/canteen.js"></script> -->
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+    </style>
+
+
+
+    <div id="main0"></div>
+    <div id="main1"></div>
+    <div id="main2"></div>
+
+
+
+    <script>
+        const dataset = [["Forest", 320, 332, 301, 334, 390],
+        ["Steppe", 220, 182, 191, 234, 290],
+        ["Desert", 150, 232, 201, 154, 190],
+        ["Wetland", 98, 77, 101, 99, 40],
+        ["AAAAAAA", 98, 77, 101, 99, 40],
+        ["BBBBBBB", 98, 77, 101, 99, 40],
+        ["CCCCCCC", 98, 77, 101, 99, 40],
+        ["DDDDDDD", 98, 77, 101, 99, 40],
+        ["EEEEEEE", 98, 77, 101, 99, 40],
+        ["FFFFFFF", 98, 77, 101, 99, 40],
+        ["GGGGGGG", 98, 77, 101, 99, 40],
+        ["HHHHHHH", 98, 77, 101, 99, 40],
+        ["IIIIIII", 98, 77, 101, 99, 40],
+        ["JJJJJJJ", 98, 77, 101, 99, 40],
+        ["KKKKKKK", 98, 77, 101, 99, 40],
+        ["LLLLLLL", 98, 77, 101, 99, 40],
+        ["MMMMMMM", 98, 77, 101, 99, 40],
+        ["NNNNNNN", 98, 77, 101, 99, 40],
+        ["OOOOOOO", 98, 77, 101, 99, 40],
+        ["PPPPPPP", 98, 77, 101, 99, 40],
+        ["QQQQQQQ", 98, 77, 101, 99, 40],
+        ["RRRRRRR", 98, 77, 101, 99, 40],
+        ["SSSSSSS", 98, 77, 101, 99, 40],
+        ["TTTTTTT", 98, 77, 101, 99, 40]];
+        function createMultiSeries(count = 20) {
+            const rst = [];
+
+            for (let i = 0; i < count; i++) {
+                rst.push({
+                    type: "bar",
+                    seriesLayoutBy: "row"
+                })
+            }
+
+            return rst;
+        }
+    </script>
+
+
+    <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                dataset: {
+                    source: dataset
+                },
+                legend: {
+                    orient: 'horizontal',
+                    itemGap: 40,
+                },
+                xAxis: {
+                    type: "category"
+                },
+                yAxis: {},
+                series: createMultiSeries(),
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'single number item gap in legend',
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+    </script>
+
+
+    <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                dataset: {
+                    source: dataset
+                },
+                legend: {
+                    orient: 'horizontal',
+                    itemGap: [50, 10],
+                },
+                xAxis: {
+                    type: "category"
+                },
+                yAxis: {},
+                series: createMultiSeries(),
+            };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'array item gap in legend',
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+    </script>
+
+
+    <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                dataset: {
+                    source: dataset
+                },
+                legend: {
+                    orient: 'vertical',
+                    itemGap: [50, 20],
+                    left: 0,
+                },
+                xAxis: {
+                    type: "category"
+                },
+                yAxis: {},
+                series: createMultiSeries(),
+            };
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: [
+                    'array item gap in legend',
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/test/runTest/actions/__meta__.json
+++ b/test/runTest/actions/__meta__.json
@@ -122,6 +122,7 @@
   "label-position": 1,
   "largeLine-tooltip": 1,
   "legend": 11,
+  "legend-item-gap": 3,
   "legend-visualMapColor": 2,
   "line": 1,
   "line-animation": 1,

--- a/test/runTest/actions/legend-item-gap.json
+++ b/test/runTest/actions/legend-item-gap.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"screenshot","time":1329}],"scrollY":0,"scrollX":0,"timestamp":1691584053555},{"name":"Action 2","ops":[{"type":"screenshot","time":719}],"scrollY":413,"scrollX":0,"timestamp":1691584060865},{"name":"Action 3","ops":[{"type":"screenshot","time":737}],"scrollY":790.5,"scrollX":0,"timestamp":1691584065163}]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

make legend item gap has different gap distance in different direction.

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

- resolve https://github.com/apache/echarts/issues/18967

## Details

|| Before| [After](https://echarts.apache.org/examples/zh/editor.html?version=PR-18977%40b17d490&code=PYBwLglsB2AEC8sDeAoWsAmBDMWDOApmAFzJrqx7ACuATgMYGkDa5FszARGAJ4gGcANLE4AmAAwBGUUJETJAZllipAFmXyArBqkA2TgF1BbClwBiwWgTxhZCicIX3HUxwtWOAnOKMn0XAGUwAhB-WVEHWEkADlFhSU9JYVF3ZO9fdn9OABFrAlpbeM1xZOdYeSKPKPTjTI5OAHUiABssaAxZT2jhAHYe-NdYT09hVR9auq4AQRnZqc7u2D6BpKGR2DGMuvqAIT39nYXe_qjB4dHxv3YuAGE7-5ujpZPJM_XNie2ubJ_f7KflqdVucNpdtlkAKJQ6EQgEvN4XLZfThmVFosxwlbCEEfK6mTgAcSJxIJmKB2PeYPBXAAEnT6TSya9gZSkZNOABJLncjlMhGgtmZLgAKVFYuFfJZiM-7IA0vKFbLJRTpSYDOQAL4TZoEADmBHapFQ7EsEANJFgAHIABamgBeMFwzUtwhMEGCAFsCVgQCxiskqVryAAPKbBiB4I0mXj8Uiceg4PWWHicTUTHhhiNGoPoQi0M2RjjGigxpgiABGWFoQhMeYLABksDwaGAdjw47RgAB3VPoLVkdiluOV6syuvWRvN6it9siTs9tMDkt8MucEc19jjvCTlttjvd3uwfvF9BDitVjcULc76d7ucHtMn2BntcXsf5BtN3ezzjzw9ap8X3Xd98wnL9bx_P9H2jFdhzfWsPzAqcZ33Bc-0EQDYPPUcENA7dwJQ-80KPDCYNjbDL1zRD8OQu9fwfdDMPI18cM3aib0I-jiIAsjV2A3DP1oyCGJIpi-Pgti8I4uioMY3i4NYq92IImSRJ4wcsJYyjKGUoTUP_UiNOY_jJME799LTchyHVDUgA)|
|----|----|----|
|desc|ItemGap is number type, set this value will make gap distance both vertical and horizontal.|We can use an array to control the horizontal and vertical distances separately, which is compatible with the previous way of using a single value to control the distances at the same time.|
|<img width="431" alt="image" src="https://github.com/apache/echarts/assets/56526981/b8fafd8f-eb93-42dc-a70f-d864d17b116a">|<img width="788" alt="image" src="https://github.com/apache/echarts/assets/56526981/060816ca-63a9-43d0-9e2d-ae0fb67630a0">|<img width="788" alt="image" src="https://github.com/apache/echarts/assets/56526981/060816ca-63a9-43d0-9e2d-ae0fb67630a0">|
|<img width="538" alt="image" src="https://github.com/apache/echarts/assets/56526981/8ec9ba95-6bf4-43e9-9c4c-bcb3c8a9b633">|-|<img width="845" alt="image" src="https://github.com/apache/echarts/assets/56526981/00b11aa1-a59d-43ff-9d48-cb862a447cbc">|


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
