### PR TITLE
fix(aria): series type name for custom series

### DIFF
--- a/src/i18n/langAR.ts
+++ b/src/i18n/langAR.ts
@@ -106,6 +106,7 @@ export default {
             pictorialBar: 'مخطط مصوّر',
             themeRiver: 'نمط خريطة النهر',
             sunburst: 'مخطط شمسي',
+            custom: 'مخطط مخصص',
             chart: 'مخطط'
         }
     },

--- a/src/i18n/langAR.ts
+++ b/src/i18n/langAR.ts
@@ -105,7 +105,8 @@ export default {
             gauge: 'مقياس',
             pictorialBar: 'مخطط مصوّر',
             themeRiver: 'نمط خريطة النهر',
-            sunburst: 'مخطط شمسي'
+            sunburst: 'مخطط شمسي',
+            chart: 'مخطط'
         }
     },
     aria: {

--- a/src/i18n/langCS.ts
+++ b/src/i18n/langCS.ts
@@ -105,6 +105,7 @@
             pictorialBar: 'Obrázkový sloupcový graf',
             themeRiver: 'Theme River Map',
             sunburst: 'Vícevrstvý prstencový graf',
+            custom: 'Graficu persunalizatu',
             chart: 'Graf'
         }
     },

--- a/src/i18n/langCS.ts
+++ b/src/i18n/langCS.ts
@@ -104,7 +104,8 @@
             gauge: 'Indikátor',
             pictorialBar: 'Obrázkový sloupcový graf',
             themeRiver: 'Theme River Map',
-            sunburst: 'Vícevrstvý prstencový graf'
+            sunburst: 'Vícevrstvý prstencový graf',
+            chart: 'Graf'
         }
     },
     aria: {

--- a/src/i18n/langDE.ts
+++ b/src/i18n/langDE.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Meßanzeige',
             pictorialBar: 'Bildlicher Balken',
             themeRiver: 'Thematische Flusskarte',
-            sunburst: 'Sonnenausbruch'
+            sunburst: 'Sonnenausbruch',
+            chart: 'Diagramm'
         }
     },
     aria: {

--- a/src/i18n/langDE.ts
+++ b/src/i18n/langDE.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Bildlicher Balken',
             themeRiver: 'Thematische Flusskarte',
             sunburst: 'Sonnenausbruch',
+            custom: 'Graficu persunalizatu',
             chart: 'Diagramm'
         }
     },

--- a/src/i18n/langEN.ts
+++ b/src/i18n/langEN.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Gauge',
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
-            sunburst: 'Sunburst'
+            sunburst: 'Sunburst',
+            chart: 'Chart'
         }
     },
     aria: {

--- a/src/i18n/langEN.ts
+++ b/src/i18n/langEN.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
             sunburst: 'Sunburst',
+            custom: 'Custom chart',
             chart: 'Chart'
         }
     },

--- a/src/i18n/langES.ts
+++ b/src/i18n/langES.ts
@@ -76,5 +76,65 @@ export default {
             title: 'Guardar como imagen',
             lang: ['Clic derecho para guardar imagen']
         }
+    },
+    series: {
+        typeNames: {
+            pie: 'Gráfico circular',
+            bar: 'Gráfico de barras',
+            line: 'Gráfico de líneas',
+            scatter: 'Diagrama de dispersión',
+            effectScatter: 'Diagrama de dispersión de ondas',
+            radar: 'Gráfico de radar',
+            tree: 'Árbol',
+            treemap: 'Mapa de árbol',
+            boxplot: 'Diagrama de caja',
+            candlestick: 'Gráfico de velas',
+            k: 'Gráfico de líneas K',
+            heatmap: 'Mapa de calor',
+            map: 'Mapa',
+            parallel: 'Mapa de coordenadas paralelas',
+            lines: 'Gráfico de líneas',
+            graph: 'Gráfico de relaciones',
+            sankey: 'Diagrama de Sankey',
+            funnel: 'Gráfico de embudo',
+            gauge: 'Medidor',
+            pictorialBar: 'Gráfico de barras pictóricas',
+            themeRiver: 'Mapa de río temático',
+            sunburst: 'Sunburst',
+            custom: 'Gráfico personalizado',
+            chart: 'Gráfico'
+        }
+    },
+    aria: {
+        general: {
+            withTitle: 'Este es un gráfico sobre “{title}”',
+            withoutTitle: 'Este es un gráfico'
+        },
+        series: {
+            single: {
+                prefix: '',
+                withName: ' con tipo {seriesType} llamado {seriesName}.',
+                withoutName: ' con tipo {seriesType}.'
+            },
+            multiple: {
+                prefix: '. Consta de {seriesCount} series.',
+                withName: ' La serie {seriesId} es un {seriesType} que representa {seriesName}.',
+                withoutName: ' La serie {seriesId} es un {seriesType}.',
+                separator: {
+                    middle: '',
+                    end: ''
+                }
+            }
+        },
+        data: {
+            allData: 'Los datos son los siguientes: ',
+            partialData: 'Los primeros {displayCnt} elementos son: ',
+            withName: 'los datos para {name} son {value}',
+            withoutName: '{value}',
+            separator: {
+                middle: ', ',
+                end: '. '
+            }
+        }
     }
 };

