### PR TITLE
fix(tooltip): get opacity from series visual

### DIFF
--- a/src/component/tooltip/seriesFormatTooltip.ts
+++ b/src/component/tooltip/seriesFormatTooltip.ts
@@ -48,7 +48,7 @@ export function defaultSeriesFormatTooltip(opt: {
     const value = series.getRawValue(dataIndex) as any;
     const isValueArr = isArray(value);
     const markerColor = retrieveVisualColorForTooltipMarker(series, dataIndex);
-    const markerOpacity = retrieveVisualOpacityForTooltipMarker(series, dataIndex);
+    const markerOpacity = retrieveVisualOpacityForTooltipMarker(series); ;
 
     // Complicated rule for pretty tooltip.
     let inlineValue;

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -480,9 +480,8 @@ export function retrieveVisualColorForTooltipMarker(
 
 export function retrieveVisualOpacityForTooltipMarker(
     series: SeriesModel,
-    dataIndex: number
 ): number {
-    const style = series.getData().getItemVisual(dataIndex, 'style');
+    const style = series.getData().getVisual('style');
     const opacity = style.opacity;
     return opacity;
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

fix bug introduced from https://github.com/apache/echarts/pull/18921


### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

**before:**
<img width="1799" alt="image" src="https://github.com/apache/echarts/assets/56526981/ab2f1335-e634-4ed9-a4b0-57ebb07f2d02">

<img width="1799" alt="image" src="https://github.com/apache/echarts/assets/56526981/d14cc4a2-ae14-43cd-85a4-295c03c1455e">


**after:**
<img width="941" alt="image" src="https://github.com/apache/echarts/assets/56526981/3c116454-c4d0-4063-833e-bddd39a7efc9">
<img width="1799" alt="image" src="https://github.com/apache/echarts/assets/56526981/c69bfc8c-00e8-4acf-bd33-03813001bf40">



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

get opacity from realtime visual color

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

Gets the series visual opacity like the legend, but the legend gets the opacity from `legendLineStyle` when `drawType` is stroke, so the legend markers are opaque in parallel series, and the default opacity of parallel series is 0.45, so the tooltip The marker's opacity is also 0.45.

https://github.com/apache/echarts/blob/master/src/component/legend/LegendView.ts#L610-L615
```typescript
    if ((itemStyle.opacity as any) === 'inherit') {
        /**
         * Use lineStyle.opacity if drawType is stroke
         */
        itemStyle.opacity = (drawType === 'fill' ? itemVisualStyle : lineVisualStyle).opacity;
    }
``` 

1. line series
If we set the opacity of lineStyle, the legend will respect these opacity.
[demo](https://echarts.apache.org/examples/zh/editor.html?c=line-stack&code=PYBwLglsB2AEC8sDeAoWtJgDYFMBcya6GOAHmAQOQDKYAhgMYDWOAJrADITQ6VEC-AGiJhgwLJBAFUxDACcIAc0U45VOqQgBnPuiFFcK6K2lF0rOvQIBtSgFEAtnQhZKg2JQCq0KHACCrDrulABqEKw4wLABQR4AIhByOAxgbh7UOHRyDAAWsHbQity8ALoCwuiKCiaEsrgAZhQeAMwApG5msAqKOU2UACztFcQARsBgog5UbR2yDDD03Bx0IzhYBGByAK445SJiWGOkprL1mWBbSSeysFp0AG44floAkk4q0vydX3rDpH6aLTXdBgACeIHwHgYlhwimAclBs1GwC2xiyoIA4nQpLB6nQsFocMNzJY6DZKABZGBpSgAFR2NIA6mwabSclsaQAxBQ06iWXmoyhlX5EUEA7TAjDgyGUe74hl7dCEhQ4IGwaydGQ3aB0BwyxzOVzE4hgiFULDFJGyLT0ZhUWnjfFW4gWKzqgCMACYAAzud3NT1-73uv3NfruACcvtgnua0c97u9JWN6AtPFooNwktkoEYEDBBG9ADpminYD9iPoiGV-ABuIA)
<img width="1794" alt="image" src="https://github.com/apache/echarts/assets/56526981/d3201baa-e318-400c-ba0b-35a7d15289ed">

2. parallel series
But for the parallel series, we set the opacity of lineStyle. At this time, the legend ignores the opacity in lineStyle.
[demo](https://echarts.apache.org/examples/zh/editor.html?c=parallel-aqi&code=PTAEGUGMAsFMFsCGAuAUCUATRAXWAaAQQEUBJASwDtNYAPfABQFkAmAOgFZGmBGABnwBhAPL4AcsJb5wk1JAD2lAM44suRACEAUqAC8oANqpQhnvlAcuoAJzmOANnN82AFkegeADnPuA5IHsg3wBdfGNDKVAWKx4zSNjneysAZhdzW1BfQAx5YNCTAyS7dwB2HwLQZzKeVItzAJywg2qkspLI9IrK9z9skIarFwiWapdq5yL3FwEPbvq8908Ijm8bKZ42Itb7ZebawN681qLh9I3zNbdzF2WWVrr9w2Wi5ctzT1W2FnSOdM_d2cMfvZWiweO4WG9LmxlvxlvZqr5ALOJgDK9QCGNoBl83-Bn4Z080Ru5hBYM4EXssXxGUAtHKojH3LGxJLpHjpJLLZwcVpJWI8KxZTE8CIuLmxSZOVxlEHmW49XKmMpw8wsyXVNZ8YZgiJ3GVY5V8R6MljvQ79WK-QDe8dS-dFdaUzqCzq5liMCX5zei-e4dqAwe02CkzmUedKGjxWtZqvZ3DF3hxwxFOX9aV4cZGBmdrHGoctrC10r4qW7E18ObEY6LrB6IlUE1qDQSItDWs4rgTKlNebSJaAGWdku4EmTGWV2zWImGfIyq5E2NbQEUyt2Mnsa2VrCdKtipy4WhNlpqGkMFVy41M2QrKzMO_1Bq0t2c7OKNUG8ixI6WPCGexzp1Z03Zd_maRrYE_Q8XEWymFxp31OVc2RAsa2hexVlrUCiVOGwSzbADMV-DwQPLM5EgJdZ5jKQValdQCGiSKYOEGcN3j4AMpk7Pc8njUALhqTifXBM4pgvVAggAblQAA3RAACc1BwRAAHEAC09EMYNnQVYFWjWUFxU0ocn3CV4rHsCIii5NgmSMqZdyXajJW2R5lV9ex50OasGmqTtOySPs2Gc4YplzfSDGNS4BR86xuVeLk9MxdwHDsElGWnIE0nPNyDh8JoWNZNh02qDgyXSh47H6Bz7RYbzJSsF8ioME55miHhKg-JJNMnck2NMALYk8LlVXtVUSwmNsbLyGJXiadIkLLeVIka2r-Uyuw-viKFjL_FsFpaAT9XeJlYV7BbqnQ_hoieYiYym5U_FG0wrSm5ZPEbXKCNnDzc0o91JTlLNnusPgrAKhV4VurFWjfckXGe75FkqDVQaTCxYlJNJnt65HolzBH0giyUjzM1rhkqaycKmOd-MrBZiKeG9lSxnDYnJiwyZ80ziwJEacPraoxw8EUpwq2FoRJjsVxaTT-o8cyiIsFpaoPGxBxY8kkly8Hoh5UGojOLjPGVBcVV5_mPwyT6O0jJr-OhVr7SuYVoR5M2gKiy5YUrXymTUrt5eeHcfGhX1Kq7UN5fSKmbErI4FQ-dp_Vqmj-ItyNPG2Xy-I8PguRdC1aQ4mJnhPe0WW3W0KJzoTRIk6TsFk8AAAllKMMa0mFPErGccOQIq-WfGqw4cs8CZqvp3PXjlKzHL4NcCVuUGdTD_HyqF5ay_gvpE8lNrJ_VlfTZzrVIynl2PE7NZ062XezX3hoJeKLeBp3pHV6ovJHqmqxzvKNbd5qxdMS-ecZFnqzQ4KsWefIrK0SsBCKWmcqoEhBnyIUrRepnAViqMi1V4RO2DKOE4XJUxS2RgKeGfIVxGSVkvJUdhOaJmVHaUAT1_RmShhNS4bYcFjStI9ZCBNDLqWfl9PC1RPCdE0tLOwN4hycNMIcdIt4M7iIBnYZk4DEyPGFPMH0g8lpzQWjjQ4QpmomxToeeWE9JEt1FGBCwyQTRax6psVsq0vgTHsVzfix02pJSPrOMiu4ZEGG7owzYlY-CrElIMEWNZrrQnTiGd2LgDGFFqNhS8vdLiA1WlHLsjI1E1g9D8JoOUUacU0lKHCHIikKh9N8GhaZahBXTtmf2aRIzfklD8EeNZGSmL5pUaw4iIxpC-CaNJWoE4eByU1Lk0zODcPqZSa-7EuRMP6RzAmYcAGpPLiJcSUlQBKBgAgRAjcwgAG9QCUEQPAWAyAMg11gL4cwVAaC0HuVMPAtAcD3N8IAU9NAD45r4UAABfGUlzrm3N-SQCg1A6DPNAK8ug9zYhfJ-RkGFwKwUXKuTcu5GRmBRARUi95kRzBot-YSzgWLwW4qhQS3gfBiVwtJWUClDL-A0pxZC_FvgRDMrefc6o7LgX8tBbSnlvyJAsAFci7iIrpVcpMBCvFvyZAypeSy-57gRXqqVaAFV9LfCAElvQA5X6ytJa0EVZqsUV32dJAANlQWA4AcAAE8HWwGUucsIAB3cgmAcDQBRTKeQAAHRAkByDuo-ZwVAILRLhpwOQRQ3qwgACNI0AGsADmkl5AAFdqCCHkA6-QklfkAGJmhJGeWET1ObYDUHuT6kwJh03yBwDgeQ8B7kJzCCYGuKBDC-A0LAcgAArKgOaEW-HANARAlAc0LvILOuSBbF05oAF7QELf8Ew0aEByUQGG-5tYB2gDRa6j1-LW1tpMAoMtFaMiVoAGbvrrfekwr7FA4HAOQLd-KqgXpBWEbFJhu2luTaeg1F6I2YEwNOlFAgL2ZsgLm_NRbMAlqfVWlg-HP1to7ZJGgkkcPlqrRsIohH23ltIwAdQDUGlFYGZQRskogB1nqHWEFoOQJQ9ym5trvfexDvbygynvZKw5xykAGD4EENgaLJNtqoGJWAkklD4pwJJAtBAL0mCQKyswBm6WwAADLyEgLgFNlBfkqCkjgXwIGVOXLEyGsz9yjlwDkzwRTaLxUXrc-QcTERpPeZOUE_zdBVDgeE1gELfbzDhdk4gfI0XvmBfvcF8T1QUs-bSy4DLsXXMJfE1YfLkWODFay_F9zXpkuqpkwVgw9gatxeVaZ-rJRTOVbk0UYrKmINurDby6zeAc3lrdTRttQ7BO8j-IInZbpahwQxLUQApHIIgLCBsI9wMBiX4xuh1TAT0trCBgEwShd2-vuTpvTMpLugHgFQD5j2wCGcQKS7kKGTBPbE02pQtmz3vdU5QAASpu29F2PttsfRRkdlbMBhlgBwTAs7K2wEjXOewGPQGICSJm4IbBJKwHU5p2AAAKAAlDDr9GB4eSUIA6sNC7BOrCCHTkwoG_tgDi-xzj3Hzv3s9a-9FvgOAAFIZuSXIMu8XXhpcqY7V2ntyHfttoF1x2APG-NKAACKwFfYgAtDr0Uibbe60bvyJIOr0zNkw0nfAwsAODGgAHUwd2Zyz43gcZCbejobZnj0wfPV-szAAVGL17PXC7D6ARnVb32vs99-39_7AMopYKZjrbavv8fM862PYenWUBde6mPsG49w9LQj3wlbEAN-c1XnnX6c8mDz0ocP5B0NF6_SXsvN7e9h4Ty-qjTe48t_vW3w5YanU4AL6XofbbrvyFu6AY3DqtPZ8Dx38ziB0066Xw-mvz669J_H1P3b3OZRadl7AATKlsu9aa6O8dU6l2e6t7yrX3HPf9-j_iv_uXvpmHnNjJJoFoC5kFs_kavOpuiup_iNt_lJILjrn_s6gAfckATeoHmAUOvXFAU_mHk7uupujunuoHl_r8j_mgYHtgRXvQSAV-ngeoIpFfqAJzgmkAA)
<img width="1799" alt="image" src="https://github.com/apache/echarts/assets/56526981/5b78f6f1-a2fd-462d-9a3a-25a9c3f97b59">

I'm not sure this is the appropriate way to fix this error, could you give me some suggestions?@Ovilia 

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
