### PR TITLE
feat: add role region to div tag when aria: true

### DIFF
--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -154,7 +154,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
         }
 
         if (labelModel.get('description')) {
-            dom.setAttribute('role', 'region');
+            dom.setAttribute('role', 'img');
             dom.setAttribute('aria-label', labelModel.get('description'));
             return;
         }
@@ -242,7 +242,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
             const endSeparator = separatorModel.get('end');
             ariaLabel += seriesLabels.join(middleSeparator) + endSeparator;
 
-            dom.setAttribute('role', 'region');
+            dom.setAttribute('role', 'img');
             dom.setAttribute('aria-label', ariaLabel);
         }
     }

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -154,6 +154,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
         }
 
         if (labelModel.get('description')) {
+            dom.setAttribute('role', 'region');
             dom.setAttribute('aria-label', labelModel.get('description'));
             return;
         }
@@ -241,6 +242,7 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
             const endSeparator = separatorModel.get('end');
             ariaLabel += seriesLabels.join(middleSeparator) + endSeparator;
 
+            dom.setAttribute('role', 'region');
             dom.setAttribute('aria-label', ariaLabel);
         }
     }

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -153,8 +153,9 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
             return;
         }
 
+        dom.setAttribute('role', 'img');
+
         if (labelModel.get('description')) {
-            dom.setAttribute('role', 'img');
             dom.setAttribute('aria-label', labelModel.get('description'));
             return;
         }
@@ -242,7 +243,6 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
             const endSeparator = separatorModel.get('end');
             ariaLabel += seriesLabels.join(middleSeparator) + endSeparator;
 
-            dom.setAttribute('role', 'img');
             dom.setAttribute('aria-label', ariaLabel);
         }
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add role="region" on div tag when aria option is true to allow the aria-label property on the div



### Fixed issues

#20034

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

When aria option was true it would add aria-label to a div tag without a role. aria-label should only be added to interactive elements so it would fail Accessibility tests like Lighthouse's.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://github.com/apache/echarts/assets/124843824/8c62f8cc-16ef-4c02-a6a7-76c83f261a6a)


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Now with role="region" the aria-label is allowed on the element. 

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://github.com/apache/echarts/assets/124843824/0672df34-5bb3-4390-980e-0b1e848e4e17)


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