--- a/src/i18n/langFI.ts
+++ b/src/i18n/langFI.ts
@@ -76,5 +76,65 @@ export default {
             title: 'Tallenna kuvana',
             lang: ['Paina oikeaa hiirennappia tallentaaksesi kuva']
         }
+    },
+    series: {
+        typeNames: {
+            pie: 'Ympyrädiagrammi',
+            bar: 'Pylväsdiagrammi',
+            line: 'Viivakaavio',
+            scatter: 'Pisteplot',
+            effectScatter: 'Ripple-pisteplot',
+            radar: 'Sädekaavio',
+            tree: 'Puu',
+            treemap: 'Tilastoaluekartta',
+            boxplot: 'Viivadiagrammi',
+            candlestick: 'Kynttiläkaavio',
+            k: 'K-linjakaavio',
+            heatmap: 'Lämpökartta',
+            map: 'Kartta',
+            parallel: 'Rinnakkaiskoordinaattikartta',
+            lines: 'Viivakuvaaja',
+            graph: 'Suhdekuvaaja',
+            sankey: 'Sankey-kaavio',
+            funnel: 'Suppilokaavio',
+            gauge: 'Mittari',
+            pictorialBar: 'Kuvallinen pylväs',
+            themeRiver: 'Teemajokikartta',
+            sunburst: 'Auringonkehä',
+            custom: 'Mukautettu kaavio',
+            chart: 'Kaavio'
+        }
+    },
+    aria: {
+        general: {
+            withTitle: 'Tämä on kaavio “{title}”',
+            withoutTitle: 'Tämä on kaavio'
+        },
+        series: {
+            single: {
+                prefix: '',
+                withName: ' tyyppiä {seriesType} nimeltään {seriesName}.',
+                withoutName: ' tyyppiä {seriesType}.'
+            },
+            multiple: {
+                prefix: '. Se koostuu {seriesCount} sarjasta.',
+                withName: ' Sarja {seriesId} on {seriesType}, joka edustaa {seriesName}.',
+                withoutName: ' Sarja {seriesId} on {seriesType}.',
+                separator: {
+                    middle: '',
+                    end: ''
+                }
+            }
+        },
+        data: {
+            allData: 'Tiedot ovat seuraavat: ',
+            partialData: 'Ensimmäiset {displayCnt} kohtaa ovat: ',
+            withName: 'tiedot nimelle {name} ovat {value}',
+            withoutName: '{value}',
+            separator: {
+                middle: ', ',
+                end: '. '
+            }
+        }
     }
 };

--- a/src/i18n/langFR.ts
+++ b/src/i18n/langFR.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Barres à images',
             themeRiver: 'Stream Graph',
             sunburst: 'Sunburst',
+            custom: 'Graphique personnalisé',
             chart: 'Graphique'
         }
     },

--- a/src/i18n/langFR.ts
+++ b/src/i18n/langFR.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Jauge',
             pictorialBar: 'Barres à images',
             themeRiver: 'Stream Graph',
