### PR TITLE
fix: Fix position style check

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -362,7 +362,7 @@ class TooltipHTMLContent {
             const container = this._api.getDom();
             const position = getComputedStyle(container, 'position');
             const domStyle = container.style;
-            if (domStyle.position !== 'absolute' && position !== 'absolute') {
+            if (position !== 'absolute') {
                 domStyle.position = 'relative';
             }
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

Starting from version 6.6.10 of vue-echarts, the style of the container has been modified to include position:absolute. This change results in an update being triggered when switching routes, where an inline style of position:relative is added to the container, causing it to lose its height.

Reproducible Git repository address: https://github.com/SadWood/vue-quick-start-template/tree/echarts_bug

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
The values returned by getComputedStyle are resolved values, so it's straightforward to determine whether getComputedStyle(container, 'position') is 'absolute' or not.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
