### PR TITLE
fix(marker): fix markArea position when axis is with `alignWithLabel`

### DIFF
--- a/src/chart/bar/BaseBarSeries.ts
+++ b/src/chart/bar/BaseBarSeries.ts
@@ -101,11 +101,12 @@ class BaseBarSeriesModel<Opts extends BaseBarSeriesOption<unknown> = BaseBarSeri
                     // If axis type is category, use tick coords instead
                     if (axis.type === 'category' && dims != null) {
                         const tickCoords = axis.getTicksCoords();
+                        const alignTicksWithLabel = axis.getTickModel().get('alignWithLabel');
 
                         let targetTickId = clampData[idx];
                         // The index of rightmost tick of markArea is 1 larger than x1/y1 index
                         const isEnd = dims[idx] === 'x1' || dims[idx] === 'y1';
-                        if (isEnd) {
+                        if (isEnd && !alignTicksWithLabel) {
                             targetTickId += 1;
                         }
 

--- a/test/markArea.html
+++ b/test/markArea.html
@@ -28,6 +28,8 @@ under the License.
     </head>
     <body>
         <div id="main0"></div>
+        <div id="main-align"></div>
+        <div id="main-overlapping"></div>
         <div id="main1"></div>
         <div id="main2"></div>
         <script>
@@ -133,7 +135,311 @@ under the License.
                 };
 
                 var chart = testHelper.create(echarts, 'main0', {
-                    option: option
+                    option: option,
+                    title: 'MarkArea with grid filter'
+                });
+            });
+
+        </script>
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                        axisTick: {
+                            alignWithLabel: true
+                        }
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                        data: [150, 230, 224, 218, 135, 147, 260],
+                        type: 'bar',
+                        markArea: {
+                            data: [
+                                [
+                                    {
+                                        xAxis: 'Tue'
+                                    },
+                                    {
+                                        xAxis: 'Fri'
+                                    }
+                                ]
+                            ]
+                        }
+                        }
+                    ]
+                };
+                var chart = testHelper.create(echarts, 'main-align', {
+                    option: option,
+                    title: ['MarkArea with alignWithLabel', 'MarkArea should be Tue ~ Fri']
+                });
+            });
+
+        </script>
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'category',
+                        data: Array.from(Array(2017).keys())
+                    },
+                    yAxis: { type: 'value', show: true, max: 100 },
+                    series: [
+                        {
+                        type: 'bar',
+                        data: [
+                            [65, 100, 0],
+                            [130, 100, 1],
+                            [196, 100, 2],
+                            [260, 100, 3],
+                            [325, 100, 4],
+                            [391, 100, 5],
+                            [456, 100, 6],
+                            [522, 100, 7],
+                            [1117, 100, 8],
+                            [1189, 100, 9],
+                            [1254, 100, 10],
+                            [1319, 100, 11],
+                            [1420, 100, 12],
+                            [1485, 100, 13],
+                            [1551, 100, 14],
+                            [1616, 100, 15],
+                            [1750, 100, 16],
+                            [1817, 100, 17],
+                            [1882, 100, 18],
+                            [1947, 100, 19],
+                            [2014, 100, 20],
+                            [2081, 100, 21],
+                            [2147, 100, 22]
+                        ],
+                        barGap: 0,
+                        zlevel: 1,
+
+                        barWidth: 1, //10,
+                        itemStyle: {
+                            color: 'red',
+                            opacity: 0.5
+                        },
+                        emphasis: {
+                            itemStyle: {
+                            color: '#ffb703',
+                            opacity: 1,
+                            borderWidth: 2,
+                            borderColor: '#fee440'
+                            }
+                        },
+                        markArea: {
+                            emphasis: {
+                            itemStyle: {
+                                color: '#48cae4',
+                                opacity: 0.5
+                            }
+                            },
+                            zlevel: 10,
+                            itemStyle: {
+                            //opacity: 0
+                            },
+                            data: [
+                            [
+                                {
+                                xAxis: '65'
+                                },
+                                {
+                                xAxis: '130'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '130'
+                                },
+                                {
+                                xAxis: '196'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '196'
+                                },
+                                {
+                                xAxis: '260'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '260'
+                                },
+                                {
+                                xAxis: '325'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '325'
+                                },
+                                {
+                                xAxis: '391'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '391'
+                                },
+                                {
+                                xAxis: '456'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '456'
+                                },
+                                {
+                                xAxis: '522'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '522'
+                                },
+                                {
+                                xAxis: '1117'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1117'
+                                },
+                                {
+                                xAxis: '1189'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1189'
+                                },
+                                {
+                                xAxis: '1254'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1254'
+                                },
+                                {
+                                xAxis: '1319'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1319'
+                                },
+                                {
+                                xAxis: '1420'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1420'
+                                },
+                                {
+                                xAxis: '1485'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1485'
+                                },
+                                {
+                                xAxis: '1551'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1551'
+                                },
+                                {
+                                xAxis: '1616'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1616'
+                                },
+                                {
+                                xAxis: '1750'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1750'
+                                },
+                                {
+                                xAxis: '1817'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1817'
+                                },
+                                {
+                                xAxis: '1882'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1882'
+                                },
+                                {
+                                xAxis: '1947'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '1947'
+                                },
+                                {
+                                xAxis: '2014'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '2014'
+                                },
+                                {
+                                xAxis: '2081'
+                                }
+                            ],
+                            [
+                                {
+                                xAxis: '2081'
+                                },
+                                {
+                                xAxis: '2147'
+                                }
+                            ]
+                            ]
+                        }
+                        }
+                    ],
+                    dataZoom: { endValue: 912 }
+                };
+                var chart = testHelper.create(echarts, 'main-overlapping', {
+                    option: option,
+                    title: [
+                        'MarkArea when some ticks are overlapping',
+                        'There should be **no overlapping around 456**',
+                        'This test case should be fixed in the future.'
+                    ]
                 });
             });
 


