### PR TITLE
fix(ssr): hovering legend items should not trigger tooltip

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -226,12 +226,14 @@ class LegendView extends ComponentView {
                     .on('mouseover', curry(dispatchHighlightAction, seriesModel.name, null, api, excludeSeriesId))
                     .on('mouseout', curry(dispatchDownplayAction, seriesModel.name, null, api, excludeSeriesId));
 
-                itemGroup.eachChild(child => {
-                    const ecData = getECData(child);
-                    ecData.seriesIndex = seriesModel.seriesIndex;
-                    ecData.dataIndex = dataIndex;
-                    ecData.ssrType = 'legend';
-                });
+                if (ecModel.ssr) {
+                    itemGroup.eachChild(child => {
+                        const ecData = getECData(child);
+                        ecData.seriesIndex = seriesModel.seriesIndex;
+                        ecData.dataIndex = dataIndex;
+                        ecData.ssrType = 'legend';
+                    });
+                }
 
                 legendDrawnMap.set(name, true);
             }
@@ -277,12 +279,14 @@ class LegendView extends ComponentView {
                             .on('mouseover', curry(dispatchHighlightAction, null, name, api, excludeSeriesId))
                             .on('mouseout', curry(dispatchDownplayAction, null, name, api, excludeSeriesId));
 
-                        itemGroup.eachChild(child => {
-                            const ecData = getECData(child);
-                            ecData.seriesIndex = seriesModel.seriesIndex;
-                            ecData.dataIndex = dataIndex;
-                            ecData.ssrType = 'legend';
-                        });
+                        if (ecModel.ssr) {
+                            itemGroup.eachChild(child => {
+                                const ecData = getECData(child);
+                                ecData.seriesIndex = seriesModel.seriesIndex;
+                                ecData.dataIndex = dataIndex;
+                                ecData.ssrType = 'legend';
+                            });
+                        }
 
                         legendDrawnMap.set(name, true);
                     }

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -463,6 +463,11 @@ class TooltipView extends ComponentView {
             this._showAxisTooltip(dataByCoordSys, e);
         }
         else if (el) {
+            const ecData = getECData(el);
+            if (ecData.ssrType === 'legend') {
+                // Don't trigger tooltip for legend tooltip item
+                return;
+            }
             this._lastDataByCoordSys = null;
 
             let seriesDispatcher: Element;

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -427,18 +427,20 @@ class ECharts extends Eventful<ECEventDefinition> {
 
         }
 
-        zrender.registerSSRDataGetter(el => {
-            const ecData = getECData(el);
-            const dataIndex = ecData.dataIndex;
-            if (dataIndex == null) {
-                return;
-            }
-            const hashMap = createHashMap();
-            hashMap.set('series_index', ecData.seriesIndex);
-            hashMap.set('data_index', dataIndex);
-            ecData.ssrType && hashMap.set('ssr_type', ecData.ssrType);
-            return hashMap;
-        });
+        if (opts.ssr) {
+            zrender.registerSSRDataGetter(el => {
+                const ecData = getECData(el);
+                const dataIndex = ecData.dataIndex;
+                if (dataIndex == null) {
+                    return;
+                }
+                const hashMap = createHashMap();
+                hashMap.set('series_index', ecData.seriesIndex);
+                hashMap.set('data_index', dataIndex);
+                ecData.ssrType && hashMap.set('ssr_type', ecData.ssrType);
+                return hashMap;
+            });
+        }
 
         const zr = this._zr = zrender.init(dom, {
             renderer: opts.renderer || defaultRenderer,


### PR DESCRIPTION
fix a bug introduced by #18381

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

#18381 brings a bug that hovering the legend will show tooltips.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Tooltip shows when hovering the legend.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Tooltip not shows when hovering the legend.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
