### PR TITLE
fix: fix using the toolbox to change line or bar charts but without u…

### DIFF
--- a/src/component/toolbox/feature/MagicType.ts
+++ b/src/component/toolbox/feature/MagicType.ts
@@ -116,7 +116,7 @@ class MagicType extends ToolboxFeature<ToolboxMagicTypeFeatureOption> {
                 zrUtil.defaults(newSeriesOpt, seriesModel.option);
                 (newOption.series as SeriesOption[]).push(newSeriesOpt);
             }
-            // Modify boundaryGap
+            // Modify series
             const coordSys = seriesModel.coordinateSystem;
             if (coordSys && coordSys.type === 'cartesian2d' && (type === 'line' || type === 'bar')) {
                 const categoryAxis = coordSys.getAxesByScale('ordinal')[0];
@@ -130,7 +130,6 @@ class MagicType extends ToolboxFeature<ToolboxMagicTypeFeatureOption> {
                     for (let i = 0; i <= axisIndex; i++) {
                         (newOption[axisType] as any)[axisIndex] = (newOption[axisType] as any)[axisIndex] || {};
                     }
-                    (newOption[axisType] as any)[axisIndex].boundaryGap = type === 'bar';
                 }
             }
         };


### PR DESCRIPTION
…ng default boundaryGap configuration.

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fixed using the toolbox to change line or bar charts but without using default boundaryGap configuration.

### Fixed issues

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
using the toolbox to change line or bar charts but without using default boundaryGap configuration.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
start
![image](https://github.com/apache/echarts/assets/37520757/f0cb7f67-57a0-46b6-a41a-69a11989e5f3)
before
![image](https://github.com/apache/echarts/assets/37520757/97946222-a149-4cf2-9574-3b243dcad76f)
after
![image](https://github.com/apache/echarts/assets/37520757/b3190772-65b5-4f26-aa3b-b7852796ac0c)

change
![image](https://github.com/apache/echarts/assets/37520757/cadd8c25-a6d2-4a18-9e67-f1d4609576cf)
![image](https://github.com/apache/echarts/assets/37520757/f96a060b-c7a5-4536-9a59-97352285f6ac)

official website demo
![image](https://github.com/apache/echarts/assets/37520757/78dbd92e-a5c9-437b-b6ec-61f62d25fd54)
![image](https://github.com/apache/echarts/assets/37520757/015de1d7-6fad-4e4a-b324-3fd225be8178)

[official demo](https://echarts.apache.org/examples/en/editor.html?c=line-marker)
modify xAxis->boundaryGap: fasle to boundaryGap: true, click run then click switch to line chart.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
