### PR TITLE
Refactor ComposeUnitOption to use KnownKeys utility

### DIFF
--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -93,11 +93,17 @@ type GetDependency<DependencyOption extends ComponentOption> = {
 
 type GetDependencies<MainType extends string> = GetDependency<Dependencies[Extract<MainType, DependenciesKeys>]>;
 
+// Retrieves the keys of a type that are not of type string or number.
+// https://github.com/microsoft/TypeScript/issues/25987#issuecomment-870515762
+type KnownKeys<T> = keyof {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: never
+};
+
 type ComposeUnitOption<OptionUnion extends ComponentOption> =
     // Will be never if some component forget to specify mainType.
     CheckMainType<GetMainType<OptionUnion>> &
     Omit<EChartsCoreOption, 'baseOption' | 'options'> & {
-        [key in GetMainType<OptionUnion>]?: Arrayable<
+        [key in KnownKeys<GetMainType<OptionUnion>>]?: Arrayable<
             ExtractComponentOption<OptionUnion, key>
         // TODO: It will make error log too complex.
         // So this more strict type checking will not be used currently to make sure the error msg is friendly.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details
Retrieves the keys of a type that are not of type string or number

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->




### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
the `KnownKeys` type allows you to focus on the known keys of a type and disregard any keys defined via index signatures, providing more control and specificity when working with object properties
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->




## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
