### PR TITLE
fix(bar): Fixing a missing bar in log scaled stack. close 19517

### DIFF
--- a/src/layout/barGrid.ts
+++ b/src/layout/barGrid.ts
@@ -545,7 +545,13 @@ export function createProgressiveLayout(seriesType: string): StageHandler {
                         else {
                             const coord = cartesian.dataToPoint([baseValue, value]);
                             if (stacked) {
-                                const startCoord = cartesian.dataToPoint([baseValue, startValue]);
+                                let adjustedStartValue = startValue;
+                                if (startValue === 0 && valueAxis.type === 'log') {
+                                    // Since log(0) == -Infinity, we adjust the start value to 1
+                                    // so that log(1) == 0, and the bars go from 0.
+                                    adjustedStartValue = 1;
+                                }
+                                const startCoord = cartesian.dataToPoint([baseValue, adjustedStartValue]);
                                 baseCoord = startCoord[1];
                             }
                             x = coord[0] + columnOffset;

--- a/test/bar-log.html
+++ b/test/bar-log.html
@@ -40,6 +40,7 @@ under the License.
 
 
         <div id="main0"></div>
+        <div id="main1"></div>
 
         <script>
 
@@ -72,6 +73,45 @@ under the License.
 
                 chart = myChart = testHelper.create(echarts, 'main0', {
                     title: 'bar in log axis',
+                    option: option,
+                    info: option
+                });
+            });
+
+        </script>
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require(['echarts'], function (echarts) {
+                option = {
+                    animation: false,
+                    yAxis: { 
+                        type: 'log'
+                    },
+                    xAxis: {
+                        type: 'category',
+                        data: ['First', 'Second']
+                    },
+                    series: [
+                        {
+                            type: 'bar',
+                            data: ['-', 2000],
+
+                            stack: 'main',
+                        },
+                        {
+                            type: 'bar',
+                            data: [2500, 3000],
+                            stack: 'main',
+                        }
+                    ]
+                };
+
+                chart = myChart = testHelper.create(echarts, 'main1', {
+                    title: 'There should be three stacked bars',
                     option: option,
                     info: option
                 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This change fixes a log scale of stacked bar chart - where some rectangles were getting Infinite height due to the log. 



### Fixed issues
- https://github.com/apache/echarts/issues/19517


## Details

### Before: What was the problem?

![image](https://github.com/apache/echarts/assets/74387947/058f1d0d-0d7a-4eb8-9fd0-c2ef78cf1f2f)


### After: How does it behave after the fixing?

After the fix, the bar is rendered as expected.

<img width="411" alt="image" src="https://github.com/apache/echarts/assets/74387947/990a49f8-6fd6-4344-8a26-b186cc06a682">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
