### PR TITLE
chore(workflow): fix timezone error when getting new year by `new Date`

### DIFF
--- a/.github/workflows/.scripts/update-notice-year.js
+++ b/.github/workflows/.scripts/update-notice-year.js
@@ -7,7 +7,10 @@ module.exports = async function updateNoticeYear(
   /** @type {{ octokit: Octokit, context: Context }} */
   { octokit, context }
 ) {
-  const newYear = new Date().getFullYear()
+  const now = new Date()
+  // Change to UTC+8
+  now.setHours(now.getHours() + 8)
+  const newYear = now.getFullYear()
   console.log('Prepare to update notice year to', newYear)
 
   const noticeContent = `Apache ECharts


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Fix the timezone error when getting new year by `new Date`

#19453

https://github.com/apache/echarts/actions/runs/7371451106/job/20058853427#step:3:1

![image](https://github.com/apache/echarts/assets/26999792/ccb04ca8-b008-480e-a599-a069950cfdd9)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
