### PR TITLE
support brush selection on line series

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -42,6 +42,7 @@ import type Polar from '../../coord/polar/Polar';
 import {createSymbol, ECSymbol} from '../../util/symbol';
 import {Group} from '../../util/graphic';
 import {LegendIconParams} from '../../component/legend/LegendModel';
+import type { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 
 type LineDataValue = OptionDataValue | OptionDataValue[];
 
@@ -215,6 +216,15 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
 
         triggerLineEvent: false
     };
+
+    brushSelector(dataIndex: number, data: SeriesData, selectors: BrushCommonSelectorsForSeries): boolean {
+        const points = data.getLayout('points');
+        const pointOffset = dataIndex * 2;
+        const x = points[pointOffset];
+        const y = points[pointOffset + 1];
+
+        return selectors.point([x, y]);
+    }
 
     getLegendIcon(opt: LegendIconParams): ECSymbol | Group {
         const group = new Group();


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others


### What does this PR do?

This PR adds the support brushing selection to `line` series. Previously, 
This pull requests adds `brushSelector` to the LineSeries


### Fixed issues

- https://github.com/apache/echarts/issues/14258
- https://github.com/apache/echarts/issues/18155

## Details

### Before: What was the problem?

`brushselected` event returned an empty `dataIndex` array which makes it hard to figure out which points are selected with brushing.

### After: How does it behave after the fixing?

`LineSeriesModel` implements `brushSelector` method where it gets point coordinates by `dataIndex` and then uses brush selector to understand if the point should be selected.

<img width="479" alt="Screenshot 2023-10-11 at 8 38 18 PM" src="https://github.com/apache/echarts/assets/14301985/a5f15aab-63ec-4dd1-a4b9-7024acf82176">


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
