### PR TITLE
fix(tooltip): fix tooltip XSS issue when legend name is HTML string

### DIFF
--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -67,6 +67,7 @@ import {
 } from 'zrender/src/core/util';
 import { getECData } from './innerStore';
 import ComponentModel from '../model/Component';
+import { encodeHTML } from 'zrender/src/core/dom';
 
 
 import {
@@ -600,10 +601,11 @@ export function setTooltipConfig(opt: {
     const ecData = getECData(opt.el);
     ecData.componentMainType = mainType;
     ecData.componentIndex = componentIndex;
+
     ecData.tooltipConfig = {
         name: itemName,
         option: defaults({
-            content: itemName,
+            content: encodeHTML(itemName),
             formatterParams: formatterParams
         }, itemTooltipOptionObj)
     };

--- a/test/tooltip.html
+++ b/test/tooltip.html
@@ -66,8 +66,8 @@ under the License.
         <div class="chart" id="positionSpecified"></div>
         <!--<h1>alwaysShowContent (check when hover on the last one, the content should not be the previous one)</h1>-->
         <!--<div class="chart" id="alwaysShowContent"></div>-->
-
-
+        <h1>Tooltip shouldn't render legend name as HTML element by default</h1>
+        <div class="chart" id="tooltip-legend-xss"></div>
 
 
 
@@ -785,34 +785,39 @@ under the License.
         <script>
 
             require(['echarts'], function (echarts) {
-
                 var option = {
                     tooltip: {
-                        trigger: 'axis',
-                        triggerOn: 'click',
-                        axisPointer: {
-                            type: 'cross'
-                        }
-                    }
-                };
-                var baseTop = 90;
-                var height = 150;
-                var gap = 50;
-                makeCategoryGrid(option, {
-                    grid: {top: baseTop, height: height},
-                    yAxis: {
-                        name: 'click show tip',
+                        trigger: 'axis'
+                    },
+                    legend: {
+                        data: ['<img onerror=alert(1)/>'],
                         tooltip: {
                             show: true
                         }
-                    }
-                });
-                baseTop += height + gap;
-
-                createChart('click', echarts, option, baseTop);
+                    },
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {},
+                    series: [
+                        {
+                            name: '<img onerror=alert(1)/>',
+                            type: 'line',
+                            stack: 'Total',
+                            areaStyle: {},
+                            emphasis: {
+                                focus: 'series'
+                            },
+                            data: [220, 182, 191, 234, 290, 330, 310]
+                        }
+                    ]
+                };
+                createChart('tooltip-legend-xss', echarts, option, 500);
             })
         </script>
 
 
     </body>
 </html>
+


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Some components use `graphic.setTooltipConfig` to provide the tooltip ability and use its name as the default tooltip content. This causes potential XSS issues when the name (like `legend`) is an HTML string. This PR tries to fix it by escaping the raw name from HTML. If users hope to render HTML, they can use `tooltip.formatter` to do that.

### Fixed issues

- #19997


## Details

### Before: What was the problem?

<img src="https://github.com/apache/echarts/assets/26999792/ec625c33-6a11-44d6-ba92-d0de69b3aaab" width="500">

### After: How does it behave after the fixing?

<img src="https://github.com/apache/echarts/assets/26999792/220149df-7516-44d1-9dce-178eaa986bd1" width="500">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the last test case in `test/tooltip.html`.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
