### PR TITLE
Fix stacked areas overflow on null values when connectNulls is true

### DIFF
--- a/src/chart/line/helper.ts
+++ b/src/chart/line/helper.ts
@@ -117,18 +117,27 @@ export function getStackedOnPoint(
     data: SeriesData,
     idx: number
 ) {
-    let value = NaN;
+    let stackedOverValue = NaN;
+    let stackResultValue = NaN;
     if (dataCoordInfo.stacked) {
-        value = data.get(data.getCalculationInfo('stackedOverDimension'), idx) as number;
+        stackedOverValue = data.get(
+            data.getCalculationInfo('stackedOverDimension'),
+            idx
+        ) as number;
+        stackResultValue = data.get(
+            data.getCalculationInfo('stackResultDimension'),
+            idx
+        ) as number;
     }
-    if (isNaN(value)) {
-        value = dataCoordInfo.valueStart;
+
+    if (isNaN(stackedOverValue) && !isNaN(stackResultValue)) {
+        stackedOverValue = dataCoordInfo.valueStart;
     }
 
     const baseDataOffset = dataCoordInfo.baseDataOffset;
     const stackedData = [];
     stackedData[baseDataOffset] = data.get(dataCoordInfo.baseDim, idx);
-    stackedData[1 - baseDataOffset] = value;
+    stackedData[1 - baseDataOffset] = stackedOverValue;
 
     return coordSys.dataToPoint(stackedData);
 }

--- a/src/chart/line/helper.ts
+++ b/src/chart/line/helper.ts
@@ -130,7 +130,7 @@ export function getStackedOnPoint(
         ) as number;
     }
 
-    if (isNaN(stackedOverValue) && !isNaN(stackResultValue)) {
+    if (isNaN(stackedOverValue) && !(dataCoordInfo.stacked && isNaN(stackResultValue))) {
         stackedOverValue = dataCoordInfo.valueStart;
     }
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

[Minimal reproduction](https://echarts.apache.org/examples/en/editor.html?c=line-simple&code=PYBwLglsB2AEC8sDeAoWsAmBDMWDOApmAFzJrqYQC2B0eUdpA2gEQAeLANLCwJ5c9eAJgF8AzCwC6ncujzAArgCcAxgWayKSWG1IBGbr1JDDQ0gFZDY47AC-Milp3HDpaAoA2H028_fYvNaw7l52Do7IzrBirtE-sAYBQUJhmpLk9uRsAIJsEHikqI5gvCDqsADkKjgEAObASrwV4ZnovLn5hZolZaQVAG5YHgoEFRnhhEoQBAWwTJpFET3lFR4Q0KPhjiowGypgAHJ-s2BKI1sUWEoEWADKJR7lSK0RtDsYT5qOujwcF45GQRcL6pCKwPC4FQAa1ILAhWGhwMcL3Qi2KpRWaw2zRBO2ge0Ox1Ip3OIKuN3uvEehRRFDewA-XTB6B-7CRzMBfBE_1BEXh0Nh_Kh7PQtLRFGWfSxm1xuwI-yOXhOZwIPPJdweT1p6HpjLIzKibJ5bVhgRFFG14MhMJ4QvNtnI6VsAG4gA)
[Fix on the preview branch](https://echarts.apache.org/examples/en/editor.html?version=PR-19602%40536da2c&code=PYBwLglsB2AEC8sDeAoWsAmBDMWDOApmAFzJrqYQC2B0eUdpA2gEQAeLANLCwJ5c9eAJgF8AzCwC6ncujzAArgCcAxgWayKSWG1IBGbr1JDDQ0gFZDY47AC-Milp3HDpaAoA2H028_fYvNaw7l52Do7IzrBirtE-sAYBQUJhmpLk9uRsAIJsEHikqI5gvCDqsADkKjgEAObASrwV4ZnovLn5hZolZaQVAG5YHgoEFRnhhEoQBAWwTJpFET3lFR4Q0KPhjiowGypgAHJ-s2BKI1sUWEoEWADKJR7lSK0RtDsYT5qOujwcF45GQRcL6pCKwPC4FQAa1ILAhWGhwMcL3Qi2KpRWaw2zRBO2ge0Ox1Ip3OIKuN3uvEehRRFDewA-XTB6B-7CRzMBfBE_1BEXh0Nh_Kh7PQtLRFGWfSxm1xuwI-yOXhOZwIPPJdweT1p6HpjLIzKibJ5bVhgRFFG14MhMJ4QvNtnI6VsAG4gA)

The pull request fixes the logic of computing stacked on points of stacked areas which fixes areas overflow on null values when `connectNulls` is true.

Stacked on value can be `NaN` when:
1) When the value of series exists but there is no series below it or the series it is stacked on do not have suitable values according to `stackStrategy`
2) When the value of series itself is `NaN`

The `getStackedOnPoint` function behaved the same in both scenarios, when the stacked on value is `NaN` it decided that the area should be stacked on the `valueStart` of the series coordinates. However, when the value of series itself is `NaN` the stacked on value should be NaN as well for `connectNulls` option to work correctly and just connect the line without dropping it to the start of coordinates.

### Fixed issues

Closes https://github.com/apache/echarts/issues/19598
Closes https://github.com/apache/echarts/issues/17135

## Details

There is an existing test case `area-stack.html` which has a chart affected by the issue.

### Before: What was the problem?

Yellow and blue areas have enabled `connectNulls` so the lines in the middle are connected but areas drop to the start of coordinates.

<img width="1442" alt="Screenshot 2024-02-08 at 4 29 21 PM" src="https://github.com/apache/echarts/assets/14301985/1cd0ce0f-7cf3-4cd2-a147-2844130e49bf">

### After: How does it behave after the fixing?

After the fix not only the lines are connected but also areas.

<img width="1439" alt="Screenshot 2024-02-08 at 4 28 39 PM" src="https://github.com/apache/echarts/assets/14301985/3f772843-f36f-48b7-bc39-607850bdd9a6">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`area-stack.html -> line break` 


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
