### PR TITLE
fix: detectValue & parseDataValue not crashing with BigInt

### DIFF
--- a/src/data/helper/dataValueHelper.ts
+++ b/src/data/helper/dataValueHelper.ts
@@ -67,7 +67,7 @@ export function parseDataValue(
         ? NaN
         // If string (like '-'), using '+' parse to NaN
         // If object, also parse to NaN
-        : +value;
+        : Number(value);
 };
 
 

--- a/src/data/helper/sourceHelper.ts
+++ b/src/data/helper/sourceHelper.ts
@@ -449,8 +449,8 @@ function doGuessOrdinal(
     function detectValue(val: OptionDataValue): BeOrdinalValue {
         const beStr = isString(val);
         // Consider usage convenience, '1', '2' will be treated as "number".
-        // `isFinit('')` get `true`.
-        if (val != null && isFinite(val as number) && val !== '') {
+        // `Number('')` (or any whitespace) is `0`.
+        if (val != null && Number.isFinite(Number(val)) && val !== '') {
             return beStr ? BE_ORDINAL.Might : BE_ORDINAL.Not;
         }
         else if (beStr && val !== '-') {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing

### What does this PR do?

- Replaces global `isFinite` with `Number.isFinite` and unary (`+`) with `Number()` conversion so that a simple chart doesn't blow up when passing in a `BigInt`

### ~Fixed~ Related issues

- Related to #19237 (addresses a small part of it)

## Details

### Before: What was the problem?

When passing a `BigInt` data column to a chart, the chart blows up.

![image](https://github.com/apache/echarts/assets/638946/c0661a57-f6d4-41d3-90f5-3347c634bbe6)

```
Uncaught TypeError: Cannot convert a BigInt value to a number
    at isFinite (<anonymous>)
    at detectValue (chunk-TNIQ5HHQ.js?v=9ea597be:5513:25)
    at doGuessOrdinal (chunk-TNIQ5HHQ.js?v=9ea597be:5494:21)
    at guessOrdinal (chunk-TNIQ5HHQ.js?v=9ea597be:5434:10)
    at new SourceImpl2 (chunk-TNIQ5HHQ.js?v=9ea597be:5538:17)
    at createSource (chunk-TNIQ5HHQ.js?v=9ea597be:5555:16)
```

👇 

This is happens because of the way `isFinite`, `isNaN`, and `+` (unary operator) coerces the values. `isFinite` and `isNaN` implicitly converts the values in a way that's incompatible with `BigInt`. 

The `Number.isFinite()` and `Number.isNaN()` methods work [in a more predictable way](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description) by not casting non-numeric values implicitly - We can do that explicitly using `Number()` which can be more [_more performant_](https://jsperf.app/momomi)) and does work with `BigInt`

The unary `+` operator conversion will likely never be supported for `BigInt` [for compatibility reasons with ASM](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs), while `Number()` does (with possible loss of precision)


<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Chart is rendered without crashing 🚀 

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Please let me know if you'd like me to address some of the conversion issues in other places of the codebase too. That would require quite a few changes though; I've kept this PR small to increase its chances of being merged 👀 

Thank you 🙏 