### PR TITLE
fix(line): fix areaStyle skewing in stepped line series and incorrect connectNull behavior

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -147,8 +147,19 @@ function getStackedOnPoints(
     return points;
 }
 
+/**
+ * Filter the null data and extend data for step considering `stepTurnAt`
+ *
+ * @param points data to convert, that may containing null
+ * @param basePoints base data to reference, used only for areaStyle points
+ * @param coordSys coordinate system
+ * @param stepTurnAt 'start' | 'end' | 'middle' | true
+ * @param connectNulls whether to connect nulls
+ * @returns converted point positions
+ */
 function turnPointsIntoStep(
     points: ArrayLike<number>,
+    basePoints: ArrayLike<number> | null,
     coordSys: Cartesian2D | Polar,
     stepTurnAt: 'start' | 'end' | 'middle',
     connectNulls: boolean
@@ -163,12 +174,18 @@ function turnPointsIntoStep(
     const nextPt: number[] = [];
     const filteredPoints = [];
     if (connectNulls) {
-      for (i = 0; i < points.length; i += 2) {
-          if (!isNaN(points[i]) && !isNaN(points[i + 1])) {
-              filteredPoints.push(points[i], points[i + 1]);
-          }
-      }
-      points = filteredPoints;
+        for (i = 0; i < points.length; i += 2) {
+            /**
+             * For areaStyle of stepped lines, `stackedOnPoints` should be
+             * filtered the same as `points` so that the base axis values
+             * should stay the same as the lines above. See #20021
+             */
+            const reference = basePoints || points;
+            if (!isNaN(reference[i]) && !isNaN(reference[i + 1])) {
+                filteredPoints.push(points[i], points[i + 1]);
+            }
+        }
+        points = filteredPoints;
     }
     for (i = 0; i < points.length - 2; i += 2) {
         nextPt[0] = points[i + 2];
@@ -717,12 +734,11 @@ class LineView extends ChartView {
             );
 
             if (step) {
-                // TODO If stacked series is not step
-                points = turnPointsIntoStep(points, coordSys, step, connectNulls);
-
                 if (stackedOnPoints) {
-                    stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step, connectNulls);
+                    stackedOnPoints = turnPointsIntoStep(stackedOnPoints, points, coordSys, step, connectNulls);
                 }
+                // TODO If stacked series is not step
+                points = turnPointsIntoStep(points, null, coordSys, step, connectNulls);
             }
 
             polyline = this._newPolyline(points);
@@ -801,11 +817,11 @@ class LineView extends ChartView {
                 else {
                     // Not do it in update with animation
                     if (step) {
-                        // TODO If stacked series is not step
-                        points = turnPointsIntoStep(points, coordSys, step, connectNulls);
                         if (stackedOnPoints) {
-                            stackedOnPoints = turnPointsIntoStep(stackedOnPoints, coordSys, step, connectNulls);
+                            stackedOnPoints = turnPointsIntoStep(stackedOnPoints, points, coordSys, step, connectNulls);
                         }
+                        // TODO If stacked series is not step
+                        points = turnPointsIntoStep(points, null, coordSys, step, connectNulls);
                     }
 
                     polyline.setShape({
@@ -1337,10 +1353,10 @@ class LineView extends ChartView {
         let stackedOnNext = diff.stackedOnNext;
         if (step) {
             // TODO If stacked series is not step
-            current = turnPointsIntoStep(diff.current, coordSys, step, connectNulls);
-            stackedOnCurrent = turnPointsIntoStep(diff.stackedOnCurrent, coordSys, step, connectNulls);
-            next = turnPointsIntoStep(diff.next, coordSys, step, connectNulls);
-            stackedOnNext = turnPointsIntoStep(diff.stackedOnNext, coordSys, step, connectNulls);
+            stackedOnCurrent = turnPointsIntoStep(diff.stackedOnCurrent, diff.current, coordSys, step, connectNulls);
+            current = turnPointsIntoStep(diff.current, null, coordSys, step, connectNulls);
+            stackedOnNext = turnPointsIntoStep(diff.stackedOnNext, diff.next, coordSys, step, connectNulls);
+            next = turnPointsIntoStep(diff.next, null, coordSys, step, connectNulls);
         }
         // Don't apply animation if diff is large.
         // For better result and avoid memory explosion problems like

--- a/test/line-step.html
+++ b/test/line-step.html
@@ -38,6 +38,8 @@ under the License.
 
 
         <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
 
 
 
@@ -105,6 +107,109 @@ under the License.
         </script>
 
 
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        data: [null, 250, null, 260, 270, 280, null],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: true
+                    },
+                    {
+                        data: [null, 150, 160, null, 170, 180, 190],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: true
+                    },
+                    {
+                        data: [40, 50, 60, null, 70, null, null],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: true
+                    },
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    'null points in step line with connectNull: true',
+                    'AreaStyle should be correct.'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+
+        <script>
+        require([
+            'echarts',
+            // 'map/js/china',
+            // './data/nutrients.json'
+        ], function (echarts) {
+            var option;
+
+            option = {
+                xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        data: [null, 250, null, 260, 270, 280, null],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: false
+                    },
+                    {
+                        data: [null, 150, 160, null, 170, 180, 190],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: false
+                    },
+                    {
+                        data: [40, 50, 60, null, 70, null, null],
+                        type: 'line',
+                        areaStyle: { opacity: 0.2 },
+                        step: 'end',
+                        connectNulls: false
+                    },
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'main2', {
+                title: [
+                    'null points in step line with connectNull: false',
+                    'AreaStyle should be correct.'
+                ],
+                option: option
+            });
+        });
+        </script>
     </body>
 </html>
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

Resolves #20021


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

areaStyle with stepped line series and connectNull is not correct.

<img width="855" alt="image" src="https://github.com/apache/echarts/assets/779050/445cf04d-d5d0-40f9-8731-01b0ed8c9a28">


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

No skewing in areaStyle.

<img width="676" alt="image" src="https://github.com/apache/echarts/assets/779050/1e6e3483-12dd-426c-8058-d6263744a209">


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
