### PR TITLE
Implement DataZoom Feature - Fixes #19732

### DIFF
--- a/.eslintrc-common.yaml
+++ b/.eslintrc-common.yaml
@@ -27,6 +27,24 @@
 # "eslint.workingDirectories": [{"mode": "auto"}]
 # ```
 # Note that it should be "workingDirectories" rather than "WorkingDirectories".
+globals:
+    CanvasRenderingContext2D: "readonly"
+    CanvasLineJoin: "readonly"
+    CanvasLineCap: "readonly"
+    HTMLElement: "readonly"
+    HTMLDivElement: "readonly"
+    SVGElement: "readonly"
+    Document: "readonly"
+    Blob: "readonly"
+    Event: "readonly"
+
+
+env:
+  browser: true
+  node: true
+  es2021: true
+
+
 
 root: true
 rules:

--- a/src/component/dataZoom/InsideZoomModel.ts
+++ b/src/component/dataZoom/InsideZoomModel.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import DataZoomModel, {DataZoomOption} from './DataZoomModel';
+import DataZoomModel, { DataZoomOption } from './DataZoomModel';
 import { inheritDefaultOption } from '../../util/component';
 
 export interface InsideDataZoomOption extends DataZoomOption {
@@ -38,6 +38,14 @@ export interface InsideDataZoomOption extends DataZoomOption {
 
     moveOnMouseWheel?: boolean | 'shift' | 'ctrl' | 'alt'
 
+    /**
+     * Add configration attribute to control zoom X and Y axis.
+     */
+
+    zoomXOnMouseWheel?: boolean | 'shift' | 'ctrl' | 'alt'
+
+    zoomYOnMouseWheel?: boolean | 'shift' | 'ctrl' | 'alt'
+
     preventDefaultMouseMove?: boolean
 
     /**
@@ -51,14 +59,15 @@ class InsideZoomModel extends DataZoomModel<InsideDataZoomOption> {
     static readonly type = 'dataZoom.inside';
     type = InsideZoomModel.type;
 
-    static defaultOption: InsideDataZoomOption = inheritDefaultOption(DataZoomModel.defaultOption, {
-        disabled: false,
-        zoomLock: false,
-        zoomOnMouseWheel: true,
-        moveOnMouseMove: true,
-        moveOnMouseWheel: false,
-        preventDefaultMouseMove: true
-    });
+    static defaultOption: InsideDataZoomOption =
+        inheritDefaultOption(DataZoomModel.defaultOption, {
+            disabled: false,
+            zoomLock: false,
+            zoomOnMouseWheel: true,
+            moveOnMouseMove: true,
+            moveOnMouseWheel: false,
+            preventDefaultMouseMove: true
+        });
 }
 
 export default InsideZoomModel;

--- a/test/test-scroll-zoom.html
+++ b/test/test-scroll-zoom.html
@@ -1,0 +1,86 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="dist/echarts.min.js"></script>
+</head>
+
+<body>
+    <style>
+        html,
+        body,
+        #main {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+    <div id="info"></div>
+    <div id="main"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            var chart = echarts.init(document.getElementById('main'));
+            var xAxisData = [];
+            var data = [];
+            // Add data point so as to see a more obvious effect.
+            for (var i = 0; i < 50; i++) {
+                xAxisData.push('Catergory' + i);
+                data.push(Math.round(Math.random() * 100));
+            }
+            chart.setOption({
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'line'
+                    }
+                },
+                xAxis: {
+                    data: xAxisData
+                },
+                yAxis: {
+                    splitArea: {
+                        show: true
+                    }
+                },
+                series: [{
+                    name: 'line',
+                    type: 'line',
+                    symbol: 'circle',
+                    symbolSize: 10,
+                    data: data
+                }],
+                dataZoom: [{
+                    // Use dataZoom we implemented
+                    type: 'inside',
+                    start: 0,
+                    end: 100
+                }]
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "target": "ES3",
+        // ES3 has been bandoned.
+        "target": "ES6",
 
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
## Overview
This Pull Request introduces a new mobile-specific feature for the `dataZoom` component within ECharts. It resolves feature #19732, which requests the implementation of mobile dataZoom-Inside for horizontal and vertical using touch gestures and scrolling scale using mouse.

## Changes
The following are the key changes made in this PR:
- Enhanced `InsideZoomModel.ts` and `InsideZoomView.ts` to support touch gesture recognition for mobile devices.
- Integrated new gesture handling logic that distinguishes between horizontal and vertical gestures to apply data zoom accordingly.

## Testing
Manual testing was conducted to confirm the functionality. Test file : test/test-scroll-zoom.html



By merging this PR, ECharts will provide an enhanced interactive experience for mobile users, allowing more precise control over data visualization.

## Screenshots
![image](https://github.com/apache/echarts/assets/72302467/2244f34a-acad-4cd1-85fe-099e5e09ec1f)



## Notes
- Additional testing on a wider range of devices is recommended to ensure universal compatibility and responsiveness.
- Further feedback from the community can be valuable for iterative improvement of the touch interaction model.

Resolves: #19732