-            sunburst: 'Sunburst'
+            sunburst: 'Sunburst',
+            chart: 'Graphique'
         }
     },
     aria: {

--- a/src/i18n/langHU.ts
+++ b/src/i18n/langHU.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Mérőeszköz',
             pictorialBar: 'Képes sávdiagram',
             themeRiver: 'Folyó témájú térkép',
-            sunburst: 'Napégés'
+            sunburst: 'Napégés',
+            chart: 'Diagram'
         }
     },
     aria: {

--- a/src/i18n/langHU.ts
+++ b/src/i18n/langHU.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Képes sávdiagram',
             themeRiver: 'Folyó témájú térkép',
             sunburst: 'Napégés',
+            custom: 'Egyedi diagram',
             chart: 'Diagram'
         }
     },

--- a/src/i18n/langIT.ts
+++ b/src/i18n/langIT.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
             sunburst: 'Radiale',
+            custom: 'Egyedi diagram',
             chart: 'Grafico'
         }
     },

--- a/src/i18n/langIT.ts
+++ b/src/i18n/langIT.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Gauge',
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
-            sunburst: 'Radiale'
+            sunburst: 'Radiale',
+            chart: 'Grafico'
         }
     },
     aria: {

--- a/src/i18n/langJA.ts
+++ b/src/i18n/langJA.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: '絵入り棒グラフ',
             themeRiver: 'テーマリバー',
             sunburst: 'サンバースト',
+            custom: 'カスタムチャート',
             chart: 'チャート'
         }
     },

--- a/src/i18n/langJA.ts
+++ b/src/i18n/langJA.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'ゲージ',
             pictorialBar: '絵入り棒グラフ',
             themeRiver: 'テーマリバー',
-            sunburst: 'サンバースト'
+            sunburst: 'サンバースト',
+            chart: 'チャート'
         }
     },
     aria: {

--- a/src/i18n/langKO.ts
+++ b/src/i18n/langKO.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: '픽토그램 차트',
             themeRiver: '스트림 그래프',
             sunburst: '선버스트 차트',
+            custom: '맞춤 차트',
             chart: '차트'
         }
     },

--- a/src/i18n/langKO.ts
+++ b/src/i18n/langKO.ts
@@ -104,7 +104,8 @@ export default {
             gauge: '계기',
             pictorialBar: '픽토그램 차트',
             themeRiver: '스트림 그래프',
-            sunburst: '선버스트 차트'
+            sunburst: '선버스트 차트',
+            chart: '차트'
         }
     },
     aria: {

--- a/src/i18n/langPL.ts
+++ b/src/i18n/langPL.ts
@@ -105,6 +105,7 @@
             pictorialBar: 'Wykres słupkowy obrazkowy',
             themeRiver: 'Wykres rzeki tematycznej',
             sunburst: 'Wykres hierarchiczny słonecznikowy',
+            custom: 'Wykres niestandardowy',
             chart: 'Wykres'
         }
     },

--- a/src/i18n/langPL.ts
+++ b/src/i18n/langPL.ts
@@ -104,7 +104,8 @@
             gauge: 'Wykres zegarowy',
             pictorialBar: 'Wykres słupkowy obrazkowy',
             themeRiver: 'Wykres rzeki tematycznej',
-            sunburst: 'Wykres hierarchiczny słonecznikowy'
+            sunburst: 'Wykres hierarchiczny słonecznikowy',
+            chart: 'Wykres'
         }
     },
     aria: {

--- a/src/i18n/langPT-br.ts
+++ b/src/i18n/langPT-br.ts
@@ -105,7 +105,8 @@ export default {
             gauge: 'Gauge',
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
-            sunburst: 'Sunburst'
+            sunburst: 'Sunburst',
+            chart: 'Gráfico'
         }
     },
     aria: {

--- a/src/i18n/langPT-br.ts
+++ b/src/i18n/langPT-br.ts
@@ -106,6 +106,7 @@ export default {
             pictorialBar: 'Pictorial bar',
             themeRiver: 'Theme River Map',
             sunburst: 'Sunburst',
+            custom: 'Gráfico personalizado',
             chart: 'Gráfico'
         }
     },

--- a/src/i18n/langRO.ts
+++ b/src/i18n/langRO.ts
@@ -105,6 +105,7 @@
             pictorialBar: 'Diagramă cu bare picturale',
             themeRiver: 'Streamgraph',
             sunburst: 'Diagramă rază de soare',
