### PR TITLE
feat(pie): 'itemRadiusScale' function added for pie series

### DIFF
--- a/src/chart/pie/pieLayout.ts
+++ b/src/chart/pie/pieLayout.ts
@@ -114,6 +114,7 @@ export default function pieLayout(
         const clockwise = seriesModel.get('clockwise');
 
         const roseType = seriesModel.get('roseType');
+        const itemRadiusScale = seriesModel.get('itemRadiusScale');
         const stillShowZeroSum = seriesModel.get('stillShowZeroSum');
 
         // [0...max]
@@ -188,6 +189,19 @@ export default function pieLayout(
                 actualEndAngle = endAngle - halfPadAngle;
             }
 
+            let outerRadius = r;
+            if (typeof itemRadiusScale === 'function') {
+                // calculate the radius of the current pie item based on the scale from the used-defined function
+                let scale = itemRadiusScale(seriesModel.getDataParams(idx)) || 0;
+                // scale should always be between 0 and 1
+                scale = Math.max(0, Math.min(scale, 1));
+                // r0 is used here to scale radius properly in case of 'donut' style.
+                outerRadius = (r - r0) * scale + r0;
+            }
+            else if (roseType) {
+                outerRadius = linearMap(value, extent, [r0, r]);
+            }
+
             data.setItemLayout(idx, {
                 angle: angle,
                 startAngle: actualStartAngle,
@@ -196,9 +210,7 @@ export default function pieLayout(
                 cx: cx,
                 cy: cy,
                 r0: r0,
-                r: roseType
-                    ? linearMap(value, extent, [r0, r])
-                    : r
+                r: outerRadius
             });
 
             currentAngle = endAngle;

--- a/test/pie-itemRadiusScale.html
+++ b/test/pie-itemRadiusScale.html
@@ -1,0 +1,244 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        #main {
+            width:  100%;
+            height: 92%;
+        }
+
+        p {
+            text-align: center;
+        }
+
+        button {
+            padding:    5px 15px;
+            background: lightgray;
+            cursor:     pointer;
+        }
+
+        button:hover {
+            background: transparent;
+        }
+    </style>
+</head>
+<body>
+<p>
+    <button type="button"
+            onclick="selectRandomValues()">
+        Random selection
+    </button>
+</p>
+<div id="main"></div>
+<script>
+    let dataset = {
+        dimensions: [ 'key', 'value', 'selected' ],
+        source:     [
+            [ 'A', 1092, 112 ],
+            [ 'B', 768, 499 ],
+            [ 'C', 604, 257 ],
+            [ 'D', 238, 180 ],
+        ],
+    };
+
+    function selectRandomValues() {
+        dataset.source.forEach(row => {
+            row[2] = row[1] * Math.random();
+        });
+        chart.setOption({ dataset });
+    }
+
+
+    function itemScale(params) {
+        const { data = [] } = params;
+        return data[2] / data[1];
+    }
+
+    function itemScaleQuadratic(params) {
+        const { value, encode } = params;
+        const val = value[encode.value?.[0]];
+        const selected = value[encode.value?.[1]];
+        const scale = selected / val;
+        return Math.pow(scale, 1 / 2);
+    }
+
+    function itemScaleCubic(params) {
+        const { value, encode } = params;
+        const val = value[encode.value?.[0]];
+        const selected = value[encode.value?.[1]];
+        const scale = selected / val;
+        return Math.pow(scale, 1 / 3);
+    }
+
+    let chart;
+
+    require([
+        'echarts'
+    ], function (echarts) {
+        chart = echarts.init(document.getElementById('main'), null, {});
+
+        chart.setOption({
+            legend:  {
+                itemStyle: { opacity: 1 },
+            },
+            tooltip: { trigger: 'item' },
+            dataset: dataset,
+            title:   [
+                createTitle([ 1, 1 ], 'default'),
+                createTitle([ 1, 2 ], 'extra pie as background'),
+                createTitle([ 1, 3 ], 'donut style'),
+                createTitle([ 2, 1 ], 'cubic scale'),
+                createTitle([ 2, 2 ], 'quadratic scale'),
+                createTitle([ 2, 3 ], 'quadratic scale + donut style'),
+            ],
+            series:  [
+                /* example #1: scaling based on a simple function */
+                createScaledSeries([ 1, 1 ], {}, itemScale),
+
+                /* example #2: add pie with the same angles, but full radius and semitransparent background */
+                createBackgroundSeries([ 1, 2 ]),
+                createScaledSeries([ 1, 2 ], {}, itemScale),
+
+                /* example #3: add donut with the same angles, but full outer radius and semitransparent background */
+                createBackgroundSeries([ 1, 3 ], { radius: [ '13%', '22%' ] }),
+                createScaledSeries([ 1, 3 ], { radius: [ '13%', '22%' ] }, itemScale),
+
+                /* example #4: almost the same as examples #2, but non-linear function used */
+                createBackgroundSeries([ 2, 1 ]),
+                createScaledSeries([ 2, 1 ], { encode: [ 'value', 'selected' ] }, itemScaleCubic),
+
+                /* example #5: almost the same as examples #2, but non-linear function used */
+                createBackgroundSeries([ 2, 2 ]),
+                createScaledSeries([ 2, 2 ], { encode: [ 'value', 'selected' ] }, itemScaleQuadratic),
+
+                /* example #6: almost the same as examples #3, but non-linear function used */
+                createBackgroundSeries([ 2, 3 ], { radius: [ '13%', '22%' ] }),
+                createScaledSeries([ 2, 3 ], { radius: [ '13%', '22%' ], encode: [ 'value', 'selected' ] }, itemScaleQuadratic),
+            ]
+        });
+
+        function createTitle(pos, text) {
+            return {
+                subtext:   text,
+                textAlign: 'center',
+                left:      `${(pos[1] / 3 - 1 / 6) * 100}%`,
+                top:       `${(pos[0] - 1) * 50 + 6}%`,
+            }
+        }
+
+        /**
+         * @param pos {number[]}
+         * @param [radius] {string[]|number[]}
+         * @param [encode] {string|string[]}
+         * @param itemRadiusScale {function}
+         * @return {*}
+         */
+        function createScaledSeries(pos, { radius, encode = 'value' } = {}, itemRadiusScale) {
+            return {
+                name:            `Selected ${encode instanceof Array ? encode[0] : encode}`,
+                type:            'pie',
+                center:          [
+                    `${(pos[1] / 3 - 1 / 6) * 100}%`,
+                    `${(pos[0] - 1) * 50 + 25}%`,
+                ],
+                radius:          radius || '22%',
+                z:               10,
+                emphasis:        { disabled: true },
+                encode:          {
+                    itemName: 'key',
+                    value:    encode,
+                },
+                itemRadiusScale: itemRadiusScale,
+                label:           {
+                    formatter(params) {
+                        console.log(params);
+                        const { name, data = [], percent, sum } = params;
+                        const value = data[1];
+                        const selected = data[2];
+                        const selectedPercent = Math.floor(selected / sum * 10_000) / 100;
+
+                        let text = `{bold|${name}: ${Math.round(selected)} (${selectedPercent}%)}`;
+                        text += `\n{small|Total: ${value} (${percent}%)}`;
+                        return text;
+                    },
+                    rich: {
+                        bold:  { fontWeight: 'bold', height: 21, fontSize: 14 },
+                        small: { fontStyle: 'italic' },
+                    },
+                },
+                tooltip:         {
+                    // formatter: `{b}: {e}, {f}%`,
+                    formatter(params) {
+                        const { seriesName, name, marker, data = [], sum } = params;
+                        const selected = data[2];
+                        const selectedPercent = Math.floor(selected / sum * 10_000) / 100;
+                        let text = `${seriesName}<br>`;
+                        text += `${marker} ${name}: <strong>${Math.round(selected)} (${selectedPercent}%)</strong><br>`;
+                        return text;
+                    },
+                },
+            };
+        }
+
+        /**
+         * @param pos {number[]}
+         * @param [radius] {string[]|number[]}
+         * @param [encode] {string}
+         * @return {*}
+         */
+        function createBackgroundSeries(pos, { radius, encode = 'value' } = {}) {
+            return {
+                name:      `Total ${encode}`,
+                type:      'pie',
+                center:    [
+                    `${(pos[1] / 3 - 1 / 6) * 100}%`,
+                    `${(pos[0] - 1) * 50 + 25}%`,
+                ],
+                radius:    radius || '22%',
+                label:     { show: false },
+                itemStyle: { opacity: 0.25 },
+                encode:    {
+                    itemName: 'key',
+                    value:    encode,
+                },
+                tooltip:   {
+                    formatter(params) {
+                        const { seriesName, name, marker, value, encode, percent } = params;
+                        const val = value[encode.value?.[0]] || '-';
+                        let text = `${seriesName}<br>`;
+                        text += `${marker} ${name}: <strong>${val} (${percent}%)</strong>`;
+                        return text;
+                    },
+                },
+            };
+        }
+    })
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
`itemRadiusScale` function added for pie series to control the radius of each item


### Fixed issues

<!--
- #xxxx: ...
-->
#19020
#15674

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
There was no easy option for pie charts to control the radius of items. In current version I can control either the whole pie radius or use some autocalculations with `roseType` option. But this is not suitable for our tasks. Earlier we used dashbords in PowerBI and the same feature in PBI looked like:


<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/16826622/0913325e-6a88-4aa3-be48-062b5c4464a9)
![image](https://github.com/apache/echarts/assets/16826622/e29cd6b2-9a89-4110-b32f-b61611ba10fc)


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
The solution is very similar with [scatter charts](https://echarts.apache.org/examples/en/editor.html?c=bubble-gradient) and its `symbolSize` option. Now (with this PR) i can pass custom function `itemRadiusScale`, which returns value from 0 to 1. That value is used within pie component to calculate outer radius for each item. In simple words, we now have a third dimension for each item, which means the size from center to the outer circle, almost like in scatter.

Also, few calculated values (sum, maxValue) passed into `getDataParams` callback to make tooltip calculations easier.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/16826622/8ad263ba-7e5b-45cd-b74d-896d70d65409)



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/pie-itemRadiusScale.html`

here some content from the test file

https://github.com/apache/echarts/assets/16826622/2464bf2c-48d4-4f20-b84b-c3a7c18e73d9


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This is my first PR here. Sorry, if i violated the rules (=
