### PR TITLE
Fix #19247:[Bug fixing]Edge arrows do not scale on zoom in/out

### DIFF
--- a/src/chart/graph/GraphView.ts
+++ b/src/chart/graph/GraphView.ts
@@ -38,6 +38,7 @@ import { getECData } from '../../util/innerStore';
 
 import { simpleLayoutEdge } from './simpleLayoutHelper';
 import { circularLayout, rotateNodeLabel } from './circularLayoutHelper';
+import Graph from '../../data/Graph';
 
 function isViewCoordSys(coordSys: CoordinateSystem): coordSys is View {
     return coordSys.type === 'view';
@@ -276,6 +277,7 @@ class GraphView extends ChartView {
                 });
                 this._updateNodeAndLinkScale();
                 adjustEdge(seriesModel.getGraph(), getNodeGlobalScale(seriesModel));
+                this._updateEdgeSymbolScale(seriesModel.getGraph(), getNodeGlobalScale(seriesModel));
                 this._lineDraw.updateLayout();
                 // Only update label layout on zoom
                 api.updateLabelLayout();
@@ -291,6 +293,13 @@ class GraphView extends ChartView {
         data.eachItemGraphicEl(function (el: Symbol, idx) {
             el && el.setSymbolScale(nodeScale);
         });
+    }
+
+    _updateEdgeSymbolScale(graph: Graph, scale: number) {
+        graph.eachEdge(function (edge, idx) {
+            const line = edge.getGraphicEl() as Line;
+            line.setEdgeSymbolScale(scale);
+        })
     }
 
     updateLayout(seriesModel: GraphSeriesModel) {

--- a/src/chart/helper/Line.ts
+++ b/src/chart/helper/Line.ts
@@ -401,13 +401,11 @@ class Line extends graphic.Group {
         if (symbolFrom) {
             symbolFrom.setPosition(fromPos);
             setSymbolRotation(symbolFrom, 0);
-            symbolFrom.scaleX = symbolFrom.scaleY = invScale * percent;
             symbolFrom.markRedraw();
         }
         if (symbolTo) {
             symbolTo.setPosition(toPos);
             setSymbolRotation(symbolTo, 1);
-            symbolTo.scaleX = symbolTo.scaleY = invScale * percent;
             symbolTo.markRedraw();
         }
 
@@ -514,6 +512,14 @@ class Line extends graphic.Group {
                 align: label.__align || textAlign
             });
         }
+    }
+
+    setEdgeSymbolScale(scale: number) {
+        const lineGroup = this;
+        const symbolFrom = lineGroup.childOfName('fromSymbol') as ECSymbol;
+        const symbolTo = lineGroup.childOfName('toSymbol') as ECSymbol;
+        symbolFrom.scaleX = symbolFrom.scaleY =  scale;
+        symbolTo.scaleX = symbolTo.scaleY =  scale;
     }
 }
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Edge arrows now scale upon zooming in and out in graph view, just like the nodes

### Fixed issues

#19311 

## Details

### Before: What was the problem?

When zooming in and out on a graph, the nodes scale properly, but the arrows on the edges do not. This results in a visual imbalance where the arrows appear disproportionately large or small compared to the nodes at different zoom levels, leading to a degradation in the readability and aesthetic appeal of the graph.

Before Zooming:
![Screenshot 2023-12-12 at 01 15 38](https://github.com/apache/echarts/assets/82098467/3369499d-02ac-47c0-b6a9-859a2f2a499a)
After Zooming:
![Screenshot 2023-12-12 at 01 15 53](https://github.com/apache/echarts/assets/82098467/551ee881-217d-4547-b964-49bf7d4f586f)

### After: How does it behave after the fixing?

The arrows on the edges now scale in proportion with the nodes, maintaining a consistent and relative size at all zoom levels, ensuring a balanced and visually coherent graph representation, irrespective of the zoom.

Here the node is side 20 and arrow is 10. As shown in the screenshots, on both zoom levels, the arrow appears to be about half as large as the node.

Before Zooming:
![Screenshot 2023-12-12 at 01 16 03](https://github.com/apache/echarts/assets/82098467/59a31230-2e01-4441-8e39-1b3afd90684c)
After Zooming:
![Screenshot 2023-12-12 at 01 16 14](https://github.com/apache/echarts/assets/82098467/2aaceb7e-cada-465b-ab41-c0494495b13e)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
