### PR TITLE
feat: Add option to dataZoom to support nature move or smoothly move/scale when using track pad like on track pad of mac.

### DIFF
--- a/src/component/dataZoom/InsideZoomModel.ts
+++ b/src/component/dataZoom/InsideZoomModel.ts
@@ -20,6 +20,12 @@
 import DataZoomModel, {DataZoomOption} from './DataZoomModel';
 import { inheritDefaultOption } from '../../util/component';
 
+export interface NatureMoveOnMouseWheelOpt {
+  windowScrollSpeedFactor?: number
+  zoomFactor?: number
+  wheelZoomSpeed?: number
+}
+
 export interface InsideDataZoomOption extends DataZoomOption {
 
     /**
@@ -37,6 +43,12 @@ export interface InsideDataZoomOption extends DataZoomOption {
     moveOnMouseMove?: boolean | 'shift' | 'ctrl' | 'alt'
 
     moveOnMouseWheel?: boolean | 'shift' | 'ctrl' | 'alt'
+
+    /**
+     * Whether enable touchpad, if open this,
+     * other options such as `zoomOnMouseWheel` `moveOnMouseMove` will be ignored.
+     */
+    natureMoveOnMouseWheel?: boolean | NatureMoveOnMouseWheelOpt
 
     preventDefaultMouseMove?: boolean
 

--- a/test/gesture.html
+++ b/test/gesture.html
@@ -1,0 +1,171 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </head>
+    <body>
+        <style>
+            h1 {
+                line-height: 60px;
+                height: 60px;
+                background: #146402;
+                text-align: center;
+                font-weight: bold;
+                color: #eee;
+                font-size: 14px;
+            }
+            .chart {
+                height: 600px;
+            }
+        </style>
+
+        <div id="main" class="chart"></div>
+        <script>
+
+        require(
+            ['echarts'],
+            function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main'));
+                var data1 = [];
+                var data2 = [];
+                var data3 = [];
+                var random = function (max) {
+                  return (Math.random() * max).toFixed(3);
+                };
+                for (var i = 0; i < 500; i++) {
+                  data1.push([random(15), random(10), random(1)]);
+                  data2.push([random(10), random(10), random(1)]);
+                  data3.push([random(15), random(10), random(1)]);
+                }
+                option = {
+                  animation: false,
+                  legend: {
+                    data: ['scatter', 'scatter2', 'scatter3']
+                  },
+                  tooltip: {},
+                  xAxis: {
+                    type: 'value',
+                    min: 'dataMin',
+                    max: 'dataMax',
+                    splitLine: {
+                      show: true
+                    }
+                  },
+                  yAxis: {
+                    type: 'value',
+                    min: 'dataMin',
+                    max: 'dataMax',
+                    splitLine: {
+                      show: true
+                    }
+                  },
+                  dataZoom: [
+                    {
+                      type: 'slider',
+                      show: true,
+                      xAxisIndex: [0],
+                      start: 1,
+                      end: 35
+                    },
+                    {
+                      type: 'slider',
+                      show: true,
+                      yAxisIndex: [0],
+                      left: '93%',
+                      start: 29,
+                      end: 36
+                    },
+                    {
+                      type: 'inside',
+                      xAxisIndex: [0],
+                      start: 1,
+                      end: 35
+                    },
+                    {
+                      type: 'inside',
+                      yAxisIndex: [0],
+                      start: 29,
+                      end: 36
+                    },
+                    {
+                      type: 'inside',
+                      natureMoveOnMouseWheel: true
+                    }
+                  ],
+                  series: [
+                    {
+                      name: 'scatter',
+                      type: 'scatter',
+                      itemStyle: {
+                        normal: {
+                          opacity: 0.8
+                        }
+                      },
+                      symbolSize: function (val) {
+                        return val[2] * 40;
+                      },
+                      data: data1
+                    },
+                    {
+                      name: 'scatter2',
+                      type: 'scatter',
+                      itemStyle: {
+                        normal: {
+                          opacity: 0.8
+                        }
+                      },
+                      symbolSize: function (val) {
+                        return val[2] * 40;
+                      },
+                      data: data2
+                    },
+                    {
+                      name: 'scatter3',
+                      type: 'scatter',
+                      itemStyle: {
+                        normal: {
+                          opacity: 0.8
+                        }
+                      },
+                      symbolSize: function (val) {
+                        return val[2] * 40;
+                      },
+                      data: data3
+                    }
+                  ]
+                };
+                chart.setOption(option);
+
+
+                window.onresize = chart.resize;
+            }
+        );
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information
Add option to dataZoom to support nature move or smoothly move/scale when using track pad like on track pad of mac.

This pull request is in the type of:

- [ x] bug fixing
- [ x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Add an option called natureMoveOnMouseWheel of dataZoom to support this feature.
When this option is set to true. The behavior of mac track pad on chart will act as on a normal page. Which means you can move up/down and zoom the chart in/out using two fingers!



### Fixed issues


- #17286
- #17288
- [related issue](https://github.com/chanzuckerberg/single-cell-data-portal/issues/4200)
- [related issue2](https://github.com/chanzuckerberg/sci-components/issues/523)


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
We can't use the touchpad to move the dataZoom. We just can scale it. And I wish that we can use the touchpad to move the dataZoom window. Such as lots of software, they can use the touchpad to scroll x direction and y direction both.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

You can see the test file in the `test/gesture.html` see the result.

https://github.com/apache/echarts/assets/33452468/24cbd002-c67b-406c-8fa7-a6c2660678b1


<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
