### PR TITLE
feat(time): add meridian template {a}/{A}

### DIFF
--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -121,7 +121,8 @@ export function format(
     const m = date[minutesGetterName(isUTC)]();
     const s = date[secondsGetterName(isUTC)]();
     const S = date[millisecondsGetterName(isUTC)]();
-
+    const a = H >= 12 ? 'pm' : 'am';
+    const A = a.toUpperCase();
 
     const localeModel = lang instanceof Model ? lang
         : getLocaleModel(lang || SYSTEM_LANG) || getDefaultLocaleModel();
@@ -132,6 +133,8 @@ export function format(
     const dayOfWeekAbbr = timeModel.get('dayOfWeekAbbr');
 
     return (template || '')
+        .replace(/{a}/g, a + '')
+        .replace(/{A}/g, A + '')
         .replace(/{yyyy}/g, y + '')
         .replace(/{yy}/g, pad(y % 100 + '', 2))
         .replace(/{Q}/g, q + '')

--- a/test/ut/spec/util/time.test.ts
+++ b/test/ut/spec/util/time.test.ts
@@ -29,6 +29,7 @@ describe('util/time', function () {
 
         const time = new Date('2003-04-09 01:04:02.300 UTC');
         const anotherTime = new Date('2023-12-19 11:44:33.003 UTC');
+        const oneMoreTime = new Date('2023-01-12 13:09:01.035 UTC');
 
         // test {yyyy}, {yy} ...
         it('should format year', function () {
@@ -126,6 +127,19 @@ describe('util/time', function () {
         it('should format millisecond', function () {
             expect(format(time, '{S}', true)).toEqual('300');
             expect(format(anotherTime, '{S}', true)).toEqual('3');
+        });
+
+        // test {a} ...
+        it('should format meridian', function () {
+            expect(format(time, '{a}', true)).toEqual('am');
+            expect(format(anotherTime, '{a}', true)).toEqual('am');
+            expect(format(oneMoreTime, '{a}', true)).toEqual('pm');
+        });
+
+        it('should format meridian in uppercase', function () {
+            expect(format(time, '{A}', true)).toEqual('AM');
+            expect(format(anotherTime, '{A}', true)).toEqual('AM');
+            expect(format(oneMoreTime, '{A}', true)).toEqual('PM');
         });
     });
 });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

I added a meridian template to the time format.

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

There wasn't a template to show the meridian.

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

Now it's possible to use the template {a} | {A} to show the meridian on the time formatting

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
