### PR TITLE
feat(label): support align for min/max labels

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -17,7 +17,9 @@
 * under the License.
 */
 
-import {retrieve, defaults, extend, each, isObject, map, isString, isNumber, isFunction, retrieve2} from 'zrender/src/core/util';
+import {
+    retrieve, defaults, extend, each, isObject, map, isString, isNumber, isFunction, retrieve2
+} from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import {getECData} from '../../util/innerStore';
 import {createTextStyle} from '../../label/labelStyle';

--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {retrieve, defaults, extend, each, isObject, map, isString, isNumber, isFunction} from 'zrender/src/core/util';
+import {retrieve, defaults, extend, each, isObject, map, isString, isNumber, isFunction, retrieve2} from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import {getECData} from '../../util/innerStore';
 import {createTextStyle} from '../../label/labelStyle';
@@ -776,6 +776,29 @@ function buildAxisLabel(
 
         const tickCoord = axis.dataToCoord(tickValue);
 
+        const align = itemLabelModel.getShallow('align', true)
+            || labelLayout.textAlign;
+        const alignMin = retrieve2(
+            itemLabelModel.getShallow('alignMinLabel', true),
+            align
+        );
+        const alignMax = retrieve2(
+            itemLabelModel.getShallow('alignMaxLabel', true),
+            align
+        );
+
+        const verticalAlign = itemLabelModel.getShallow('verticalAlign', true)
+            || itemLabelModel.getShallow('baseline', true)
+            || labelLayout.textVerticalAlign;
+        const verticalAlignMin = retrieve2(
+            itemLabelModel.getShallow('verticalAlignMinLabel', true),
+            verticalAlign
+        );
+        const verticalAlignMax = retrieve2(
+            itemLabelModel.getShallow('verticalAlignMaxLabel', true),
+            verticalAlign
+        );
+
         const textEl = new graphic.Text({
             x: tickCoord,
             y: opt.labelOffset + opt.labelDirection * labelMargin,
@@ -784,11 +807,12 @@ function buildAxisLabel(
             z2: 10 + (labelItem.level || 0),
             style: createTextStyle(itemLabelModel, {
                 text: formattedLabel,
-                align: itemLabelModel.getShallow('align', true)
-                    || labelLayout.textAlign,
-                verticalAlign: itemLabelModel.getShallow('verticalAlign', true)
-                    || itemLabelModel.getShallow('baseline', true)
-                    || labelLayout.textVerticalAlign,
+                align: index === 0
+                    ? alignMin
+                    : index === labels.length - 1 ? alignMax : align,
+                verticalAlign: index === 0
+                    ? verticalAlignMin
+                    : index === labels.length - 1 ? verticalAlignMax : verticalAlign,
                 fill: isFunction(textColor)
                     ? textColor(
                         // (1) In category axis with data zoom, tick is not the original

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -17,6 +17,7 @@
 * under the License.
 */
 
+import { TextAlign, TextVerticalAlign } from 'zrender/src/core/types';
 import {
     TextCommonOption, LineStyleOption, OrdinalRawValue, ZRColor,
     AreaStyleOption, ComponentOption, ColorString,
@@ -223,6 +224,14 @@ interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     showMinLabel?: boolean,
     // true | false | null/undefined (auto)
     showMaxLabel?: boolean,
+    // 'left' | 'center' | 'right' | null/undefined (auto)
+    alignMinLabel?: TextAlign,
+    // 'left' | 'center' | 'right' | null/undefined (auto)
+    alignMaxLabel?: TextAlign,
+    // 'top' | 'middle' | 'bottom' | null/undefined (auto)
+    verticalAlignMinLabel?: TextVerticalAlign,
+    // 'top' | 'middle' | 'bottom' | null/undefined (auto)
+    verticalAlignMaxLabel?: TextVerticalAlign,
     margin?: number,
     rich?: Dictionary<TextCommonOption>
     /**

--- a/test/axis-align-lastLabel.html
+++ b/test/axis-align-lastLabel.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+
+
+        <div id="main1"></div>
+
+
+
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            var data = [];
+            for (let i = 0; i < 200; ++i) {
+                data.push([i, Math.floor(Math.random() * 100)]);
+            }
+
+            option = {
+                xAxis: {
+                    axisLabel: {
+                        formatter: 'label of {value}',
+                        showMinLabel: true,
+                        showMaxLabel: true,
+                        alignMinLabel: 'left',
+                        alignMaxLabel: 'right'
+                    }
+                },
+                yAxis: {},
+                series: {
+                    type: 'line',
+                    data
+                },
+                dataZoom: {
+                    type: 'slider',
+                    start: 20,
+                    end: 42
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'alignMinLabel: left, alignMaxLabel: right'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            var data = [];
+            for (let i = 0; i < 200; ++i) {
+                data.push([i, Math.floor(Math.random() * 100)]);
+            }
+
+            option = {
+                yAxis: {
+                    axisLabel: {
+                        formatter: 'label of {value}',
+                        showMinLabel: true,
+                        showMaxLabel: true,
+                        verticalAlignMinLabel: 'bottom',
+                        verticalAlignMaxLabel: 'top'
+                    }
+                },
+                xAxis: {},
+                series: {
+                    type: 'line',
+                    data
+                },
+                dataZoom: {
+                    type: 'slider',
+                    start: 20,
+                    end: 42,
+                    yAxisIndex: 0
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'verticalAlignMinLabel: bottom, verticalAlignMaxLabel: top'
+                ],
+                option: option
+                // height: 300,
+                // buttons: [{text: 'btn-txt', onclick: function () {}}],
+                // recordCanvas: true,
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

In some cases, especially when the canvas size is limited, we wish to confine the axis labels to be within an area rather than may be outside of the canvas when the label text is long. In this PR, I proposed a way to set align/verticalAlign for the first and last labels so that we can make sure they are within the boundary of the grid area.

### Fixed issues

#19215

## Details

### Before: What was the problem?

The first and last label may be too long to be displayed when the text is long and the canvas size is limited.

<img width="1184" alt="image" src="https://github.com/apache/echarts/assets/779050/498aaa54-3bd5-46d7-841d-2ca561a1e1dc">



### After: How does it behave after the fixing?

When setting `alignMinLabel: 'left', alignMaxLabel: 'right'` we can make sure the text is within the grid's width and the inner labels may hide when overlap.

<img width="1171" alt="image" src="https://github.com/apache/echarts/assets/779050/48d5855c-e7cc-4b00-b9d8-264ff1834f49">




## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
