### PR TITLE
chore(workflow): add a scheduled workflow to update the NOTICE year automatically

### DIFF
--- a/.github/workflows/.scripts/update-notice-year.js
+++ b/.github/workflows/.scripts/update-notice-year.js
@@ -1,0 +1,90 @@
+/**
+ * @typedef {import('@octokit/rest').Octokit} Octokit
+ * @typedef {import('@actions/github')['context']} Context
+ */
+
+module.exports = async function updateNoticeYear(
+  /** @type {{ octokit: Octokit, context: Context }} */
+  { octokit, context }
+) {
+  const newYear = new Date().getFullYear()
+  console.log('Prepare to update notice year to', newYear)
+
+  const noticeContent = `Apache ECharts
+Copyright 2017-${newYear} The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).`
+
+  const repoCtx = context.repo
+
+  const repoInfo = (await octokit.rest.repos.get(repoCtx)).data
+  const defaultBranchName = repoInfo.default_branch
+  const remoteNoticeFile = (await octokit.rest.repos.getContent({
+    ...repoCtx,
+    path: 'NOTICE',
+    ref: defaultBranchName
+  })).data
+  const remoteNoticeContent = base64ToUtf8(remoteNoticeFile.content)
+  if (remoteNoticeContent === noticeContent) {
+    console.log('NOTICE year is already updated.')
+    return
+  }
+
+  console.log('Ready to update the NOTICE file:\n' + noticeContent)
+
+  const defaultBranch = (await octokit.rest.repos.getBranch({
+    ...repoCtx,
+    branch: defaultBranchName
+  })).data
+
+  const newBranchName = `bot/update-notice-year/${newYear}`
+  await octokit.rest.git.createRef({
+    ...repoCtx,
+    ref: `refs/heads/${newBranchName}`,
+    sha: defaultBranch.commit.sha
+  })
+  console.log('Created a new branch:', newBranchName)
+
+  await octokit.rest.repos.createOrUpdateFileContents({
+    ...repoCtx,
+    path: 'NOTICE',
+    message: `chore: update NOTICE year to ${newYear}`,
+    content: utf8ToBase64(noticeContent),
+    sha: remoteNoticeFile.sha,
+    branch: newBranchName
+  })
+
+  console.log('Updated the NOTICE file on the new branch')
+
+  const pr = (await octokit.rest.pulls.create({
+    ...repoCtx,
+    head: newBranchName,
+    base: defaultBranchName,
+    maintainer_can_modify: true,
+    title: `chore: update NOTICE year to ${newYear}`,
+    body: `## Brief Information
+
+This pull request is in the type of:
+
+- [ ] bug fixing
+- [ ] new feature
+- [x] others
+
+### What does this PR do?
+
+Update notice year to ${newYear}. 💖
+
+Happy new year! 祝大家新年快乐！🎇`
+  })).data
+
+  console.log(`Opened PR #${pr.number} for updating the NOTICE file`)
+}
+
+function utf8ToBase64(data) {
+  return Buffer.from(data, 'utf-8').toString('base64')
+}
+
+function base64ToUtf8(data) {
+  return Buffer.from(data, 'base64').toString('utf-8')
+}

--- a/.github/workflows/update-notice-year.yml
+++ b/.github/workflows/update-notice-year.yml
@@ -22,7 +22,3 @@ jobs:
           script: |
             const updateNoticeYear = require('.github/workflows/.scripts/update-notice-year.js')
             await updateNoticeYear({ octokit: github, context })
-
-
-
-

--- a/.github/workflows/update-notice-year.yml
+++ b/.github/workflows/update-notice-year.yml
@@ -1,0 +1,28 @@
+name: Update NOTICE year
+
+on:
+  schedule:
+    # 1/1 00:00 UTC+8
+    - cron: '0 16 31 12 *'
+  workflow_dispatch:
+
+jobs:
+  update-notice-year:
+    if: ${{ github.repository_owner == 'apache' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows/.scripts
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const updateNoticeYear = require('.github/workflows/.scripts/update-notice-year.js')
+            await updateNoticeYear({ octokit: github, context })
+
+
+
+


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Add a scheduled workflow to update the NOTICE year on 1/1 00:00 (UTC+8) every year automatically.

![image](https://github.com/apache/echarts/assets/26999792/d183c3fe-eb91-4673-b858-e13655e86014)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
