### PR TITLE
Fix 19570 tree chart not compliant strict csp styles

### DIFF
--- a/src/.eslintrc.yaml
+++ b/src/.eslintrc.yaml
@@ -34,10 +34,11 @@ parserOptions:
     sourceType: module
     ecmaFeatures:
         modules: true
-    project: "tsconfig.json"
+    project: "**/tsconfig.json"
 plugins: ["@typescript-eslint"]
 env:
     es6: false
+    browser: true
 globals:
     jQuery: false
     Promise: false

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -73,34 +73,49 @@ function assembleArrow(
     borderColor = convertToColorString(borderColor);
     const arrowPos = mirrorPos(arrowPosition);
     const arrowSize = Math.max(Math.round(borderWidth) * 1.5, 6);
-    let positionStyle = '';
-    let transformStyle = CSS_TRANSFORM_VENDOR + ':';
+
+    const arrowClasses = ['tooltip-arrow'];
+    const transformClasses = [];
     let rotateDeg;
-    if (indexOf(['left', 'right'], arrowPos) > -1) {
-        positionStyle += 'top:50%';
-        transformStyle += `translateY(-50%) rotate(${rotateDeg = arrowPos === 'left' ? -225 : -45}deg)`;
+
+    if (['left', 'right'].includes(arrowPos)) {
+        arrowClasses.push('tooltip-arrow-horizontal');
+        transformClasses.push(`tooltip-arrow-rotate-${rotateDeg = arrowPos === 'left' ? -225 : -45}`);
     }
     else {
-        positionStyle += 'left:50%';
-        transformStyle += `translateX(-50%) rotate(${rotateDeg = arrowPos === 'top' ? 225 : 45}deg)`;
+        arrowClasses.push('tooltip-arrow-vertical');
+        transformClasses.push(`tooltip-arrow-rotate-${rotateDeg = arrowPos === 'top' ? 225 : 45}`);
     }
+
+    function calculateArrowOffset(rotatedWH: number, borderWidth: number, arrowWH: number) {
+        return Math.round(
+            (
+                ((rotatedWH - Math.SQRT2 * borderWidth) / 2
+                    + Math.SQRT2 * borderWidth
+                    - (rotatedWH - arrowWH) / 2)
+                * 100
+            ) / 100
+        );
+    }
+
+    function getColorClassName(color: ZRColor) {
+        const colorValue = convertToColorString(color);
+        return colorValue.replace(/[^a-zA-Z0-9]/g, '');
+    }
+
     const rotateRadian = rotateDeg * Math.PI / 180;
     const arrowWH = arrowSize + borderWidth;
     const rotatedWH = arrowWH * Math.abs(Math.cos(rotateRadian)) + arrowWH * Math.abs(Math.sin(rotateRadian));
-    const arrowOffset = Math.round(((rotatedWH - Math.SQRT2 * borderWidth) / 2
-        + Math.SQRT2 * borderWidth - (rotatedWH - arrowWH) / 2) * 100) / 100;
-    positionStyle += `;${arrowPos}:-${arrowOffset}px`;
+    const arrowOffset = calculateArrowOffset(rotatedWH, borderWidth, arrowWH);
 
-    const borderStyle = `${borderColor} solid ${borderWidth}px;`;
-    const styleCss = [
-        `position:absolute;width:${arrowSize}px;height:${arrowSize}px;z-index:-1;`,
-        `${positionStyle};${transformStyle};`,
-        `border-bottom:${borderStyle}`,
-        `border-right:${borderStyle}`,
-        `background-color:${backgroundColor};`
-    ];
+    arrowClasses.push(`tooltip-arrow-offset-${arrowPos}-${arrowOffset}`);
 
-    return `<div style="${styleCss.join('')}"></div>`;
+    const borderColorClass = `tooltip-arrow-border-color-${getColorClassName(borderColor)}`;
+    const backgroundColorClass = `tooltip-arrow-background-color-${getColorClassName(backgroundColor)}`;
+
+    const classes = [...arrowClasses, borderColorClass, backgroundColorClass, ...transformClasses];
+
+    return `<div class="${classes.join(' ')}"></div>`;
 }
 
 function assembleTransition(duration: number, onlyFade?: boolean): string {

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -418,24 +418,53 @@ class TooltipHTMLContent {
         borderColor?: ZRColor,
         arrowPosition?: TooltipOption['position']
     ) {
+        function clearContent(el: HTMLElement) {
+            while (el.firstChild) {
+                el.removeChild(el.firstChild);
+            }
+        }
+
+        function setTextContent(el: HTMLElement, text: string) {
+            clearContent(el);
+
+            const fragment = document.createRange().createContextualFragment(text);
+            while (fragment.firstChild) {
+                el.appendChild(fragment.firstChild);
+            }
+        }
+
+        function appendArrow(el: HTMLElement, arrow: string) {
+            if (!arrow) {
+                return;
+            }
+            const arrowEl = document.createElement('div');
+            arrowEl.classList.add('tooltip-arrow');
+            arrowEl.innerHTML = arrow;
+            el.appendChild(arrowEl);
+        }
+
         const el = this.el;
 
         if (content == null) {
-            el.innerHTML = '';
+            clearContent(el);
             return;
         }
 
         let arrow = '';
-        if (isString(arrowPosition) && tooltipModel.get('trigger') === 'item'
-            && !shouldTooltipConfine(tooltipModel)) {
+        if (
+            isString(arrowPosition)
+            && tooltipModel.get('trigger') === 'item'
+            && !shouldTooltipConfine(tooltipModel)
+        ) {
             arrow = assembleArrow(tooltipModel, borderColor, arrowPosition);
         }
         if (isString(content)) {
-            el.innerHTML = content + arrow;
+            setTextContent(el, content);
+            appendArrow(el, arrow);
         }
         else if (content) {
             // Clear previous
-            el.innerHTML = '';
+            clearContent(el);
             if (!isArray(content)) {
                 content = [content];
             }
@@ -448,9 +477,7 @@ class TooltipHTMLContent {
             if (arrow && el.childNodes.length) {
                 // no need to create a new parent element, but it's not supported by IE 10 and older.
                 // const arrowEl = document.createRange().createContextualFragment(arrow);
-                const arrowEl = document.createElement('div');
-                arrowEl.innerHTML = arrow;
-                el.appendChild(arrowEl);
+                appendArrow(el, arrow);
             }
         }
     }

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -40,8 +40,6 @@ type RichTextStyle = {
 
 type TextStyle = string | RichTextStyle;
 
-const TOOLTIP_LINE_HEIGHT_CSS = 'line-height:1';
-
 // TODO: more textStyle option
 function getTooltipTextStyle(
     textStyle: TooltipOption['textStyle'],
@@ -60,10 +58,14 @@ function getTooltipTextStyle(
     if (renderMode === 'html') {
         // `textStyle` is probably from user input, should be encoded to reduce security risk.
         return {
-            // eslint-disable-next-line max-len
-            nameStyle: `font-size:${encodeHTML(nameFontSize + '')}px;color:${encodeHTML(nameFontColor)};font-weight:${encodeHTML(nameFontWeight + '')}`,
-            // eslint-disable-next-line max-len
-            valueStyle: `font-size:${encodeHTML(valueFontSize + '')}px;color:${encodeHTML(valueFontColor)};font-weight:${encodeHTML(valueFontWeight + '')}`
+            nameStyle: `tooltip-name-style tooltip-name-color-${nameFontColor.replace(
+                '#',
+                ''
+            )} tooltip-name-size-${nameFontSize} tooltip-name-weight-${nameFontWeight}`,
+            valueStyle: `tooltip-value-style tooltip-value-color-${valueFontColor.replace(
+                '#',
+                ''
+            )} tooltip-value-size-${valueFontSize} tooltip-value-weight-${valueFontWeight}`,
         };
     }
     else {
@@ -71,13 +73,13 @@ function getTooltipTextStyle(
             nameStyle: {
                 fontSize: nameFontSize,
                 fill: nameFontColor,
-                fontWeight: nameFontWeight
+                fontWeight: nameFontWeight,
             },
             valueStyle: {
                 fontSize: valueFontSize,
                 fill: valueFontColor,
-                fontWeight: valueFontWeight
-            }
+                fontWeight: valueFontWeight,
+            },
         };
     }
 }
@@ -288,7 +290,7 @@ function buildSection(
     }
     else {
         return wrapBlockHTML(
-            `<div style="${nameStyle};${TOOLTIP_LINE_HEIGHT_CSS};">`
+            '<div class="tooltip-content">'
                 + encodeHTML(displayableHeader)
                 + '</div>'
                 + subMarkupText,

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -409,11 +409,31 @@ function wrapBlockHTML(
     encodedContent: string,
     topGap: number
 ): string {
-    const clearfix = '<div style="clear:both"></div>';
-    const marginCSS = `margin: ${topGap}px 0 0`;
-    return `<div style="${marginCSS};${TOOLTIP_LINE_HEIGHT_CSS};">`
-        + encodedContent + clearfix
-        + '</div>';
+    function createElementFromHTML(htmlString: string) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlString.trim(), 'text/html');
+        const fragment = document.createDocumentFragment();
+
+        for (const child of doc.body.childNodes as any) {
+            fragment.appendChild(child);
+        }
+
+        return fragment;
+    }
+
+    const clearfixDiv = document.createElement('div');
+    clearfixDiv.classList.add('clearfix');
+
+    const contentDiv = document.createElement('div');
+    contentDiv.classList.add('tooltip-content');
+    contentDiv.classList.add(`margin-top-${topGap}`);
+
+    const contentFragment = createElementFromHTML(encodedContent);
+    contentDiv.appendChild(contentFragment);
+
+    contentDiv.appendChild(clearfixDiv);
+
+    return contentDiv.outerHTML;
 }
 
 function wrapInlineNameHTML(

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -454,17 +454,34 @@ function wrapInlineValueHTML(
     alignRight: boolean,
     valueCloseToMarker: boolean,
     style: string
-): string {
+): HTMLElement {
     // Do not too close to marker, considering there are multiple values separated by spaces.
-    const paddingStr = valueCloseToMarker ? '10px' : '20px';
-    const alignCSS = alignRight ? `float:right;margin-left:${paddingStr}` : '';
+    const padding = valueCloseToMarker ? '10px' : '20px';
+    const alignClass = alignRight
+        ? 'tooltip-value-right'
+        : 'tooltip-value-left';
+    const styleClasses = `tooltip-value-container ${alignClass} ${padding}`;
+
     valueList = isArray(valueList) ? valueList : [valueList];
-    return (
-        `<span style="${alignCSS};${style}">`
-        // Value has commas inside, so use '  ' as delimiter for multiple values.
-        + map(valueList, value => encodeHTML(value)).join('&nbsp;&nbsp;')
-        + '</span>'
-    );
+
+    const valueSpan = document.createElement('span');
+    valueSpan.classList.add(...styleClasses.split(' '));
+
+    // Split the style argument by spaces and add each class separately
+    const styleClassList = style.split(' ');
+    valueSpan.classList.add(...styleClassList);
+
+    valueList.forEach((value) => {
+        const valueNode = document.createTextNode(encodeHTML(value));
+        valueSpan.appendChild(valueNode);
+
+        if (value !== valueList[valueList.length - 1]) {
+            const spacer = document.createTextNode('\u00A0\u00A0'); // Non-breaking spaces
+            valueSpan.appendChild(spacer);
+        }
+    });
+
+    return valueSpan;
 }
 
 function wrapInlineNameRichText(ctx: TooltipMarkupBuildContext, name: string, style: RichTextStyle): string {

--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -443,8 +443,8 @@ function wrapInlineNameHTML(
     leftHasMarker: boolean,
     style: string
 ): string {
-    const marginCss = leftHasMarker ? 'margin-left:2px' : '';
-    return `<span style="${style};${marginCss}">`
+    const marginCss = leftHasMarker ? 'margin-left-2px' : '';
+    return `<span class="${style} ${marginCss}">`
         + encodeHTML(name)
         + '</span>';
 }

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -192,7 +192,7 @@ export function getTooltipMarker(inOpt: ColorString | GetTooltipMarkerOpt, extra
     } : (inOpt || {}) as GetTooltipMarkerOpt;
     const color = opt.color;
     const type = opt.type;
-    extraCssText = opt.extraCssText;
+    const extraCssClasses = opt.extraCssText ? opt.extraCssText.split(' ') : [];
     const renderMode = opt.renderMode || 'html';
 
     if (!color) {
@@ -200,14 +200,11 @@ export function getTooltipMarker(inOpt: ColorString | GetTooltipMarkerOpt, extra
     }
 
     if (renderMode === 'html') {
-        return type === 'subItem'
-        ? '<span style="display:inline-block;vertical-align:middle;margin-right:8px;margin-left:3px;'
-            + 'border-radius:4px;width:4px;height:4px;background-color:'
-            // Only support string
-            + encodeHTML(color) + ';' + (extraCssText || '') + '"></span>'
-        : '<span style="display:inline-block;margin-right:4px;'
-            + 'border-radius:10px;width:10px;height:10px;background-color:'
-            + encodeHTML(color) + ';' + (extraCssText || '') + '"></span>';
+        const markerClass = type === 'subItem' ? 'tooltip-marker-sub' : 'tooltip-marker';
+        const colorClass = `tooltip-marker-color-${color.replace('#', '')}`;
+        const classes = [markerClass, colorClass, ...extraCssClasses];
+
+        return `<span class="${classes.join(' ')}"></span>`;
     }
     else {
         // Should better not to auto generate style name by auto-increment number here.

--- a/test/asset/tree-basic.css
+++ b/test/asset/tree-basic.css
@@ -1,0 +1,6 @@
+html, body, #main {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    height: 100%;
+}

--- a/test/asset/tree-basic.css
+++ b/test/asset/tree-basic.css
@@ -4,3 +4,53 @@ html, body, #main {
     margin: 0;
     height: 100%;
 }
+
+.clearfix {
+    clear: both;
+}
+
+.tooltip-content {
+    line-height: 1;
+}
+
+.tooltip-name-size-14 {
+    font-size: 14px;
+}
+
+.tooltip-name-color-666 {
+    color: #6e7079;
+}
+
+.tooltip-name-size-12 {
+    font-size: 12px;
+}
+
+.tooltip-name-weight-400 {
+    font-weight: 400;
+}
+
+.tooltip-value-color-464646 {
+    color: #464646;
+}
+
+.tooltip-value-size-14 {
+    font-size: 14px;
+}
+
+.tooltip-value-weight-900 {
+    font-weight: 900;
+}
+
+.margin-top-0 {
+    margin-top: 0px;
+}
+
+.tooltip-value-right {
+    float: right;
+    margin-left: 20px; /* Adjust as needed */
+}
+
+.tooltip-value-left {
+    float: left;
+    margin-right: 20px; /* Adjust as needed */
+}

--- a/test/heatmap.html
+++ b/test/heatmap.html
@@ -27,6 +27,7 @@ under the License.
     <link rel="stylesheet" href="lib/reset.css" />
     <link rel="stylesheet" href="lib/basic.css">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Security-Policy" content="style-src 'self';" />
 </head>
 
 <body>

--- a/test/heatmap.html
+++ b/test/heatmap.html
@@ -25,20 +25,11 @@ under the License.
     <script src="lib/config.js"></script>
     <script src="lib/testHelper.js"></script>
     <link rel="stylesheet" href="lib/reset.css" />
+    <link rel="stylesheet" href="lib/basic.css">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 
 <body>
-    <style>
-        html,
-        body,
-        #main,
-        #main2 {
-            width: 100%;
-            height: 100%;
-            margin: 0;
-        }
-    </style>
     <div id="main"></div>
     <div id="main2"></div>
     <div id="main3"></div>

--- a/test/lib/basic.css
+++ b/test/lib/basic.css
@@ -79,3 +79,44 @@ html, body, #main, #main2 {
 .tooltip-marker-color-6e7079 {
     background-color: #6e7079;
 }
+
+/* Base styles for the arrow */
+.tooltip-arrow {
+    position: absolute;
+    width: 6px; /* Adjust as needed */
+    height: 6px; /* Adjust as needed */
+    z-index: -1;
+}
+
+/* Horizontal arrow styles */
+.tooltip-arrow-horizontal {
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+/* Vertical arrow styles */
+.tooltip-arrow-vertical {
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+/* Rotation styles */
+.tooltip-arrow-rotate-225 {
+    transform: translateY(-50%) rotate(225deg);
+}
+
+.tooltip-arrow-rotate-45 {
+    transform: translateY(-50%) rotate(45deg);
+}
+
+.tooltip-arrow-rotate--225 {
+    transform: translateY(-50%) rotate(-225deg);
+}
+
+.tooltip-arrow-rotate--45 {
+    transform: translateY(-50%) rotate(-45deg);
+}
+
+.tooltip-arrow-background-color-fff {
+    background-color: #ffffff;
+}

--- a/test/lib/basic.css
+++ b/test/lib/basic.css
@@ -54,3 +54,28 @@ html, body, #main, #main2 {
     float: left;
     margin-right: 20px; /* Adjust as needed */
 }
+
+.tooltip-marker,
+.tooltip-marker-sub {
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 8px;
+}
+
+.tooltip-marker {
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+}
+
+.tooltip-marker-sub {
+    margin-left: 3px;
+    width: 4px;
+    height: 4px;
+    border-radius: 2px;
+}
+
+/* Color styles for markers */
+.tooltip-marker-color-6e7079 {
+    background-color: #6e7079;
+}

--- a/test/lib/basic.css
+++ b/test/lib/basic.css
@@ -1,4 +1,4 @@
-html, body, #main {
+html, body, #main, #main2 {
     width: 100%;
     padding: 0;
     margin: 0;

--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -25,6 +25,7 @@ under the License.
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
         <script src="lib/jquery.min.js"></script>
+        <meta http-equiv="Content-Security-Policy" content="style-src 'self';" />
     </head>
     <body>
         <style>

--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -25,7 +25,7 @@ under the License.
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
         <script src="lib/jquery.min.js"></script>
-        <link rel="stylesheet" href="asset/tree-basic.css">
+        <link rel="stylesheet" href="lib/basic.css">
         <meta http-equiv="Content-Security-Policy" content="style-src 'self';" />
     </head>
     <body>

--- a/test/tree-basic.html
+++ b/test/tree-basic.html
@@ -25,17 +25,10 @@ under the License.
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
         <script src="lib/jquery.min.js"></script>
+        <link rel="stylesheet" href="asset/tree-basic.css">
         <meta http-equiv="Content-Security-Policy" content="style-src 'self';" />
     </head>
     <body>
-        <style>
-            html, body, #main {
-                width: 100%;
-                padding: 0;
-                margin: 0;
-                height: 100%;
-            }
-        </style>
         <div id="main"></div>
         <script>
             var formatUtil;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- bug fixing.
- refactoring.

### What does this PR do?

This pull request addresses a specific limitation concerning [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). When CSP is enabled, direct assignments to an element's style property using a string are disallowed. However it is possible to use className instead.

### Fixed issues

[Tree chart with tooltips is not compliant with strict CSP directives for styles](https://github.com/apache/echarts/issues/19570)

## Details

### Before: What was the problem?

CSP violation errors are thrown into browser console:

<img width="793" alt="image" src="https://github.com/apache/echarts/assets/18514351/dfc2c049-05e3-4cb2-b2f9-8a2883f9594c">

### After: How does it behave after the fixing?

It no longer uses inline styles.

<img width="800" alt="image" src="https://github.com/apache/echarts/assets/18514351/0327d897-11f4-4b7c-94f9-4c893513137d">

## Document Info

One of the following should be checked.

- This PR doesn't relate to document changes

### ZRender Changes

- [ ] No.

## Others

Tried to apply a similar solution as in https://github.com/ecomfe/zrender/pull/1030
