### PR TITLE
fix shadow area in slider

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -394,6 +394,7 @@ class SliderZoomView extends DataZoomView {
             // Optimize for large data shadow
             const stride = Math.round(data.count() / size[0]);
             let lastIsEmpty: boolean;
+            let lastThisCoord: any;
             data.each([info.thisDim, otherDim], function (thisValue: ParsedValue, thatValue: ParsedValue, index) {
                 if (stride > 0 && (index % stride)) {
                     // thisCoord += step;
@@ -433,7 +434,11 @@ class SliderZoomView extends DataZoomView {
                 linePoints.push([thisCoord, otherCoord]);
 
                 lastIsEmpty = isEmpty;
+                lastThisCoord = thisCoord;
             });
+
+            // Close the last segment
+            areaPoints.push([lastThisCoord, 0]);
 
             polygonPts = this._shadowPolygonPts = areaPoints;
             polylinePts = this._shadowPolylinePts = linePoints;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR fixes shadow below data line in dataZoom series preview where there are many points (>50k)



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
-last point was not set to 0, which triggered incorrect rendering of shadow line 

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![echarts_shadowLine_bug](https://github.com/apache/echarts/assets/92551249/a096d037-747d-4446-a378-2ba2c799a9d6)




### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
-added last point as 0 always

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![echarts_shadowLine_bugfix](https://github.com/apache/echarts/assets/92551249/23ef41b7-d9a6-46b2-863d-a37ae82ba9a9)





## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
