### PR TITLE
georoam supports the totalZoom parameter

### DIFF
--- a/src/component/helper/MapDraw.ts
+++ b/src/component/helper/MapDraw.ts
@@ -595,6 +595,7 @@ class MapDraw {
             roamHelper.updateViewOnZoom(controllerHost, e.scale, e.originX, e.originY);
 
             api.dispatchAction(zrUtil.extend(makeActionBase(), {
+                totalZoom: controllerHost.zoom,
                 zoom: e.scale,
                 originX: e.originX,
                 originY: e.originY,

--- a/test/map-china.html
+++ b/test/map-china.html
@@ -87,6 +87,7 @@ under the License.
                     itemStyle: {
                         areaColor: '#fff'
                     },
+                    roam: true,
                     data: [{
                         name: '广西',
                         itemStyle: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [] new feature



### What does this PR do?

The georoam event of the map component supports the totalZoom parameter, which is used to do some interaction with the linkage business when the chart is resized



## Details

### Before: What was the problem?

<!-- After the map is reduced, the map label copy needs to be hidden. Before this, the cumulative zoom ratio cannot be obtained, and the business is not convenient to realize -->

### After: How does it behave after the fixing?

<!-- After the repaired georoam event is executed, the business can get the cumulative Zoom ratio through the parameter -->


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
