### PR TITLE
fix(tooltip): fix potential NPE when the parent node of the tooltip element doesn't exist

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -520,6 +520,8 @@ class TooltipHTMLContent {
     }
 
     dispose() {
+        clearTimeout(this._hideTimeout);
+        clearTimeout(this._longHideTimeout);
         this.el.remove();
         this.el = this._container = null;
     }

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -520,7 +520,7 @@ class TooltipHTMLContent {
     }
 
     dispose() {
-        this.el.parentNode.removeChild(this.el);
+        this.el.remove();
         this.el = this._container = null;
     }
 

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -522,7 +522,9 @@ class TooltipHTMLContent {
     dispose() {
         clearTimeout(this._hideTimeout);
         clearTimeout(this._longHideTimeout);
-        this.el.remove();
+
+        const parentNode = this.el.parentNode;
+        parentNode && parentNode.removeChild(this.el);
         this.el = this._container = null;
     }
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

1. Fix potential NPE when the parent node of the tooltip element doesn't exist.
2. clear timers when disposing

### Fixed issues

- Fix #19248

## Details

### Before: What was the problem?

As the tooltip `dispose` is using `parentNode.removeChild` to remove the element itself and there is no non-null check, an NPE issue may occur.

### After: How does it behave after the fixing?

<del>Switch to use the element's own `remove` API.</del>
Add a non-null check before calling `parentNode.removeChild`

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
