### PR TITLE
feat(axis): enale boundaryGap for category axis

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {each, map} from 'zrender/src/core/util';
+import {each, isArray, map} from 'zrender/src/core/util';
 import {linearMap, getPixelPrecision, round} from '../util/number';
 import {
     createAxisTicks,
@@ -126,7 +126,7 @@ class Axis {
 
         if (this.onBand && scale.type === 'ordinal') {
             extent = extent.slice() as [number, number];
-            fixExtentWithBands(extent, (scale as OrdinalScale).count());
+            fixExtentWithBands(extent, (scale as OrdinalScale).count(), isArray(this.onBand) ? this.onBand : []);
         }
 
         return linearMap(data, NORMALIZED_EXTENT, extent, clamp);
@@ -271,12 +271,12 @@ class Axis {
 
 }
 
-function fixExtentWithBands(extent: [number, number], nTick: number): void {
+function fixExtentWithBands(extent: [number, number], nTick: number, onBand = [] as number[]): void {
     const size = extent[1] - extent[0];
     const len = nTick;
     const margin = size / len / 2;
-    extent[0] += margin;
-    extent[1] -= margin;
+    extent[0] += onBand[0] || margin;
+    extent[1] -= onBand[1] || margin;
 }
 
 // If axis has labels [1, 2, 3, 4]. Bands on the axis are

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -271,7 +271,7 @@ class Axis {
 
 }
 
-function fixExtentWithBands(extent: [number, number], nTick: number, onBand = [] as number[]): void {
+function fixExtentWithBands(extent: [number, number], nTick: number, onBand: number[] = []): void {
     const size = extent[1] - extent[0];
     const len = nTick;
     const margin = size / len / 2;

--- a/test/line-space-between.html
+++ b/test/line-space-between.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <div id="main0"></div>
+    <div></div>
+    <script>
+        var chart;
+        var myChart;
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            var option = {
+                legend: {
+                    left: 'center',
+                    bottom: 'bottom'
+                },
+                xAxis: {
+                    type: 'category',
+                    boundaryGap: [32, 32],
+                    data: ['2022-07-11', '2022-07-11', '2022-07-11', '2022-07-11', '2022-07-11', '2022-07-11', '2022-07-11']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'line series 1',
+                        type: 'line',
+                        data: [28.5, 70.5, 108.4, 129.2, 144.0, 176.0, 135.6],
+                        symbolSize: 10,
+                        symbol: 'square',
+                        emphasis: {
+                            focus: 'series',
+                            lineStyle: {
+                                width: 5
+                            }
+                        }
+                    },
+                    {
+                        name: 'line series 2',
+                        type: 'line',
+                        data: [226.9, 194.1, 95.6, 54.4, 29.9, 71.5, 106.4],
+                        symbolSize: 10,
+                        symbol: 'circle',
+                        emphasis: {
+                            focus: 'series'
+                        }
+                    }
+                ]
+            };
+
+            chart = myChart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'The line should be bolder when hovering on it'
+                ],
+                option: option
+            });
+        });
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
I'd like to align ending axis labels with the boundary, but the boundaryGap not suitable for category axis chart.


### Fixed issues

<!--
- #xxxx: ...
-->
#19636 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
place axis label space-between
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/26688579/10700733-a8a6-4590-b073-91effa1c1a4e)


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
