### PR TITLE
feature(axis): add hiddenTicks to remove SplitLine on specified tick

### DIFF
--- a/src/component/axis/CartesianAxisView.ts
+++ b/src/component/axis/CartesianAxisView.ts
@@ -123,6 +123,7 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         const splitLineModel = axisModel.getModel('splitLine');
         const lineStyleModel = splitLineModel.getModel('lineStyle');
         let lineColors = lineStyleModel.get('color');
+        const hiddenTicks = splitLineModel.get('hiddenTicks') || [];
 
         lineColors = zrUtil.isArray(lineColors) ? lineColors : [lineColors];
 
@@ -142,6 +143,11 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         for (let i = 0; i < ticksCoords.length; i++) {
             const tickCoord = axis.toGlobalCoord(ticksCoords[i].coord);
 
+            const tickValue = ticksCoords[i].tickValue;
+            if (hiddenTicks.includes(tickValue)) {
+                continue
+            }
+
             if (isHorizontal) {
                 p1[0] = tickCoord;
                 p1[1] = gridRect.y;
@@ -156,9 +162,8 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
             }
 
             const colorIndex = (lineCount++) % lineColors.length;
-            const tickValue = ticksCoords[i].tickValue;
             const line = new graphic.Line({
-                anid: tickValue != null ? 'line_' + ticksCoords[i].tickValue : null,
+                anid: tickValue != null ? 'line_' + tickValue : null,
                 autoBatch: true,
                 shape: {
                     x1: p1[0],

--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -302,7 +302,7 @@ function fixOnBandTicksCoords(
     let diffSize;
     if (ticksLen === 1) {
         ticksCoords[0].coord = axisExtent[0];
-        last = ticksCoords[1] = {coord: axisExtent[1]};
+        last = ticksCoords[1] = {coord: axisExtent[1], tickValue: ticksCoords[0].tickValue};
     }
     else {
         const crossLen = ticksCoords[ticksLen - 1].tickValue - ticksCoords[0].tickValue;
@@ -315,7 +315,7 @@ function fixOnBandTicksCoords(
         const dataExtent = axis.scale.getExtent();
         diffSize = 1 + dataExtent[1] - ticksCoords[ticksLen - 1].tickValue;
 
-        last = {coord: ticksCoords[ticksLen - 1].coord + shift * diffSize};
+        last = {coord: ticksCoords[ticksLen - 1].coord + shift * diffSize, tickValue: dataExtent[1] + 1};
 
         ticksCoords.push(last);
     }

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -258,7 +258,8 @@ interface MinorTickOption {
 
 interface SplitLineOption {
     show?: boolean,
-    interval?: 'auto' | number | ((index:number, value: string) => boolean)
+    interval?: 'auto' | number | ((index:number, value: string) => boolean),
+    hiddenTicks?: number[];
     // colors will display in turn
     lineStyle?: LineStyleOption<ZRColor | ZRColor[]>
 }

--- a/test/axis-splitLine.html
+++ b/test/axis-splitLine.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+
+    <body>
+        <div id="main"></div>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var chartDom = document.getElementById('main');
+                var myChart = echarts.init(chartDom);
+                var option;
+
+                option = {
+                    xAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                    splitLine: {
+                        show: true,
+                        hiddenTicks:[0,1,2,5,7],
+                        lineStyle: {
+                            color: 'black',
+                            width:3
+                        }
+                    },
+                },
+                    yAxis: {
+                    type: 'value',
+                    axisLine: {
+                        show: true,
+                        lineStyle: {
+                            color: 'rgba(255,100,0,0.8)',
+                            width: 12
+                        }
+                    }
+                },
+                    series: [
+                        {
+                        data: [150, 230, 224, 218, 135, 147, 260],
+                        type: 'line'
+                        }
+                    ]
+                };
+
+                option && myChart.setOption(option);
+            })
+        </script>
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:
- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?
添加"删除坐标轴指定刻度上的分隔线"的功能
Add feature to remove SplitLine on specified tick in coordinate axis

### Fixed issues
- #20053 

## Details
### Before: What was the problem?
用户无法自定义删除任意刻度上的分割线
当 xAxis 选项中的 splitline 属性与 yAxis 选项中的 axisLine 属性同时设置时，两条线会在 yAxis 轴线所在的位置重叠
User cannot customize the deletion of dividing lines on any scale.
While splitline attr in xAxis options and axisLine atrr in yAxis options set concurrently, two lines from each other overlapper in the position where yAxis axisline lies.

### After: How does it behave after the fixing?
用户可以在 `hiddenTicks` 数组中添加要删除的刻度索引，从而删除对应的分割线
User can add the tick index to be deleted in the hiddenTicks array to delete the corresponding dividing line.
```javascript
xAxis: {
  type: 'category',
  data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
  splitLine: {
    show: true,
    hiddenTicks: [0,1,2,5,7],
    lineStyle: { color: 'black', width:3 }
},
```
<img width="971" alt="截屏2024-07-03 16 55 23" src="https://github.com/apache/echarts/assets/55272646/bd0deea1-58bb-4948-b071-5a7342746333">

### Note
在调试代码的过程中发现`ticksCoords`数组中没有给刻度线右侧的点设置`tickValue`，这会影响在后续查询隐藏线条的绘制，所以修改了 Axis.ts 的`getTicksCoords`方法
While debugging the code, I found that the `ticksCoords` array did not set `tickValue` for the points on the left and right sides of the tick mark, which would affect the drawing of hidden lines in subsequent queries, so I modified the `getTicksCoords` method of Axis.ts
![截屏2024-07-03 16 49 15](https://github.com/apache/echarts/assets/55272646/e477d29f-3618-4209-bbe9-555021b7526d)




## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
