### PR TITLE
chore(workflow): use forked workflow deps for timely update

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,11 +25,11 @@ jobs:
             return jobsRes.data.jobs.some((job) => job.name.includes('build') && job.conclusion === 'success');
 
     outputs:
-      SHOULD_DEPOLY: ${{ steps.check-build-success.outputs.result }}
+      SHOULD_DEPLOY: ${{ steps.check-build-success.outputs.result }}
 
   deploy:
     needs: [on-success]
-    if: ${{ needs.on-success.outputs.SHOULD_DEPOLY == 'true' }}
+    if: ${{ needs.on-success.outputs.SHOULD_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +38,7 @@ jobs:
           mkdir .actions
           cd .actions
           git clone --depth=1 https://github.com/dawidd6/action-download-artifact.git
-          git clone --depth=1 https://github.com/actions-cool/maintain-one-comment.git
+          git clone --depth=1 https://github.com/plainheart/maintain-one-comment.git
 
       - name: Fetch PR dist files
         uses: ./.actions/action-download-artifact
@@ -70,7 +70,6 @@ jobs:
           COMMIT_SHA_SHORT: ${{ steps.pr-metadata.outputs.COMMIT_SHA_SHORT }}
         with:
           body: |
-            <!-- ECHARTS_PR_PREVIEW -->
             The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?version=PR-${{ env.PR_NUMBER }}@${{ env.COMMIT_SHA_SHORT }}
           body-include: '<!-- ECHARTS_PR_PREVIEW -->'
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/teardown-pr-preview.yml
+++ b/.github/workflows/teardown-pr-preview.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install action dependencies
-        run: git clone --depth=1 https://github.com/actions-cool/maintain-one-comment.git
+        run: git clone --depth=1 https://github.com/plainheart/maintain-one-comment.git
 
       - name: Delete PR preview comment
         uses: ./maintain-one-comment


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

The action tool [maintain-one-comment](https://github.com/actions-cool/maintain-one-comment) that we are using is quite inactive, so I forked it and will add features as needed and keep maintaining the fork.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx
