### PR TITLE
fix(aria): avoid throwing error in SSR mode (#19191)

### DIFF
--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -139,6 +139,11 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
     }
 
     function setLabel() {
+        const dom = api.getZr().dom;
+        // No DOM if using SSR
+        if (!dom) {
+            return;
+        }
         const labelLocale = ecModel.getLocaleModel().get('aria');
         const labelModel = ariaModel.getModel('label');
         labelModel.option = zrUtil.defaults(labelModel.option, labelLocale);
@@ -147,7 +152,6 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
             return;
         }
 
-        const dom = api.getZr().dom;
         if (labelModel.get('description')) {
             dom.setAttribute('aria-label', labelModel.get('description'));
             return;

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -140,10 +140,11 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
 
     function setLabel() {
         const dom = api.getZr().dom;
-        // No DOM if using SSR
+        // TODO: support for SSR
         if (!dom) {
             return;
         }
+
         const labelLocale = ecModel.getLocaleModel().get('aria');
         const labelModel = ariaModel.getModel('label');
         labelModel.option = zrUtil.defaults(labelModel.option, labelLocale);

--- a/test/node/ssr.js
+++ b/test/node/ssr.js
@@ -25,6 +25,10 @@ const chart = echarts.init(null, null, {
 });
 
 chart.setOption({
+    aria: {
+        // Not supported in SSR, but should not throw error
+        enabled: true,
+    },
     series: [
         {
             name: 'Nightingale Chart',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Skip setting aria label attribute when in SSR mode.

### Fixed issues

#19191: <q>[Bug] SVG ARIA doesn’t work with SSR</q>


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

`aria-label` was set on the DOM element, but in SSR there is no DOM element, so it would throw when enabling `aria` or `locals` in options when using SSR, because the `dom` variable in code is `null`.

Also, this makes the last example in [this release note](https://echarts.apache.org/handbook/en/basics/release-note/v5-feature/) (Two color locals) not working in SSR.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![html demo](https://github.com/apache/echarts/assets/20166026/57e2b22c-4788-4578-8dd0-d4a663ecf0ca)

<img src="https://github.com/apache/echarts/assets/20166026/fc8f210f-ae4c-4937-9fb3-2c4be126d316" height="300px">

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

No aria label was added, but locals are working in SSR.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img height="400px" src="https://github.com/apache/echarts/assets/20166026/6a284521-60f7-43b4-b7b1-a0571184c100">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
