### PR TITLE
fix(core): fix potential NPE when reading default init options from global object in dev environment

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -418,11 +418,11 @@ class ECharts extends Eventful<ECEventDefinition> {
                 env.hasGlobalWindow ? window : global
             ) as any;
 
-            defaultRenderer = root.__ECHARTS__DEFAULT__RENDERER__ || defaultRenderer;
+            defaultRenderer = root?.__ECHARTS__DEFAULT__RENDERER__ ?? defaultRenderer;
 
             defaultCoarsePointer = retrieve2(root.__ECHARTS__DEFAULT__COARSE_POINTER, defaultCoarsePointer);
 
-            const devUseDirtyRect = root.__ECHARTS__DEFAULT__USE_DIRTY_RECT__;
+            const devUseDirtyRect = root?.__ECHARTS__DEFAULT__USE_DIRTY_RECT__ ?? null;
             defaultUseDirtyRect = devUseDirtyRect == null
                 ? defaultUseDirtyRect
                 : devUseDirtyRect;

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -414,22 +414,17 @@ class ECharts extends Eventful<ECEventDefinition> {
         let defaultUseDirtyRect = false;
 
         if (__DEV__) {
-            let devUseDirtyRect = null;
             const root = (
                 /* eslint-disable-next-line */
                 env.hasGlobalWindow ? window : global
             ) as any;
 
             if (root) {
-                defaultRenderer = root.__ECHARTS__DEFAULT__RENDERER__ || defaultRenderer;
-                devUseDirtyRect = root.__ECHARTS__DEFAULT__USE_DIRTY_RECT__;
+                defaultRenderer = retrieve2(root.__ECHARTS__DEFAULT__RENDERER__, defaultRenderer);
                 defaultCoarsePointer = retrieve2(root.__ECHARTS__DEFAULT__COARSE_POINTER, defaultCoarsePointer);
+                defaultUseDirtyRect = retrieve2(root.__ECHARTS__DEFAULT__USE_DIRTY_RECT__, defaultUseDirtyRect);
             }
 
-
-            defaultUseDirtyRect = devUseDirtyRect == null
-                ? defaultUseDirtyRect
-                : devUseDirtyRect;
         }
 
         const zr = this._zr = zrender.init(dom, {

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -412,17 +412,21 @@ class ECharts extends Eventful<ECEventDefinition> {
         let defaultRenderer = 'canvas';
         let defaultCoarsePointer: 'auto' | boolean = 'auto';
         let defaultUseDirtyRect = false;
+
         if (__DEV__) {
+            let devUseDirtyRect = null;
             const root = (
                 /* eslint-disable-next-line */
                 env.hasGlobalWindow ? window : global
             ) as any;
 
-            defaultRenderer = root?.__ECHARTS__DEFAULT__RENDERER__ ?? defaultRenderer;
+            if (root) {
+                defaultRenderer = root.__ECHARTS__DEFAULT__RENDERER__ || defaultRenderer;
+                devUseDirtyRect = root.__ECHARTS__DEFAULT__USE_DIRTY_RECT__;
+                defaultCoarsePointer = retrieve2(root.__ECHARTS__DEFAULT__COARSE_POINTER, defaultCoarsePointer);
+            }
 
-            defaultCoarsePointer = retrieve2(root.__ECHARTS__DEFAULT__COARSE_POINTER, defaultCoarsePointer);
 
-            const devUseDirtyRect = root?.__ECHARTS__DEFAULT__USE_DIRTY_RECT__ ?? null;
             defaultUseDirtyRect = devUseDirtyRect == null
                 ? defaultUseDirtyRect
                 : devUseDirtyRect;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

The value of repairing the development environment `__ECHARTS__DEFAULT__RENDERER__` is undefined
![image](https://github.com/apache/echarts/assets/35005831/1025d31c-ad9a-4b26-b755-c9cbf42e4cff)



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
