### PR TITLE
do not pick X coordinate dimension as stacked dimension when both X and Y are stackable

### DIFF
--- a/src/data/helper/dataStackHelper.ts
+++ b/src/data/helper/dataStackHelper.ts
@@ -94,6 +94,12 @@ export function enableDataStack(
     let stackResultDimension: string;
     let stackedOverDimension: string;
 
+    const yCoordDimension = dimensionDefineList.find(
+        dimensionInfo => !isString(dimensionInfo) && dimensionInfo.coordDim === 'y'
+    ) as SeriesDimensionDefine | undefined;
+    const isYCoordDimensionStackable = yCoordDimension !== null
+        && yCoordDimension.type !== 'ordinal' && yCoordDimension.type !== 'time';
+
     each(dimensionDefineList, function (dimensionInfo, index) {
         if (isString(dimensionInfo)) {
             dimensionDefineList[index] = dimensionInfo = {
@@ -110,12 +116,19 @@ export function enableDataStack(
             if (!stackedDimInfo
                 && dimensionInfo.type !== 'ordinal'
                 && dimensionInfo.type !== 'time'
+                && (yCoordDimension == null || (dimensionInfo.coordDim !== 'x' && isYCoordDimensionStackable))
                 && (!stackedCoordDimension || stackedCoordDimension === dimensionInfo.coordDim)
             ) {
                 stackedDimInfo = dimensionInfo;
             }
         }
     });
+
+    if (stackedDimInfo && !byIndex && !stackedByDimInfo) {
+        // Compatible with previous design, value axis (time axis) only stack by index.
+        // It may make sense if the user provides elaborately constructed data.
+        byIndex = true;
+    }
 
     if (stackedDimInfo && !byIndex && !stackedByDimInfo) {
         // Compatible with previous design, value axis (time axis) only stack by index.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

On cartesian charts when both X and Y axes have type `value` the stack dimension is selected incorrectly which leads to broken stacked charts. This PR prevents X-axis coord dimension when Y-axis coord dimension is also stackable which allows having stacked vertical charts while not changing the API.

Further, to properly support stacked horizontal charts with both stackable axes, the API should be extended.

[Minimal reproduction](https://echarts.apache.org/examples/en/editor.html?c=line-simple&code=PYBwLglsB2AEC8sDeAoWsAeBBDEDOAXMmurGAJ4gCmRA5AG4CGANgK5W0A0J6AthNCIAGbqVi9GGIgGYSAX1GxyOfEVRiK1OkzYd5ivFQBOEKoVgBtHsTHoAJozCMiFiwEZObgExCAup0svTh8_f2t0TRpYWgAjRiMucNg8JwBjAGs6FmZaawVrdVsHJxd3Tx9_QOChUMUNSijY-MTbZLTM6OzcsTkSXxQ5AG4gA)

### Fixed issues

<!--
- #16765: https://github.com/apache/echarts/issues/16765
- #16744: https://github.com/apache/echarts/issues/16744
- #19400: https://github.com/apache/echarts/issues/19400
- #18437: https://github.com/apache/echarts/issues/18437
- #17522: https://github.com/apache/echarts/issues/17522
-->

## Details

### Before: What was the problem?

Stacking did not work on `value` xAxis. There are two stacked bar series on this screenshot:

<img width="598" alt="Screenshot 2024-02-27 at 4 51 21 PM" src="https://github.com/apache/echarts/assets/14301985/d77c51be-101c-4b7f-ad33-5317a5ab1bb8">


### After: How does it behave after the fixing?

Stacking works correctly on `value` xAxis:
<img width="537" alt="Screenshot 2024-02-27 at 4 51 01 PM" src="https://github.com/apache/echarts/assets/14301985/24a7ad89-58ac-4cb8-9fa3-04458257fa22">


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
