### PR TITLE
fix(toolbox): use `typeof` operator rather than `isFunction` util to detect if `MouseEvent` object is supported

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -17,14 +17,13 @@
 * under the License.
 */
 
-/* global Uint8Array, document */
+/* global window, Uint8Array, document */
 
 import env from 'zrender/src/core/env';
 import { ToolboxFeature, ToolboxFeatureOption } from '../featureManager';
 import { ZRColor } from '../../../util/types';
 import GlobalModel from '../../../model/Global';
 import ExtensionAPI from '../../../core/ExtensionAPI';
-import { isFunction } from 'zrender/src/core/util';
 
 export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
     icon?: string
@@ -41,8 +40,6 @@ export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
 
     lang?: string[]
 }
-
-/* global window, document */
 
 class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
 
@@ -61,7 +58,7 @@ class SaveAsImage extends ToolboxFeature<ToolboxSaveAsImageFeatureOption> {
         });
         const browser = env.browser;
         // Chrome, Firefox, New Edge
-        if (isFunction(MouseEvent) && (browser.newEdge || (!browser.ie && !browser.edge))) {
+        if (typeof MouseEvent === 'function' && (browser.newEdge || (!browser.ie && !browser.edge))) {
             const $a = document.createElement('a');
             $a.download = title + '.' + type;
             $a.target = '_blank';


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fix an unexpected replacement in https://github.com/apache/echarts/commit/53babd2b4c83e875f8df6c370b356d6b44c1919c#diff-0b91602cf047a98c67d6c4edaacbfa7399c8e0d2d4564b83ece8419d144aea84R64
\- Should use the `typeof` operator to avoid uncaught reference error.

### Fixed issues

- #16318

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
