### PR TITLE
feat(label): support labels auto-rotation

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -28,7 +28,7 @@ import {isRadianAroundZero, remRadian} from '../../util/number';
 import {createSymbol, normalizeSymbolOffset} from '../../util/symbol';
 import * as matrixUtil from 'zrender/src/core/matrix';
 import {applyTransform as v2ApplyTransform} from 'zrender/src/core/vector';
-import {shouldShowAllLabels} from '../../coord/axisHelper';
+import {shouldShowAllLabels, isNameLocationCenter} from '../../coord/axisHelper';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
 import { ZRTextVerticalAlign, ZRTextAlign, ECElement, ColorString } from '../../util/types';
 import { AxisBaseOption } from '../../coord/axisCommonTypes';
@@ -376,8 +376,8 @@ const builders: Record<'axisLine' | 'axisTickLabel' | 'axisName', AxisElementsBu
         const nameLocation = axisModel.get('nameLocation');
         const nameDirection = opt.nameDirection;
         const textStyleModel = axisModel.getModel('nameTextStyle');
-        const gap = axisModel.get('nameGap') || 0;
 
+        const gap = axisModel.axis.getNameGap();
         const extent = axisModel.axis.getExtent();
         const gapSignal = extent[0] > extent[1] ? -1 : 1;
         const pos = [
@@ -601,11 +601,6 @@ function isTwoLabelOverlapped(
     return firstRect.intersect(nextRect);
 }
 
-function isNameLocationCenter(nameLocation: string) {
-    return nameLocation === 'middle' || nameLocation === 'center';
-}
-
-
 function createTicks(
     ticksCoords: TickCoord[],
     tickTransform: matrixUtil.MatrixArray,
@@ -742,13 +737,10 @@ function buildAxisLabel(
 
     const labelModel = axisModel.getModel('axisLabel');
     const labelMargin = labelModel.get('margin');
-    const labels = axis.getViewLabels();
+    const { labels, rotation } = axis.getViewLabelsAndRotation();
 
     // Special label rotate.
-    const labelRotation = (
-        retrieve(opt.labelRotate, labelModel.get('rotate')) || 0
-    ) * PI / 180;
-
+    const labelRotation = (opt.labelRotate || labelModel.get('rotate') || rotation || 0) * PI / 180;
     const labelLayout = AxisBuilder.innerTextLayout(opt.rotation, labelRotation, opt.labelDirection);
     const rawCategoryData = axisModel.getCategories && axisModel.getCategories(true);
 

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -22,7 +22,9 @@ import {linearMap, getPixelPrecision, round} from '../util/number';
 import {
     createAxisTicks,
     createAxisLabels,
-    calculateCategoryInterval
+    calculateCategoryInterval,
+    calculateCategoryAutoLayout,
+    getAxisNameGap
 } from './axisTickLabelBuilder';
 import Scale from '../scale/Scale';
 import { DimensionName, ScaleDataValue, ScaleTick } from '../util/types';
@@ -224,6 +226,14 @@ class Axis {
         return createAxisLabels(this).labels;
     }
 
+    getViewLabelsAndRotation(): ReturnType<typeof createAxisLabels> {
+        return createAxisLabels(this);
+    }
+
+    getNameGap(): ReturnType<typeof getAxisNameGap> {
+        return getAxisNameGap(this);
+    }
+
     getLabelModel(): Model<AxisBaseOption['axisLabel']> {
         return this.model.getModel('axisLabel');
     }
@@ -269,6 +279,14 @@ class Axis {
         return calculateCategoryInterval(this);
     }
 
+    /**
+     * Only be called in category axis.
+     * Can be overridden, consider other axes like in 3D.
+     * @return Auto layout properties (interval, rotation) for cateogry axis tick and label
+     */
+    calculateCategoryAutoLayout(interval?: number): ReturnType<typeof calculateCategoryAutoLayout> {
+        return calculateCategoryAutoLayout(this, interval);
+    }
 }
 
 function fixExtentWithBands(extent: [number, number], nTick: number): void {

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -46,8 +46,9 @@ export interface AxisBaseOptionCommon extends ComponentOption,
         placeholder?: string;
     };
     nameTextStyle?: AxisNameTextStyleOption;
-    // The gap between axisName and axisLine.
+    // The gap between axisName and axisLine/labels
     nameGap?: number;
+    nameLayout?: 'auto';
 
     silent?: boolean;
     triggerEvent?: boolean;
@@ -220,6 +221,8 @@ interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     // Whether axisLabel is inside the grid or outside the grid.
     inside?: boolean,
     rotate?: number,
+    autoRotate?: boolean | [number, ...number[]],
+    minDistance?: number,
     // true | false | null/undefined (auto)
     showMinLabel?: boolean,
     // true | false | null/undefined (auto)
@@ -241,7 +244,11 @@ interface AxisLabelBaseOption extends Omit<TextCommonOption, 'color'> {
     // Color can be callback
     color?: ColorString | ((value?: string | number, index?: number) => ColorString)
     overflow?: TextStyleProps['overflow']
+    // approximate auto-layout computations (autoRotate, hideOverlap) if the total number of axis labels is over
+    // the trheshold; defaults to 40
+    layoutApproximationThreshold?: number
 }
+
 interface AxisLabelOption<TType extends OptionAxisType> extends AxisLabelBaseOption {
     formatter?: LabelFormatters[TType]
 }

--- a/src/coord/axisDefault.ts
+++ b/src/coord/axisDefault.ts
@@ -83,6 +83,7 @@ const defaultOption: AxisBaseOption = {
         // Whether axisLabel is inside the grid or outside the grid.
         inside: false,
         rotate: 0,
+        minDistance: 10,
         // true | false | null/undefined (auto)
         showMinLabel: null,
         // true | false | null/undefined (auto)

--- a/test/axis-labelAutoRotate.html
+++ b/test/axis-labelAutoRotate.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <script src="lib/draggable.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="lib/reset.css">
+    <style>
+      h1 {
+          line-height: 60px;
+          height: 60px;
+          background: #a60;
+          text-align: center;
+          font-weight: bold;
+          color: #eee;
+          font-size: 14px;
+      }
+
+      .chart {
+          height: 500px;
+      }
+
+      svg > g > text {
+        transition: all ease-in-out 0.5s;
+        color: red !important;
+        background-color: aqua;
+      }
+  </style>
+
+  </head>
+
+<body>
+    <div style="height:700px">
+        <div class="chart" id="autorotate"></div>
+    </div>
+
+    <div style="height:1000px">
+        <div class="chart" id="autorotate-y"></div>
+    </div>
+
+    <div class="chart" id="autorotate-zoom"></div>
+
+    <script>
+        const categoryAxis = {
+            type: 'category',
+            name: 'Day of the week',
+            nameLocation: 'middle',
+            nameLayout: 'auto',
+            nameGap: 8,
+            nameTextStyle: {
+                fontSize: 16,
+                padding: [6, 8],
+                backgroundColor: '#eeeeee'
+            },
+            data: ['Monday', 'hey, it\'s Tuesday!', 'yay, Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+            axisLabel: {
+                fontSize: 20,
+                margin: 12,
+                padding: 8,
+                backgroundColor: '#feee9e',
+                showMinLabel: true,
+                showMaxLabel: true
+            }
+        };
+
+        const valueAxis = {
+            type: 'value',
+            name: 'Value',
+            nameLocation: 'middle',
+            nameLayout: 'auto',
+            nameTextStyle: {
+                fontSize: 16,
+                padding: [6, 8],
+                backgroundColor: '#eeeeee'
+            },
+            axisLabel: {
+                fontSize: 16
+            }
+        };
+    </script>
+
+
+    <script>
+
+        require([
+            'echarts'
+        ], function (echarts) {
+
+            let invertedAxes = false;
+            let autoRotate = [0, 25, 45, 70, 90];
+            const option = {
+                grid: { left: 0, top: 10, right: 0, bottom: 10, containLabel: true },
+                xAxis: {
+                    ...categoryAxis,
+                    axisLabel: {
+                        ...categoryAxis.axisLabel,
+                        autoRotate,
+                    },
+                },
+                yAxis: valueAxis,
+                series: [{
+                    data: [120_000, 200_000, 150_000, 80_000, 70_000, 110_000, 130_000],
+                    type: 'bar'
+                }]
+            };
+
+            const chart = testHelper.create(echarts, 'autorotate', {
+                title: 'Category labels should auto-rotate to avoid overlap / maximize vertical grid space as the chart is horizontally resized (rotation degrees: ' + autoRotate.join(', ') + ')',
+                option: option,
+                width: 700,
+                height: 500,
+                draggable: true,
+                buttons: [{
+                    text: 'Toggle axes location',
+                    onclick: function () {
+                        invertedAxes = !invertedAxes;
+                        chart.setOption(invertedAxes ? {
+                            grid: { left: 10, top: 0, right: 0, bottom: 10, containLabel: true },
+                            xAxis: { position: 'top' },
+                            yAxis: { position: 'right' }
+                        } : {
+                            grid: { left: 0, top: 10, right: 0, bottom: 0, containLabel: true },
+                            xAxis: { position: 'left' },
+                            yAxis: { position: 'bottom' }
+                        });
+                    }
+                }, {
+                    text: 'Toggle rotation direction',
+                    onclick: function () {
+                        autoRotate = autoRotate.map(x => -x);
+                        chart.setOption({
+                            xAxis: {
+                                axisLabel: {
+                                    autoRotate,
+                                }
+                            }
+                        });
+                    }
+                }
+                ],
+            });
+        });
+    </script>
+
+
+    <script>
+
+        require([
+            'echarts'
+        ], function (echarts) {
+
+            let invertedAxes = false;
+            let autoRotate = [55, 45, 35, 25, 15, 0];
+            const option = {
+                grid: { left: 0, top: 10, right: 10, bottom: 0, containLabel: true },
+                xAxis: valueAxis,
+                yAxis: {
+                    ...categoryAxis,
+                    axisLabel: {
+                        ...categoryAxis.axisLabel,
+                        autoRotate,
+                    },
+                    axisTick: {
+                        alignWithLabel: true
+                    }
+                },
+                series: [{
+                    data: [120_000, 200_000, 150_000, 80_000, 70_000, 110_000, 130_000],
+                    type: 'bar'
+                }]
+            };
+
+            const chart = testHelper.create(echarts, 'autorotate-y', {
+                title: 'Category labels should auto-rotate as the chart is vertically resized (rotation degrees: ' + autoRotate.join(', ') + ')',
+                option: option,
+                width: 700,
+                height: 500,
+                draggable: true,
+                buttons: [{
+                    text: 'Toggle axes location',
+                    onclick: function () {
+                        invertedAxes = !invertedAxes;
+                        chart.setOption(invertedAxes ? {
+                            grid: { left: 10, top: 0, right: 0, bottom: 10, containLabel: true },
+                            xAxis: { position: 'top' },
+                            yAxis: { position: 'right' }
+                        } : {
+                            grid: { left: 0, top: 10, right: 0, bottom: 0, containLabel: true },
+                            xAxis: { position: 'left' },
+                            yAxis: { position: 'bottom' }
+                        });
+                    }
+                }, {
+                    text: 'Toggle rotation direction',
+                    onclick: function () {
+                        autoRotate = autoRotate.map(x => -x);
+                        chart.setOption({
+                            yAxis: {
+                                axisLabel: {
+                                    autoRotate,
+                                }
+                            }
+                        });
+                    }
+                }
+                ]
+            });
+        });
+    </script>
+
+
+    <script>
+
+        require([
+            'echarts'
+        ], function (echarts) {
+
+            const dataCount = 2000;
+            const data = [];
+            const categories = [];
+            for (var i = 0; i < dataCount; i++) {
+                const cat = 'category' + i;
+                categories.push(cat);
+                data.push(Math.random());
+            }
+
+            const startValue = 0;
+            const endValue = dataCount;
+            const autoRotate = [0, 25, 45, 55, 70, 90];
+
+            var option = {
+                tooltip: {
+                    trigger: 'axis'
+                },
+                dataZoom: [{
+                    startValue: startValue,
+                    endValue: endValue
+                }, {
+                    type: 'inside',
+                    startValue: startValue,
+                    endValue: endValue
+                }],
+                grid: {
+                    left: '3%',
+                    right: '4%',
+                    bottom: 60,
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    data: categories,
+                    axisLabel: {
+                        autoRotate
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                },
+                series: [
+                    {
+                        type: 'line',
+                        data: data
+                    }
+                ]
+            };
+
+            testHelper.create(echarts, 'autorotate-zoom', {
+                title: 'Category labels should auto-rotate as the chart is zoomed (rotation degrees: ' + option.xAxis.axisLabel.autoRotate.join(', ') + ')',
+                option: option
+            });
+        });
+
+    </script>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Adds an option to auto-rotate category labels based on available space, specified category interval, and the list of provided rotations.

### Fixed issues

- [#14996](https://github.com/apache/echarts/issues/14996)
- [#9265](https://github.com/apache/echarts/issues/9265) (partially)


## Details

### Before: What was the problem?

The [axis label rotation option](https://echarts.apache.org/en/option.html#xAxis.axisLabel.rotate) enhances usability of charts with a large number of categories and/or long category names by sparing the user the effort of hovering over specific value just to see its corresponding category; the usability enhancement is even greater for non-interactive, statically rendered charts.  The rotation option currently has to be chosen beforehand, though, which is suboptimal when a chart is populated with dynamic data -- depending on the data, the labels might or might need to be rotated, and the optimal rotation angle might vary.

### After: How does it behave after the fixing?

This PR introduces a new `axisLabel.autoRotate: boolean | number[]` option, which works in concert with the `axisLabel.interval: 'auto'` and `grid.containLabel: true` options to automatically manage (category) label rotation, interval, and layout:

https://github.com/apache/echarts/assets/3394202/2e672060-6500-4db9-9a9b-ecc85a38329e

https://github.com/apache/echarts/assets/3394202/78263dae-595d-4cee-8c7a-9e5e03fcbfa5

https://github.com/apache/echarts/assets/3394202/f8c13285-38c3-44a8-b020-8dba833eeed6


## Document Info

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

I'll update the documentation once the API is settled. 

## Misc

### Related test cases or examples to use the new APIs

See the new `axis-labelAutoRotate.html` test cases.


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.