+            custom: 'Diagramă personalizată',
             chart: 'Diagramă'
         }
     },

--- a/src/i18n/langRO.ts
+++ b/src/i18n/langRO.ts
@@ -104,7 +104,8 @@
             gauge: 'Calibru',
             pictorialBar: 'Diagramă cu bare picturale',
             themeRiver: 'Streamgraph',
-            sunburst: 'Diagramă rază de soare'
+            sunburst: 'Diagramă rază de soare',
+            chart: 'Diagramă'
         }
     },
     aria: {

--- a/src/i18n/langRU.ts
+++ b/src/i18n/langRU.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Столбец-картинка',
             themeRiver: 'Тематическая река',
             sunburst: 'Солнечные лучи',
+            custom: 'Пользовательская диаграмма',
             chart: 'диаграмма'
         }
     },

--- a/src/i18n/langRU.ts
+++ b/src/i18n/langRU.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Шкала',
             pictorialBar: 'Столбец-картинка',
             themeRiver: 'Тематическая река',
-            sunburst: 'Солнечные лучи'
+            sunburst: 'Солнечные лучи',
+            chart: 'диаграмма'
         }
     },
     aria: {

--- a/src/i18n/langSI.ts
+++ b/src/i18n/langSI.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Stolpčni grafikon s podobo',
             themeRiver: 'Tematski rečni grafikon',
             sunburst: 'Večnivojski tortni grafikon',
+            custom: 'Grafikon po meri',
             chart: 'Grafikon'
         }
     },

--- a/src/i18n/langSI.ts
+++ b/src/i18n/langSI.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Števec',
             pictorialBar: 'Stolpčni grafikon s podobo',
             themeRiver: 'Tematski rečni grafikon',
-            sunburst: 'Večnivojski tortni grafikon'
+            sunburst: 'Večnivojski tortni grafikon',
+            chart: 'Grafikon'
         }
     },
     aria: {

--- a/src/i18n/langTH.ts
+++ b/src/i18n/langTH.ts
@@ -76,5 +76,65 @@ export default {
             title: 'บันทึกไปยังรูปภาพ',
             lang: ['คลิกขวาเพื่อบันทึกรูปภาพ']
         }
+    },
+    series: {
+        typeNames: {
+            pie: 'แผนภูมิวงกลม',
+            bar: 'แผนภูมิแท่ง',
+            line: 'แผนภูมิเส้น',
+            scatter: 'แผนภูมิกระจาย',
+            effectScatter: 'แผนภูมิกระจายคลื่น',
+            radar: 'แผนภูมิเรดาร์',
+            tree: 'ต้นไม้',
+            treemap: 'แผนที่ต้นไม้',
+            boxplot: 'แผนภูมิกล่อง',
+            candlestick: 'แผนภูมิเทียน',
+            k: 'แผนภูมิเส้น K',
+            heatmap: 'แผนที่ความร้อน',
+            map: 'แผนที่',
+            parallel: 'แผนที่พิกัดขนาน',
+            lines: 'กราฟเส้น',
+            graph: 'กราฟความสัมพันธ์',
+            sankey: 'แผนภูมิซันกีย์',
+            funnel: 'แผนภูมิกรวย',
+            gauge: 'เกจ',
+            pictorialBar: 'แผนภูมิแท่งภาพ',
+            themeRiver: 'แผนที่แม่น้ำธีม',
+            sunburst: 'Sunburst',
+            custom: 'แผนภูมิที่กำหนดเอง',
+            chart: 'แผนภูมิ'
+        }
+    },
+    aria: {
+        general: {
+            withTitle: 'นี่คือแผนภูมิเกี่ยวกับ “{title}”',
+            withoutTitle: 'นี่คือแผนภูมิ'
+        },
+        series: {
+            single: {
+                prefix: '',
+                withName: ' ด้วยประเภท {seriesType} ชื่อ {seriesName} ',
+                withoutName: ' ด้วยประเภท {seriesType} '
+            },
+            multiple: {
+                prefix: ' มีทั้งหมด {seriesCount} ชุดข้อมูล ',
+                withName: ' ชุดข้อมูลที่ {seriesId} เป็นประเภท {seriesType} แทน {seriesName} ',
+                withoutName: ' ชุดข้อมูลที่ {seriesId} เป็นประเภท {seriesType} ',
+                separator: {
+                    middle: '',
+                    end: ''
+                }
+            }
+        },
+        data: {
+            allData: 'ข้อมูลดังต่อไปนี้: ',
+            partialData: 'ข้อมูล {displayCnt} รายการแรกคือ: ',
+            withName: 'ข้อมูลสำหรับ {name} คือ {value} ',
+            withoutName: '{value} ',
+            separator: {
+                middle: ', ',
+                end: '. '
+            }
+        }
     }
 };

