### PR TITLE
FIX added timeout to show action, so when it have a delay, it won't show unexpectedly

### DIFF
--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -36,6 +36,7 @@ class TooltipRichContent {
     private _styleCoord: [number, number, number, number] = [0, 0, 0, 0];
 
     private _hideTimeout: number;
+    private _showTimeout: number;
 
     private _alwaysShowContent: boolean = false;
 
@@ -68,8 +69,10 @@ class TooltipRichContent {
             clearTimeout(this._hideTimeout);
         }
 
-        this.el.show();
-        this._show = true;
+        this._showTimeout = setTimeout(() => {
+            this.el.show();
+            this._show = true;
+        }, 0)
     }
 
     /**
@@ -124,7 +127,9 @@ class TooltipRichContent {
             // clear the timeout in hideLater and keep showing tooltip
             if (self._enterable) {
                 clearTimeout(self._hideTimeout);
-                self._show = true;
+                this._showTimeout = setTimeout(() => {
+                    self._show = true;
+                }, 0)
             }
             self._inContent = true;
         });
@@ -188,6 +193,9 @@ class TooltipRichContent {
     }
 
     hide() {
+        if (this._showTimeout) {
+            clearTimeout(this._showTimeout);
+        }
         if (this.el) {
             this.el.hide();
         }


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

 added timeout to show action, so when it have a delay, it won't show unexpectedly


### Fixed issues

Essencially, if you change the showDelay and hideDelay options for a tooltip and you have multiple charts on a page, once you hover an item and get a tooltip, if you move fast to the other chart, that tooltip on the first chart would show up again



### After: How does it behave after the fixing?

Just added a _showTimeout (same way you already do for the hideTimeout), that can be cancelled after hiding once


