### PR TITLE
fix(dataZoom): prevent movement when zooming

### DIFF
--- a/src/component/dataZoom/InsideZoomView.ts
+++ b/src/component/dataZoom/InsideZoomView.ts
@@ -113,12 +113,19 @@ const getRangeHandlers: {
                 : (directionInfo.pixel - directionInfo.pixelStart)
             ) / directionInfo.pixelLength * (range[1] - range[0]) + range[0];
 
-        const scale = Math.max(1 / e.scale, 0);
-        range[0] = (range[0] - percentPoint) * scale + percentPoint;
-        range[1] = (range[1] - percentPoint) * scale + percentPoint;
+        let scale = Math.max(1 / e.scale, 0);
 
         // Restrict range.
         const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
+
+        if ((range[1] <= minMaxSpan.minSpan + range[0] && scale < 1)
+           || (range[1] >= minMaxSpan.maxSpan + range[0] && scale > 1)
+        ) {
+            scale = 1;
+        }
+
+        range[0] = (range[0] - percentPoint) * scale + percentPoint;
+        range[1] = (range[1] - percentPoint) * scale + percentPoint;
 
         sliderMove(0, range, [0, 100], 0, minMaxSpan.minSpan, minMaxSpan.maxSpan);
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

prevent moving when chart is scaled to  minSpan/maxSpan and moveOnMouseWheel = false


### Fixed issues

<!--
- #xxxx: ...
-->

#16144 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![CPT2401071529-1324x257](https://github.com/apache/echarts/assets/46096473/cebb73e0-6651-4696-938b-857e4c2d8dbc)



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![CPT2401071526-1230x182](https://github.com/apache/echarts/assets/46096473/915a579e-1fb2-4dee-8d4b-42eb5d1fa1f7)

## Document Info

One of the following should be checked.

- [X] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