--- a/src/i18n/langTR.ts
+++ b/src/i18n/langTR.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Gösterge',
             pictorialBar: 'Resimli Çubuk Grafiği',
             themeRiver: 'Akış Haritası',
-            sunburst: 'Güeş Patlaması Tablosu'
+            sunburst: 'Güeş Patlaması Tablosu',
+            chart: 'Grafiği'
         }
     },
     aria: {

--- a/src/i18n/langTR.ts
+++ b/src/i18n/langTR.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Resimli Çubuk Grafiği',
             themeRiver: 'Akış Haritası',
             sunburst: 'Güeş Patlaması Tablosu',
+            custom: 'Özel grafik',
             chart: 'Grafiği'
         }
     },

--- a/src/i18n/langUK.ts
+++ b/src/i18n/langUK.ts
@@ -105,6 +105,7 @@ export default {
             pictorialBar: 'Стовпчик-картинка',
             themeRiver: 'Тематична ріка',
             sunburst: 'Сонячне проміння',
+            custom: 'Спеціальна діаграма',
             chart: 'діаграма'
         }
     },

--- a/src/i18n/langUK.ts
+++ b/src/i18n/langUK.ts
@@ -104,7 +104,8 @@ export default {
             gauge: 'Шкала',
             pictorialBar: 'Стовпчик-картинка',
             themeRiver: 'Тематична ріка',
-            sunburst: 'Сонячне проміння'
+            sunburst: 'Сонячне проміння',
+            chart: 'діаграма'
         }
     },
     aria: {

--- a/src/i18n/langVI.ts
+++ b/src/i18n/langVI.ts
@@ -129,7 +129,8 @@ export default {
       pictorialBar: 'Biểu diễn hình ảnh',
       themeRiver: 'Bản đồ sông',
       sunburst: 'Biểu đồ bậc',
-      chart: 'đồ biểu'
+      custom: 'Biểu đồ tùy chỉnh',
+      chart: 'Đồ thị'
     }
   },
   aria: {

--- a/src/i18n/langVI.ts
+++ b/src/i18n/langVI.ts
@@ -128,7 +128,8 @@ export default {
       gauge: 'Biểu đồ cung tròn',
       pictorialBar: 'Biểu diễn hình ảnh',
       themeRiver: 'Bản đồ sông',
-      sunburst: 'Biểu đồ bậc'
+      sunburst: 'Biểu đồ bậc',
+      chart: 'đồ biểu'
     }
   },
   aria: {

--- a/src/i18n/langZH.ts
+++ b/src/i18n/langZH.ts
@@ -101,6 +101,7 @@ export default {
             pictorialBar: '象形柱图',
             themeRiver: '主题河流图',
             sunburst: '旭日图',
+            custom: '自定义图表',
             chart: '图表'
         }
     },

--- a/src/i18n/langZH.ts
+++ b/src/i18n/langZH.ts
@@ -100,7 +100,8 @@ export default {
             gauge: '仪表盘图',
             pictorialBar: '象形柱图',
             themeRiver: '主题河流图',
-            sunburst: '旭日图'
+            sunburst: '旭日图',
+            chart: '图表'
         }
     },
     aria: {

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -264,6 +264,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
     }
 
     function getSeriesTypeName(type: SeriesTypes) {
-        return ecModel.getLocaleModel().get(['series', 'typeNames'])[type] || '自定义图';
+        const typeNames = ecModel.getLocaleModel().get(['series', 'typeNames']);
+        return typeNames[type] || typeNames.chart;
     }
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Support series type name in aria for custom series. And I found aria is missing for some i18n files so I added them.

### Fixed issues

#18054


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Custom series type name is '自定义系列', which is not expected for languages other than Chinese.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Names in locale files are used.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
