### PR TITLE
fix(sunburst): label rotation problem when anticlockwise

### DIFF
--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -20,7 +20,7 @@
 import * as zrUtil from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import { toggleHoverEmphasis, SPECIAL_STATES, DISPLAY_STATES } from '../../util/states';
-import {createTextStyle} from '../../label/labelStyle';
+import { createTextStyle } from '../../label/labelStyle';
 import { TreeNode } from '../../data/Tree';
 import SunburstSeriesModel, { SunburstSeriesNodeItemOption, SunburstSeriesOption } from './SunburstSeries';
 import GlobalModel from '../../model/Global';
@@ -29,7 +29,7 @@ import { ColorString } from '../../util/types';
 import Model from '../../model/Model';
 import { getECData } from '../../util/innerStore';
 import { getSectorCornerRadius } from '../helper/sectorHelper';
-import {createOrUpdatePatternFromDecal} from '../../util/decal';
+import { createOrUpdatePatternFromDecal } from '../../util/decal';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { saveOldStyle } from '../../animation/basicTransition';
 import { normalizeRadian } from 'zrender/src/contain/util';
@@ -153,8 +153,8 @@ class SunburstPiece extends graphic.Sector {
 
         const focusOrIndices =
             focus === 'ancestor' ? node.getAncestorsIndices()
-            : focus === 'descendant' ? node.getDescendantIndices()
-            : focus;
+                : focus === 'descendant' ? node.getDescendantIndices()
+                    : focus;
 
         toggleHoverEmphasis(this, focusOrIndices, emphasisModel.get('blurScope'), emphasisModel.get('disabled'));
     }
@@ -217,7 +217,12 @@ class SunburstPiece extends graphic.Sector {
             let textAlign = getLabelAttr(labelStateModel, 'align');
             if (labelPosition === 'outside') {
                 r = layout.r + labelPadding;
-                textAlign = midAngle > Math.PI / 2 ? 'right' : 'left';
+                if (layout.clockwise) {
+                    textAlign = midAngle > Math.PI / 2 ? 'right' : 'left';
+                }
+                else {
+                    textAlign = midAngle > -Math.PI * 3 / 2 ? 'right' : 'left';
+                }
             }
             else {
                 if (!textAlign || textAlign === 'center') {
@@ -232,14 +237,28 @@ class SunburstPiece extends graphic.Sector {
                 }
                 else if (textAlign === 'left') {
                     r = layout.r0 + labelPadding;
-                    if (midAngle > Math.PI / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
-                        textAlign = 'right';
+                    if (layout.clockwise) {
+                        if (midAngle > Math.PI / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
+                            textAlign = 'right';
+                        }
+                    }
+                    else {
+                        if (midAngle > -Math.PI * 3 / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
+                            textAlign = 'right';
+                        }
                     }
                 }
                 else if (textAlign === 'right') {
                     r = layout.r - labelPadding;
-                    if (midAngle > Math.PI / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
-                        textAlign = 'left';
+                    if (layout.clockwise) {
+                        if (midAngle > Math.PI / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
+                            textAlign = 'left';
+                        }
+                    }
+                    else {
+                        if (midAngle > -Math.PI * 3 / 2 && !isRadianAroundZero(midAngle - Math.PI / 2)) {
+                            textAlign = 'left';
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ √] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
This pr is used to fix a bug in the sunburst map where the lable position is incorrect when loaded counterclockwise


### Fixed issues
[Bug] When the sunburst is anticlockwise, the leaf node text displays the problem externally #19050
[https://github.com/apache/echarts/issues/19050](url)

### Before: What was the problem?
<img width="690" alt="屏幕截图 2023-10-06 164717" src="https://github.com/apache/echarts/assets/143710553/83cd1489-ce00-4a88-8fdc-38512f1ebedd">

### After: How does it behave after the fixing?


<img width="697" alt="屏幕截图 2023-10-06 164240" src="https://github.com/apache/echarts/assets/143710553/23654b9c-6919-41c6-bbf5-cd06f47c0f4f">



<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [√ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
