### PR TITLE
feat(type): export `EChartsInitOpts` and more types for `echarts/core`

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -318,7 +318,7 @@ type ECEventDefinition = {
     // TODO: Use ECActionEvent
     [key: string]: (...args: unknown[]) => void | boolean
 };
-type EChartsInitOpts = {
+export type EChartsInitOpts = {
     locale?: string | LocaleOption,
     renderer?: RendererType,
     devicePixelRatio?: number,

--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -25,16 +25,24 @@ import { use } from '../extension';
 
 // Import label layout by default.
 // TODO will be treeshaked.
-import {installLabelLayout} from '../label/installLabelLayout';
+import { installLabelLayout } from '../label/installLabelLayout';
 use(installLabelLayout);
 
 
 // Export necessary types
-export {ZRColor as Color, Payload, ECElementEvent} from '../util/types';
-export {LinearGradientObject} from 'zrender/src/graphic/LinearGradient';
-export {RadialGradientObject} from 'zrender/src/graphic/RadialGradient';
-export {PatternObject, ImagePatternObject, SVGPatternObject} from 'zrender/src/graphic/Pattern';
-export {ElementEvent} from 'zrender/src/Element';
+export {
+    ZRColor as Color,
+    Payload,
+    ECElementEvent,
+    HighlightPayload,
+    DownplayPayload,
+    SelectChangedPayload
+} from '../util/types';
+export { LinearGradientObject } from 'zrender/src/graphic/LinearGradient';
+export { RadialGradientObject } from 'zrender/src/graphic/RadialGradient';
+export { PatternObject, ImagePatternObject, SVGPatternObject } from 'zrender/src/graphic/Pattern';
+export { ElementEvent } from 'zrender/src/Element';
+export * from './option';
 
 // ComposeOption
 import type { ComponentOption, ECBasicOption as EChartsCoreOption } from '../util/types';
@@ -45,9 +53,9 @@ import type { AngleAxisOption, RadiusAxisOption } from '../coord/polar/AxisModel
 import type { ParallelAxisOption } from '../coord/parallel/AxisModel';
 
 
-export {EChartsType as ECharts} from '../core/echarts';
+export { EChartsType as ECharts } from '../core/echarts';
 
-export {EChartsCoreOption};
+export { EChartsCoreOption };
 
 // type SeriesSubComponentsTypes = 'markPoint' | 'markLine' | 'markArea' | 'tooltip';
 // type InjectSeriesSubComponents<OptionUnion extends ComponentOption, Injected> =
@@ -92,16 +100,16 @@ type ComposeUnitOption<OptionUnion extends ComponentOption> =
     Omit<EChartsCoreOption, 'baseOption' | 'options'> & {
         [key in GetMainType<OptionUnion>]?: Arrayable<
             ExtractComponentOption<OptionUnion, key>
-            // TODO: It will make error log too complex.
-            // So this more strict type checking will not be used currently to make sure the error msg is friendly.
-            //
-            // Inject markPoint, markLine, markArea, tooltip in series.
-            // ExtractComponentOption<
-            //     InjectSeriesSubComponents<
-            //         OptionUnion, GetSeriesInjectedSubOption<GetMainType<OptionUnion>, OptionUnion>
-            //     >,
-            //     key
-            // >
+        // TODO: It will make error log too complex.
+        // So this more strict type checking will not be used currently to make sure the error msg is friendly.
+        //
+        // Inject markPoint, markLine, markArea, tooltip in series.
+        // ExtractComponentOption<
+        //     InjectSeriesSubComponents<
+        //         OptionUnion, GetSeriesInjectedSubOption<GetMainType<OptionUnion>, OptionUnion>
+        //     >,
+        //     key
+        // >
         >
     } & GetDependencies<GetMainType<OptionUnion>>;
 

--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -42,7 +42,6 @@ export { LinearGradientObject } from 'zrender/src/graphic/LinearGradient';
 export { RadialGradientObject } from 'zrender/src/graphic/RadialGradient';
 export { PatternObject, ImagePatternObject, SVGPatternObject } from 'zrender/src/graphic/Pattern';
 export { ElementEvent } from 'zrender/src/Element';
-export * from './option';
 
 // ComposeOption
 import type { ComponentOption, ECBasicOption as EChartsCoreOption } from '../util/types';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

Add missing types

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others


### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Expose useful types, so it can be imported via `echarts`

### Fixed issues

<!--
- #xxxx: ...
-->
#19003 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

In order to import types that not publicly expose via `echarts`, the current behaviour is something like this 

```
import { SelectChangedPayload } from 'echarts/types/src/util/types'
```

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

After the change, users could import type in a correct way:

```
import { SelectChangedPayload } from 'echarts'
```


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
