### PR TITLE
fix(ssr): remove redundant SVG attributes with `undefined` value

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -429,10 +429,14 @@ class ECharts extends Eventful<ECEventDefinition> {
 
         zrender.registerSSRDataGetter(el => {
             const ecData = getECData(el);
+            const dataIndex = ecData.dataIndex;
+            if (dataIndex == null) {
+                return;
+            }
             const hashMap = createHashMap();
             hashMap.set('series_index', ecData.seriesIndex);
-            hashMap.set('data_index', ecData.dataIndex);
-            hashMap.set('ssr_type', ecData.ssrType);
+            hashMap.set('data_index', dataIndex);
+            ecData.ssrType && hashMap.set('ssr_type', ecData.ssrType);
             return hashMap;
         });
 

--- a/src/util/innerStore.ts
+++ b/src/util/innerStore.ts
@@ -75,7 +75,7 @@ export const setCommonECData = (seriesIndex: number, dataType: SeriesDataType, d
                 childECData.seriesIndex = seriesIndex;
                 childECData.dataIndex = dataIdx;
                 childECData.dataType = dataType;
-                childECData.ssrType === 'chart';
+                childECData.ssrType = 'chart';
             });
         }
     }

--- a/test/svg-ssr.html
+++ b/test/svg-ssr.html
@@ -41,7 +41,6 @@ under the License.
 
 
 
-
         <script>
 
             require([
@@ -118,5 +117,42 @@ under the License.
         </script>
 
 
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    legend: {},
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                            name: 'line',
+                            data: [150, 230, 224, 218, 135, 147, 260],
+                            type: 'line'
+                        }
+                    ]
+                };
+                var myChart = testHelper.create(echarts, 'main1', {
+                    option: option,
+                    renderer: 'svg',
+                    title: 'There should not be SSR attribute with **undefined** value'
+                });
+                const svgDom = myChart.getZr().painter.getSvgDom();
+                const undefinedCount = Array.from(svgDom.querySelectorAll('path'))
+                    .filter(p => p.getAttribute('ecmeta_series_index') === 'undefined').length;
+                myChart.setOption({
+                    title: {
+                        text: 'UndefinedCount: ' + undefinedCount,
+                        textStyle: {
+                            color: undefinedCount > 0 ? 'red' : 'black'
+                        }
+                    }
+                });
+            });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

#18381 set some required metadata for SVG elements but it didn't skip the undefined values, which caused the chart to generate many redundant attributes with the 'undefined' value.

In this PR, I add a precheck for `dataIndex`. It will skip to set SSR data if the `dataIndex` is not present.

Also, I fixed an unexpected assignment:
```diff
- childECData.ssrType === 'chart';
+ childECData.ssrType = 'chart';
```

Besides, I also added a non-null check in zrender. Please refer to ecomfe/zrender#1048.

### Fixed issues

#18381

## Comparison

| Before | After |
| :----: | :----: |
| <img src="https://github.com/apache/echarts/assets/26999792/49affbab-c465-4908-9bbc-9850a3f1a16d" width="400"> | <img src="https://github.com/apache/echarts/assets/26999792/0fcc72b5-8ecd-4dcf-9f68-277669facde4" width="400"> |

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/svg-ssr.html`.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
