### PR TITLE
bug(label): hide labelLine on emphasis when emphasis.labelLine.show is false. close #19160

### DIFF
--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -593,6 +593,7 @@ export function setLabelLineStyle(
     defaultStyle?: Polyline['style']
 ) {
     let labelLine = targetEl.getTextGuideLine();
+    labelLine && labelLine.ensureState('emphasis');
     const label = targetEl.getTextContent();
     if (!label) {
         // Not show label line if there is no label.
@@ -627,6 +628,7 @@ export function setLabelLineStyle(
             // Create labelLine if not exists
             if (!labelLine) {
                 labelLine = new Polyline();
+                labelLine.ensureState('emphasis');
                 targetEl.setTextGuideLine(labelLine);
                 // Reset state of normal because it's new created.
                 // NOTE: NORMAL should always been the first!

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -53,6 +53,7 @@ under the License.
         <div id="main10"></div>
         <div id="main11"></div>
         <div id="main12"></div>
+        <div id="main13"></div>
 
         <script>
 
@@ -1016,6 +1017,56 @@ under the License.
                     ],
                     height: 300,
                     option: option
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    series: [
+                        {
+                            name: "Access From",
+                            type: "pie",
+                            radius: "50%",
+                            labelLine: {
+                                length: 60,
+                                lineStyle: {
+                                    width: 10
+                                }
+                            },
+                            emphasis: {
+                                labelLine: {
+                                    show: false
+                                }
+                            },
+                            data: [
+                                { value: 1048, name: "Search Engine" },
+                                { value: 735, name: "Direct" },
+                                { value: 580, name: "Email" },
+                                { value: 484, name: "Union Ads" },
+                                { value: 300, name: "Video Ads" },
+                                { value: 500, name: "Spam" },
+                                { value: 520, name: "Fake Ads" },
+                                { value: 200, name: "Indirect" },
+                            ],
+                        },
+                    ],
+                };
+
+                var chart = testHelper.create(echarts, 'main13', {
+                    title: [
+                        'Highlighted item labelLine should hide when emphasis.labelLine.show is false',
+                    ],
+                    height: 300,
+                    option
+                });
+
+                chart.dispatchAction({
+                    type: 'highlight',
+                    dataIndex: [0, 1, 2, 3, 4, 5]
                 });
             });
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Enables hiding of `labelLine` on emphasis when `emphasis.labelLine.show` is `false`.



### Fixed issues

- #19160 


## Details

### Before: What was the problem?

In pie and line charts, when `emphasis.labelLine.show` was set to `false`, the labelLine didn't disappear on emphasis. This was because the `emphasis` state didn't exist for labelLine. A similar issue (#16539) was fixed, but the labelLine could be hidden only if `emphasis.labelLine.show` was set to `true` and then reset to `false`. If this option was initially set to `false`, it didn't work.



### After: How does it behave after the fixing?

Now, the emphasis state is ensured for labelLine, which means that labelLine can now be hidden on emphasis if `emphasis.labelLine.show` is set to `false`.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


