### PR TITLE
fix(sunburst): label rotation flipping

### DIFF
--- a/test/sunburst-label-align.html
+++ b/test/sunburst-label-align.html
@@ -41,9 +41,7 @@ under the License.
 
     <div id="main0"></div>
     <div id="main1"></div>
-
-
-
+    <div id="main2"></div>
 
 
 
@@ -1158,6 +1156,42 @@ under the License.
             });
         });
     </script>
+
+
+
+    <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                series: [
+                    {
+                        type: 'sunburst',
+                        data: new Array(11).fill(0).map((it, index) => ({
+                            name: 'aaa' + index,
+                            value: 1
+                        })),
+                        levels: [{}, { r0: 40, r: 100, label: { position: 'outside'}}]
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: [
+                    'Put label in the center if it\'s a circle'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+    </script>
+
 </body>
 
 </html>

--- a/test/sunburst-label.html
+++ b/test/sunburst-label.html
@@ -197,7 +197,12 @@ under the License.
                     radius: [0, '90%'],
                     label: {
                         rotate: 'radial'
-                    }
+                    },
+                    levels: [{}, {
+                        label: {
+                            rotate: 'tangential'
+                        }
+                    }]
                 }
             };
             var chart = testHelper.create(echarts, 'main1', {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Many cases were reported with sunburst's label rotation and several PRs trying to fix them have been merged (#18240, #18962, #19174). This PR refactored and simplified the related code, fixes the problem of #19127 and tested all reported cases and make sure the label rotation algorithm is as robust as possible.

### Fixed issues

- #19127

## Details

### Before: What was the problem?

Label align is not syncing with rotation flipping, so the text is at the wrong position.

![image](https://github.com/apache/echarts/assets/779050/89f0151e-2d68-4af1-8739-3ed33614f7f6)


### After: How does it behave after the fixing?

Use `needsFlip` to make sure this logic is the same with align and rotation.

![image](https://github.com/apache/echarts/assets/779050/1477c443-daca-4021-ae48-eabc71b5bf97)

Diff:

![image](https://github.com/apache/echarts/assets/779050/98b775b8-8535-4ace-bf26-04433845485f)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

I've run the visual test with the last version 5.4.3 and the result is as expected. I've also tested all rotation values and clockwise values to make sure the text is always in the readable direction.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
