### PR TITLE
Remove empty labels from being candidates for overlap checking

### DIFF
--- a/src/label/labelLayoutHelper.ts
+++ b/src/label/labelLayoutHelper.ts
@@ -317,12 +317,11 @@ export function hideOverlap(labelList: LabelLayoutInfo[]) {
         const labelLine = labelItem.labelLine;
 
         // if the label has no text, remove it as a candidate for overlap checking
-        if (label.style?.text === ""){
+        if (label.style?.text === '') {
             hideEl(label);
             labelLine && hideEl(labelLine);
             continue;
         }
-        
         globalRect.copy(labelItem.rect);
         // Add a threshold because layout may be aligned precisely.
         globalRect.width -= 0.1;

--- a/src/label/labelLayoutHelper.ts
+++ b/src/label/labelLayoutHelper.ts
@@ -315,6 +315,14 @@ export function hideOverlap(labelList: LabelLayoutInfo[]) {
         const transform = labelItem.transform;
         const label = labelItem.label;
         const labelLine = labelItem.labelLine;
+
+        // if the label has no text, remove it as a candidate for overlap checking
+        if (label.style?.text === ""){
+            hideEl(label);
+            labelLine && hideEl(labelLine);
+            continue;
+        }
+        
         globalRect.copy(labelItem.rect);
         // Add a threshold because layout may be aligned precisely.
         globalRect.width -= 0.1;

--- a/src/label/labelLayoutHelper.ts
+++ b/src/label/labelLayoutHelper.ts
@@ -315,7 +315,6 @@ export function hideOverlap(labelList: LabelLayoutInfo[]) {
         const transform = labelItem.transform;
         const label = labelItem.label;
         const labelLine = labelItem.labelLine;
-
         globalRect.copy(labelItem.rect);
         // Add a threshold because layout may be aligned precisely.
         globalRect.width -= 0.1;

--- a/src/label/labelLayoutHelper.ts
+++ b/src/label/labelLayoutHelper.ts
@@ -316,18 +316,19 @@ export function hideOverlap(labelList: LabelLayoutInfo[]) {
         const label = labelItem.label;
         const labelLine = labelItem.labelLine;
 
-        // if the label has no text, remove it as a candidate for overlap checking
-        if (label.style?.text === '') {
-            hideEl(label);
-            labelLine && hideEl(labelLine);
-            continue;
-        }
         globalRect.copy(labelItem.rect);
         // Add a threshold because layout may be aligned precisely.
         globalRect.width -= 0.1;
         globalRect.height -= 0.1;
         globalRect.x += 0.05;
         globalRect.y += 0.05;
+        // if a labels bounding rect has no width or height (i.e. no text)
+        // it should not be shown
+        if (globalRect.width <= 0 && globalRect.height <= 0) {
+          hideEl(label);
+          labelLine && hideEl(labelLine);
+          continue;
+        }
 
         let obb = labelItem.obb;
         let overlapped = false;


### PR DESCRIPTION
**Bug Fix:** This PR is intended to update the `hideOverlap` functionality to prevent empty labels (`""`) from being considered as candidates for the overlap checking.
  - Perhaps there is a better way of ignoring labels with no text, such as setting them to `ignore = true` in the label creation process and then checking if a label is ignored before doing the overlapping comparison check, but I was unsure if that was the right way to go. I am open to suggestions!

## Details

### Before: What was the problem?

**Empty labels cause non-empty labels to be hidden**

`hideOverlap = true`
![Screenshot from 2024-05-28 20-13-54](https://github.com/apache/echarts/assets/22608765/4a2c0eb9-7067-4778-aeb5-7a331f37906d)


`hideOverlap = false`
![Screenshot from 2024-05-28 20-13-42](https://github.com/apache/echarts/assets/22608765/3b1c1244-55a2-4799-8508-6e61387c4d29)




### After: How does it behave after the fixing?

**Empty labels no longer cause non-empty labels to be hidden**

`hideOverlap = true`
![Screenshot from 2024-05-28 20-10-38](https://github.com/apache/echarts/assets/22608765/1b72597e-c2f0-49b6-a287-2311ad974e17)


`hideOverlap = false`
![Screenshot from 2024-05-28 20-10-48](https://github.com/apache/echarts/assets/22608765/a043c1ef-1111-43d8-ae0b-bee9316361d1)



## Document Info

- [x] This PR doesn't relate to document changes





## Others

### Merging options

- [x] Please squash the commits into a single one when merging.
