### PR TITLE
Fix #19247 - [Bug fixing] Echart splitline not showing on interval function (issue 19247)

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -301,8 +301,14 @@ function fixOnBandTicksCoords(
     let last;
     let diffSize;
     if (ticksLen === 1) {
-        ticksCoords[0].coord = axisExtent[0];
-        last = ticksCoords[1] = {coord: axisExtent[1]};
+        const dataExtent = axis.scale.getExtent();
+        const crossLen = dataExtent[1] - dataExtent[0];
+        const shift = (axisExtent[1] - axisExtent[0]) / crossLen;
+
+        ticksCoords[0].coord -= shift / 2;
+
+        last = {coord: axisExtent[1]};
+        ticksCoords.push(last);
     }
     else {
         const crossLen = ticksCoords[ticksLen - 1].tickValue - ticksCoords[0].tickValue;

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -298,17 +298,16 @@ function fixOnBandTicksCoords(
     }
 
     const axisExtent = axis.getExtent();
+    const dataExtent = axis.scale.getExtent();
     let last;
     let diffSize;
     if (ticksLen === 1) {
-        const dataExtent = axis.scale.getExtent();
         const crossLen = dataExtent[1] - dataExtent[0];
         const shift = (axisExtent[1] - axisExtent[0]) / crossLen;
 
         ticksCoords[0].coord -= shift / 2;
 
         last = {coord: axisExtent[1]};
-        ticksCoords.push(last);
     }
     else {
         const crossLen = ticksCoords[ticksLen - 1].tickValue - ticksCoords[0].tickValue;
@@ -318,13 +317,11 @@ function fixOnBandTicksCoords(
             ticksItem.coord -= shift / 2;
         });
 
-        const dataExtent = axis.scale.getExtent();
         diffSize = 1 + dataExtent[1] - ticksCoords[ticksLen - 1].tickValue;
 
         last = {coord: ticksCoords[ticksLen - 1].coord + shift * diffSize};
-
-        ticksCoords.push(last);
     }
+    ticksCoords.push(last);
 
     const inverse = axisExtent[0] > axisExtent[1];
 

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -306,7 +306,6 @@ function fixOnBandTicksCoords(
         const shift = (axisExtent[1] - axisExtent[0]) / (crossLen + 1);
 
         ticksCoords[0].coord -= shift / 2;
-        
         last = {coord: axisExtent[1]};
     }
     else {

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -303,10 +303,10 @@ function fixOnBandTicksCoords(
     let diffSize;
     if (ticksLen === 1) {
         const crossLen = dataExtent[1] - dataExtent[0];
-        const shift = (axisExtent[1] - axisExtent[0]) / crossLen;
+        const shift = (axisExtent[1] - axisExtent[0]) / (crossLen + 1);
 
         ticksCoords[0].coord -= shift / 2;
-
+        
         last = {coord: axisExtent[1]};
     }
     else {

--- a/test/splitline_2.html
+++ b/test/splitline_2.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        position: 'top', 
+                        data: ['', 'bbb', '', '', 'aaa', ''],
+                        splitLine: {
+                            show: true,
+                            lineStyle: {width: 11, color: 'red'},
+                            interval: function(index, value) {
+                                return value != '';
+                            }
+                        }
+                    },
+                    dataZoom: [
+                        {
+                        type: 'slider'
+                        }
+                    ],
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [150, 230, 224, 147, 260, 50],
+                        type: 'line'
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main0', {
+                        option: option
+                });
+            });
+            
+        </script>
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        position: 'top',
+                        data: ['', '', '', '', 'aaa', ''],
+                        splitLine: {
+                            show: true,
+                            lineStyle: {width: 11, color: 'red'},
+                            interval: function(index, value) {
+                                return value != '';
+                            }
+                        }
+                    },
+                    dataZoom: [
+                        {
+                        type: 'slider'
+                        }
+                    ],
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [150, 230, 224, 147, 260, 50],
+                        type: 'line'
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main1', {
+                        option: option
+                });
+            });
+            
+        </script>
+
+    </body>
+</html>

--- a/test/splitline_2.html
+++ b/test/splitline_2.html
@@ -39,6 +39,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
 
 
         <script>
@@ -119,6 +120,47 @@ under the License.
                 };
 
                 chart = myChart = testHelper.create(echarts, 'main1', {
+                        option: option
+                });
+            });
+            
+        </script>
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        position: 'top', 
+                        data: ['', 'interval_1', '', '', '', ''],
+                        splitLine: {
+                            show: true,
+                            interval: function(index, value) {
+                                return value != '';
+                            }
+                        }
+                    },
+                    dataZoom: [
+                        {
+                        type: 'slider'
+                        }
+                    ],
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [150, 230, 224, 147, 260, 50],
+                        type: 'line'
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main2', {
                         option: option
                 });
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR fixes the issue mentioned in issue 19247, where the splitline does not display at the right interval when there is only one tick given by the user. 


### Fixed issues

<!--
- #xxxx: ...
-->
https://github.com/apache/echarts/issues/19247



## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

When the given data array (which represents the intervals) has only one tick, the split line only appears at the left side of the graph. Datazoom-in also shows incorrect splitline. 

**Before Zooming in**
![image](https://github.com/apache/echarts/assets/96747053/9ef6b7de-71dc-4122-a276-6e4245667c6a)

**After Zooming in**
![image](https://github.com/apache/echarts/assets/96747053/b72101d7-1f71-4fdf-bc2e-90268fac3e01)


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

After the fix, the left splitline appears next to the correct interval given by the given data array. Datazoom-in also shows right interval splitline. 

**Before Zooming in**
![image](https://github.com/apache/echarts/assets/96747053/9a36fbd9-b9c4-4763-84c8-8d0667d5e54b)

**After zooming in**
![image](https://github.com/apache/echarts/assets/96747053/59e87e48-121d-4c79-92c6-fc82c6a48b34)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Axis.ts has been modified to fix the bug and a new html test file called splitline_2.html has been added under the test folder.