### PR TITLE
fix(clip): add an extra space to the clip-path width to prevent unexpected clip. close #19051

### DIFF
--- a/src/chart/helper/createClipPathFromCoordSys.ts
+++ b/src/chart/helper/createClipPathFromCoordSys.ts
@@ -51,8 +51,12 @@ function createGridClipPath(
     height += lineWidth;
 
     // fix: https://github.com/apache/incubator-echarts/issues/11369
-    x = Math.floor(x);
-    width = Math.round(width);
+    width = Math.ceil(width);
+    if (x !== Math.floor(x)) {
+        x = Math.floor(x);
+        // if no extra 1px on `width`, it will still be clipped since `x` is floored
+        width++;
+    }
 
     const clipPath = new graphic.Rect({
         shape: {

--- a/test/clip-line-cap.html
+++ b/test/clip-line-cap.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option;
+
+            option = {
+                grid: {
+                    width: 503,
+                    height: 400,
+                },
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    boundaryGap: false,
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        data: [150, 230, 224, 218, 135, 147, 152],
+                        type: 'line',
+                        showSymbol: false,
+                        lineStyle: {
+                            width: 4,
+                            cap: 'round',
+                        },
+                    },
+                ],
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Should Not Clip The Rightmost Cap of The Line'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add an extra space to the clip-path `width`. This will prevent the unexpected clip.

### Fixed issues

- #19051


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

As the example https://codepen.io/rexskz/pen/WNLweyw shows, the rightmost position of the line that has `cap: 'round'` is clipped incorrectly, while the leftmost part is okay.

<img width="458" alt="image" src="https://github.com/apache/echarts/assets/27483702/b8a17de7-b83a-466d-a401-82e1639ea936">

This issue only happens on the device with `devicePixelRatio >= 3`, and the chart canvas must have a special width.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The rightmost position of the line should not be clipped.

<img width="563" alt="image" src="https://github.com/apache/echarts/assets/27483702/0b7ab4b8-b3a3-44e7-9a77-1449285455f2">

This is caused by a round-off error.

Let's see if the rect is:

```js
x = 80.8;      // float
y = 100;
width = 500.4; // float
height = 100;
// x + width = 581.2
```

Browsers will render the clip-path using `rect` but handle the value as integers, so the original code converts `x` and `width` to integers:

```js
x = Math.floor(x);         // 80
width = Math.round(width); // 500
// x + width = 580
```

The result is 1.2 less, meaning the graph's rightmost `1.2px` will be clipped.

To make sure the clip-path wraps the whole graph, the `x` should keep floored, but the `width` should be ceiled (not rounded), and if `x` is floored, `width` should be add an extra `1px`.

P.S. During the visual test, I found that some cases may also be clipped incorrectly before, and will be corrected in this PR, for example:

<img width="1252" alt="image" src="https://github.com/apache/echarts/assets/27483702/f0bc2bfb-2697-4664-bd29-62f1c9e00f57">

<img width="1270" alt="image" src="https://github.com/apache/echarts/assets/27483702/8140270a-c29d-4e50-93c7-c63cefd96000">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
