### PR TITLE
Add nullables to OptionDataValue

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -637,7 +637,7 @@ export interface GraphEdgeItemObject<
      */
     target?: string | number
 }
-export type OptionDataValue = string | number | Date;
+export type OptionDataValue = string | number | Date | null | undefined;
 
 export type OptionDataValueNumeric = number | '-';
 export type OptionDataValueCategory = string;


### PR DESCRIPTION
FYI, as per the [doc](https://echarts.apache.org/en/option.html#series-heatmap.data) null and undefined values are accepted in `series.data`. But the types do not allow it.

>Empty value: 
'-' or null or undefined or NaN can be used to describe that a data item does not exist (ps：not exist does not means its value is 0).
For example, line chart can break when encounter an empty value, and scatter chart do not display graphic elements for empty values.

This is  mostly a FYI PR, haven't done any dues on how this will affect the rest of the types. Tests etc.