### PR TITLE
fix(labelLine):emphasis.labelLine not work in pie chart

### DIFF
--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -618,10 +618,7 @@ export function setLabelLineStyle(
             if (isLabelIgnored  // Not show when label is not shown in this state.
                 || !retrieve2(stateShow, showNormal) // Use normal state by default if not set.
             ) {
-                const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
-                if (stateObj) {
-                    stateObj.ignore = true;
-                }
+                setLabelLineState(labelLine, true, stateName, stateModel);
                 continue;
             }
             // Create labelLine if not exists

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -618,6 +618,10 @@ export function setLabelLineStyle(
             if (isLabelIgnored  // Not show when label is not shown in this state.
                 || !retrieve2(stateShow, showNormal) // Use normal state by default if not set.
             ) {
+                const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
+                if (stateObj) {
+                    stateObj.ignore = true;
+                }
                 setLabelLineState(labelLine, true, stateName, stateModel);
                 continue;
             }

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -536,20 +536,22 @@ function setLabelLineState(
 ) {
     const isNormal = stateName === 'normal';
     const stateObj = isNormal ? labelLine : labelLine.ensureState(stateName);
-    // Make sure display.
-    stateObj.ignore = ignore;
-    // Set smooth
-    let smooth = stateModel.get('smooth');
-    if (smooth && smooth === true) {
-        smooth = 0.3;
-    }
-    stateObj.shape = stateObj.shape || {};
-    if (smooth > 0) {
-        (stateObj.shape as Polyline['shape']).smooth = smooth as number;
-    }
+    if (stateObj != undefined) {
+        // Make sure display.
+        stateObj.ignore = ignore;
+        // Set smooth
+        let smooth = stateModel.get('smooth');
+        if (smooth && smooth === true) {
+            smooth = 0.3;
+        }
+        stateObj.shape = stateObj.shape || {};
+        if (smooth > 0) {
+            (stateObj.shape as Polyline['shape']).smooth = smooth as number;
+        }
 
-    const styleObj = stateModel.getModel('lineStyle').getLineStyle();
-    isNormal ? labelLine.useStyle(styleObj) : stateObj.style = styleObj;
+        const styleObj = stateModel.getModel('lineStyle').getLineStyle();
+        isNormal ? labelLine.useStyle(styleObj) : stateObj.style = styleObj;
+    }
 }
 
 function buildLabelLinePath(path: CanvasRenderingContext2D, shape: Polyline['shape']) {
@@ -619,9 +621,6 @@ export function setLabelLineStyle(
                 || !retrieve2(stateShow, showNormal) // Use normal state by default if not set.
             ) {
                 const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
-                if (stateObj) {
-                    stateObj.ignore = true;
-                }
                 setLabelLineState(labelLine, true, stateName, stateModel);
                 continue;
             }

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -536,22 +536,19 @@ function setLabelLineState(
 ) {
     const isNormal = stateName === 'normal';
     const stateObj = isNormal ? labelLine : labelLine.ensureState(stateName);
-    if (stateObj != undefined) {
-        // Make sure display.
-        stateObj.ignore = ignore;
-        // Set smooth
-        let smooth = stateModel.get('smooth');
-        if (smooth && smooth === true) {
-            smooth = 0.3;
-        }
-        stateObj.shape = stateObj.shape || {};
-        if (smooth > 0) {
-            (stateObj.shape as Polyline['shape']).smooth = smooth as number;
-        }
-
-        const styleObj = stateModel.getModel('lineStyle').getLineStyle();
-        isNormal ? labelLine.useStyle(styleObj) : stateObj.style = styleObj;
+    // Make sure display.
+    stateObj.ignore = ignore;
+    // Set smooth
+    let smooth = stateModel.get('smooth');
+    if (smooth && smooth === true) {
+        smooth = 0.3;
     }
+    stateObj.shape = stateObj.shape || {};
+    if (smooth > 0) {
+        (stateObj.shape as Polyline['shape']).smooth = smooth as number;
+    }
+    const styleObj = stateModel.getModel('lineStyle').getLineStyle();
+    isNormal ? labelLine.useStyle(styleObj) : stateObj.style = styleObj;
 }
 
 function buildLabelLinePath(path: CanvasRenderingContext2D, shape: Polyline['shape']) {
@@ -620,7 +617,12 @@ export function setLabelLineStyle(
             if (isLabelIgnored  // Not show when label is not shown in this state.
                 || !retrieve2(stateShow, showNormal) // Use normal state by default if not set.
             ) {
-                setLabelLineState(labelLine, true, stateName, stateModel);
+                const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
+                if (stateObj) {
+                stateObj.ignore = true;}
+                if(!!labelLine){
+                    setLabelLineState(labelLine, true, stateName, stateModel);
+                }
                 continue;
             }
             // Create labelLine if not exists

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -620,7 +620,6 @@ export function setLabelLineStyle(
             if (isLabelIgnored  // Not show when label is not shown in this state.
                 || !retrieve2(stateShow, showNormal) // Use normal state by default if not set.
             ) {
-                const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
                 setLabelLineState(labelLine, true, stateName, stateModel);
                 continue;
             }

--- a/src/label/labelGuideHelper.ts
+++ b/src/label/labelGuideHelper.ts
@@ -619,8 +619,9 @@ export function setLabelLineStyle(
             ) {
                 const stateObj = isNormal ? labelLine : (labelLine && labelLine.states[stateName]);
                 if (stateObj) {
-                stateObj.ignore = true;}
-                if(!!labelLine){
+                    stateObj.ignore = true;
+                }
+                if (!!labelLine) {
                     setLabelLineState(labelLine, true, stateName, stateModel);
                 }
                 continue;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

solved problem:emphasis.labelLine not work in pie chart #19160



### Fixed issues

<!--
- #xxxx: ...
-->
[https://github.com/apache/echarts/issues/19160](url)
#19160

## Details

### Before: What was the problem?
label lines are not hidden when emphasis
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?
When I select the blue section,label lines  are hidden when emphasis
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="301" alt="0-09 161011" src="https://github.com/apache/echarts/assets/143710553/953a8d9d-0cab-412f-929d-5b6111e7f40a">



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
