### PR TITLE
fix(pie): fix some labels may not show

### DIFF
--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -89,7 +89,7 @@ function adjustSingleSide(
             const rA = r + item.len;
             const rA2 = rA * rA;
             // Use ellipse implicit function to calculate x
-            const dx = Math.sqrt((1 - Math.abs(dy * dy / rB2)) * rA2);
+            const dx = Math.sqrt(Math.abs((1 - Math.abs(dy * dy / rB2)) * rA2));
             const newX = cx + (dx + item.len2) * dir;
             const deltaX = newX - item.label.x;
             const newTargetWidth = item.targetTextWidth - deltaX * dir;

--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -89,7 +89,7 @@ function adjustSingleSide(
             const rA = r + item.len;
             const rA2 = rA * rA;
             // Use ellipse implicit function to calculate x
-            const dx = Math.sqrt(Math.abs((1 - Math.abs(dy * dy / rB2)) * rA2));
+            const dx = Math.sqrt(Math.abs((1 - dy * dy / rB2) * rA2));
             const newX = cx + (dx + item.len2) * dir;
             const deltaX = newX - item.label.x;
             const newTargetWidth = item.targetTextWidth - deltaX * dir;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
[#20070](https://github.com/apache/echarts/issues/20070) Missing pie chart label display


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
When set option as: 
```js
option = {
  tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
  series: [
    {
      name: 'Access From',
      type: 'pie',
      radius: ['45%', '60%'],
      labelLine: { length: 30 },
      label: {
        formatter: '{a|{a}} {abg|}\n{hr|}\n {b|{b}：}{c} {per|{d}%} ',
        backgroundColor: '#F6F8FC',
        borderColor: '#8C8D8E',
        borderWidth: 1,
        borderRadius: 4,
        rich: {
          a: { color: '#6E7079', lineHeight: 22, align: 'center' },
          hr: {
            borderColor: '#8C8D8E',
            width: '100%',
            borderWidth: 1,
            height: 0
          },
          b: {
            color: '#4C5058',
            fontSize: 14,
            fontWeight: 'bold',
            lineHeight: 33
          },
          per: {
            color: '#fff',
            backgroundColor: '#4C5058',
            padding: [3, 4],
            borderRadius: 4
          }
        }
      },
      labelLayout: { hideOverlap: false },
      emphasis: { focus: 'self', blurScope: 'coordinateSystem' },
      data: [
        { value: 11048, name: 'Baidu' },
        { value: 1335, name: 'Direct' },
        { value: 310, name: 'Email' },
        { value: 251, name: 'Google' },
        { value: 234, name: 'Union Ads' },
        { value: 147, name: 'Bing' },
        { value: 135, name: 'Video Ads' },
        { value: 102, name: 'Others' },
        { value: 335, name: 'Direct1' },
        { value: 310, name: 'Email1' },
        { value: 251, name: 'Google1' },
        { value: 234, name: 'Union Ads1' },
        { value: 147, name: 'Bing1' },
        { value: 135, name: 'Video Ads1' },
        { value: 102, name: 'Others1' }
      ]
    }
  ]
};
```
Missing pie chart label display

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/20981909/76c38eb8-aa59-4485-bd1b-8f342315e4b2)



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
This bug was caused here：
path: src/chart/pie/labelLayout.ts:92
code: const dx = Math.sqrt((1 - Math.abs(dy * dy / rB2)) * rA2);
In the calculation of dx, 1- Math.abs (dy * dy/rB2) * rA2 may be negative, Absolute values should be added here.
const dx = Math.sqrt(Math.abs((1 - Math.abs(dy * dy / rB2)) * rA2));

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
![image](https://github.com/apache/echarts/assets/20981909/2919bd9b-9267-43d1-9d6d-ea5966988936)



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