### PR DESCRIPTION
Partially fix (#18499). The case when some ticks are skipped due to overlapping is not fully fixed.

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix the markArea position when axis has `axisTick.alignWithLabel: true`.

### Fixed issues

- Partially fix (#18499)

When some ticks are skipped due to overlapping (with dataZoom), there still remain to be a bug. This problem is not fixed in this PR because I can't think of an easy way to fix this. I added this test case. We should fix this later.

<img width="1193" alt="image" src="https://github.com/apache/echarts/assets/779050/d4285ab0-401e-469b-a50e-76c652b52722">

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Wrong markArea position. [Demo](https://echarts.apache.org/examples/zh/editor.html?code=PYBwLglsB2AEC8sDeAoWsAeBBDEDOAXMmurGAJ4gCmRA5AMYCGYVA5sAE7m0A0J6AE2aMiAbVoBZGL1i0AKgFcqM2gHUqAlXIAWClQDEOEFQGVmphdFoBdPqViNceORHoBrIqnvoA9D9gAhAGwAO7aVHAABowANhCs0KoQYNoAMowARlQxkbD4sJFgHEqRPGThsAC2jBxuWBxUjLARAngOYAVmYLmWVBjU9CwCMeT8pLHxiclpmdlERUpjAL4kS3aw5Dj4nmMU1HQAbrFKtKvreFRGVISwomNe3kJgIrcAjACsAAxlAEwAzN9YD8fgAWX6vAAcZVef3e0JBAHZfgA2T62MboPY0WQZGq8DFVGp1BovB7eWBPF53cn2ak0-xk-mkbBOOiKZQE8lrTneRlMzBbG60QzGHn2Fb86w8qVc5YkKVLADcQA&version=5.4.3)

<img width="707" alt="image" src="https://github.com/apache/echarts/assets/779050/50bd767f-3837-433f-9501-706a311af7db">


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Correct markArea position.

<img width="774" alt="image" src="https://github.com/apache/echarts/assets/779050/f893199f-2f48-42e3-a543-d49b77b82a96">


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
