### PR TITLE
Fix: esm issue 

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -111,13 +111,32 @@ async function run() {
     }
     else {
         const types = buildType.split(',').map(a => a.trim());
-        const cfgs = types.map(type =>
-            config.createECharts({
-                ...opt,
-                type
-            })
-        );
-        await build(cfgs);
+
+
+        // Since 5.5.0, echarts/package.json added `{"type": "module"}`, and added
+        // echarts/dist/package.json with `{"type": "commonjs"}`, both of which makes
+        // echarts/dist/echarts.esm.js can not be recognized as esm any more (at least
+        // in webpack5 and nodejs) any more. So we provides echarts/dist/echarts.esm.mjs.
+        // But for backward compat, we still provide provides echarts/dist/echarts.esm.js.
+        const isBuildingDistESM = (opt.format || '').toLowerCase() === 'esm';
+        if (isBuildingDistESM) {
+            await makeConfigAndBuild(opt, '.js');
+            await makeConfigAndBuild(opt, '.mjs');
+        }
+        else {
+            await makeConfigAndBuild(opt);
+        }
+
+        async function makeConfigAndBuild(opt, fileExtension) {
+            const cfgs = types.map(type =>
+                config.createECharts({
+                    ...opt,
+                    type,
+                    fileExtension
+                })
+            );
+            await build(cfgs);
+        }
     }
 }
 

--- a/build/config.js
+++ b/build/config.js
@@ -38,7 +38,7 @@ function createAddLicensePlugin(sourcemap) {
     }
 }
 
-function createOutputs(basename, { min }, commonOutputOpts) {
+function createOutputs(basename, { min, fileExtension }, commonOutputOpts) {
     commonOutputOpts = {
         format: 'umd',
         ...commonOutputOpts
@@ -59,7 +59,7 @@ function createOutputs(basename, { min }, commonOutputOpts) {
             createReplacePlugin('development'),
             createAddLicensePlugin(true)
         ],
-        file: basename + '.js'
+        file: basename + (fileExtension || '.js')
     }];
 
     if (min) {
@@ -73,7 +73,7 @@ function createOutputs(basename, { min }, commonOutputOpts) {
                 terser(),
                 createAddLicensePlugin(false)
             ],
-            file: basename + '.min.js'
+            file: basename + '.min' + (fileExtension || '.js')
         })
     }
     return output;
@@ -86,6 +86,7 @@ function createOutputs(basename, { min }, commonOutputOpts) {
  * @param {string} [opt.format='umd'] If set, `opt.input` is required too, and `opt.type` is ignored.
  * @param {string} [opt.min=false] If build minified output
  * @param {boolean} [opt.addBundleVersion=false] Only for debug in watch, prompt that the two build is different.
+ * @param {string} [opt.fileExtension=undefined] output file extension, default is '.js'. Should start with '.'.
  */
 exports.createECharts = function (opt = {}) {
     const srcType = opt.type !== 'all' ? '.' + opt.type : '';

--- a/package.README.md
+++ b/package.README.md
@@ -1,5 +1,10 @@
 # NOTICE about package.json
 
+See more details about in the "exports" field of `package.json` and why it is written like that in https://github.com/apache/echarts/pull/19513 .
+
+
+## Public and private
+
 Only these entries are officially exported to users:
 + `'echarts'`
 + `'echarts/index.js'`
@@ -20,6 +25,13 @@ Only these entries are officially exported to users:
 
 The other entries listed in the `"exports"` field of `package.json` make the internal files visible, but they are legacy usages, not recommended but not forbidden (for the sake of keeping backward compatible). These entries are made from the search in github about which internal files are imported.
 
+
+## File extension fully specified
+
 Since `v5.5.0`, `"type": "module"` and `"exports: {...}"` are added to `package.json`. When upgrading to `v5.5.0+`, if you meet some problems about "can not find/resolve xxx" when importing `echarts/i18n/xxx` or `echarts/theme/xxx` or some internal files, it probably because of the issue "file extension not fully specified". Please try to make the file extension fully specified (that is, `import 'xxx/xxx/xxx.js'` rather than `import 'xxx/xxx/xxx'`), or change the config of you bundler tools to support auto adding file extensions.
 
-See more details about in the "exports" field of `package.json` and why it is written like that in https://github.com/apache/echarts/pull/19513 .
+
+## Use physical entry file or alias in `"exports"` of `package.json`
+
+Although using `"exports"` of `package.json` we can make alias (or say, route) to physical file (for example: `{ "exports": { "./xxx": "./yyy/zzz.js" } }` enables `import 'echarts/xxx'` to route to `'echarts/yyy/zzz.js'`), at present we can not make sure all the versions of bundle tools and runtimes in use do it consistently. So we do not use the alias setting, but keep providing physical file for each public entry. For example, for an official public entry `'echarts/core'`, we provide a file `echarts/core.js` (and `echarts/core.d.ts`).
+

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     ".": {
       "types": "./index.d.ts",
       "import": "./index.js",
-      "require": "./index.js"
+      "require": "./dist/echarts.js"
     },
     "./core": "./core.js",
     "./core.js": "./core.js",
@@ -200,6 +200,18 @@
     "./lib/component/visualMap": "./lib/component/visualMap.js",
     "./lib/component/visualMapContinuous": "./lib/component/visualMapContinuous.js",
     "./lib/component/visualMapPiecewise": "./lib/component/visualMapPiecewise.js",
+    "./dist/echarts.common": "./dist/echarts.common.js",
+    "./dist/echarts.common.min": "./dist/echarts.common.min.js",
+    "./dist/echarts.esm": "./dist/echarts.esm.mjs",
+    "./dist/echarts.esm.min": "./dist/echarts.esm.min.mjs",
+    "./dist/echarts": "./dist/echarts.js",
+    "./dist/echarts.min": "./dist/echarts.min.js",
+    "./dist/echarts.simple": "./dist/echarts.simple.js",
+    "./dist/echarts.simple.min": "./dist/echarts.simple.min.js",
+    "./dist/extension/bmap": "./dist/extension/bmap.js",
+    "./dist/extension/bmap.min": "./dist/extension/bmap.min.js",
+    "./dist/extension/dataTool": "./dist/extension/dataTool.js",
+    "./dist/extension/dataTool.min": "./dist/extension/dataTool.min.js",
     "./*": "./*"
   }
 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Previous issue https://github.com/apache/echarts/pull/19513

This PR fixes:
+ (1) Mistake in package.json "exports"."require".
+ (2) Add entry for dist/** for "file extension not specified" usage. 
+ (3) Add `dist/echarts.esm.mjs` (after build). Originally there is only `dist/echarts.esm.js`, which is a ESM file. Since `dist/package.json` with `{"type": "commonjs"}` is added, webpack5 can not recognize it as ESM by default. This is a breaking change. So add `dist/echarts.esm.mjs` for the uses that get that trouble.
