### PR TITLE
feature(treemap): add custom cursor properties for treemap

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -38,8 +38,6 @@ import {
     DefaultEmphasisFocus,
     AriaOptionMixin,
     BlurScope,
-    OptionDataItemObject,
-    OptionDataValueNumeric,
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import { LayoutRect } from '../../util/layout';
@@ -138,7 +136,6 @@ export interface TreemapSeriesLevelOption extends TreemapSeriesVisualOption,
 export interface TreemapSeriesNodeItemOption extends
     TreemapSeriesVisualOption,
     TreemapStateOption,
-    OptionDataItemObject<OptionDataValueNumeric>,
     StatesOptionMixin<TreemapStateOption, ExtraStateOption> {
     id?: OptionId
     name?: OptionName
@@ -219,7 +216,7 @@ export interface TreemapSeriesOption
 
     levels?: TreemapSeriesLevelOption[]
 
-    data?: (OptionDataValueNumeric | OptionDataValueNumeric[] | TreemapSeriesNodeItemOption)[]
+    data?: TreemapSeriesNodeItemOption[]
 }
 
 class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
@@ -367,7 +364,10 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
      */
     getInitialData(option: TreemapSeriesOption, ecModel: GlobalModel) {
         // Create a virtual root.
-        const root = { name: option.name, children: option.data } as TreemapSeriesNodeItemOption;
+        const root: TreemapSeriesNodeItemOption = {
+            name: option.name,
+            children: option.data
+        };
 
         completeTreeValue(root);
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -37,7 +37,7 @@ import {
     SeriesLabelOption,
     DefaultEmphasisFocus,
     AriaOptionMixin,
-    BlurScope,
+    BlurScope
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import { LayoutRect } from '../../util/layout';
@@ -133,10 +133,8 @@ export interface TreemapSeriesLevelOption extends TreemapSeriesVisualOption,
     decal?: DecalObject[] | 'none'
 }
 
-export interface TreemapSeriesNodeItemOption extends
-    TreemapSeriesVisualOption,
-    TreemapStateOption,
-    StatesOptionMixin<TreemapStateOption, ExtraStateOption> {
+export interface TreemapSeriesNodeItemOption extends TreemapSeriesVisualOption,
+    TreemapStateOption, StatesOptionMixin<TreemapStateOption, ExtraStateOption> {
     id?: OptionId
     name?: OptionName
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -151,7 +151,7 @@ export interface TreemapSeriesNodeItemOption extends
 
     decal?: DecalObject[] | 'none',
 
-    cursor?:string
+    cursor?: string
 }
 
 export interface TreemapSeriesOption
@@ -367,10 +367,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
      */
     getInitialData(option: TreemapSeriesOption, ecModel: GlobalModel) {
         // Create a virtual root.
-        const root: TreemapSeriesNodeItemOption = {
-            name: option.name,
-            children: option.data.map(item => item as TreemapSeriesNodeItemOption)
-        };
+        const root = { name: option.name, children: option.data } as TreemapSeriesNodeItemOption;
 
         completeTreeValue(root);
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -37,7 +37,9 @@ import {
     SeriesLabelOption,
     DefaultEmphasisFocus,
     AriaOptionMixin,
-    BlurScope
+    BlurScope,
+    OptionDataItemObject,
+    OptionDataValueNumeric,
 } from '../../util/types';
 import GlobalModel from '../../model/Global';
 import { LayoutRect } from '../../util/layout';
@@ -133,8 +135,11 @@ export interface TreemapSeriesLevelOption extends TreemapSeriesVisualOption,
     decal?: DecalObject[] | 'none'
 }
 
-export interface TreemapSeriesNodeItemOption extends TreemapSeriesVisualOption,
-    TreemapStateOption, StatesOptionMixin<TreemapStateOption, ExtraStateOption> {
+export interface TreemapSeriesNodeItemOption extends
+    TreemapSeriesVisualOption,
+    TreemapStateOption,
+    OptionDataItemObject<OptionDataValueNumeric>,
+    StatesOptionMixin<TreemapStateOption, ExtraStateOption> {
     id?: OptionId
     name?: OptionName
 
@@ -144,7 +149,9 @@ export interface TreemapSeriesNodeItemOption extends TreemapSeriesVisualOption,
 
     color?: ColorString[] | 'none'
 
-    decal?: DecalObject[] | 'none'
+    decal?: DecalObject[] | 'none',
+
+    cursor?:string
 }
 
 export interface TreemapSeriesOption
@@ -212,7 +219,7 @@ export interface TreemapSeriesOption
 
     levels?: TreemapSeriesLevelOption[]
 
-    data?: TreemapSeriesNodeItemOption[]
+    data?: (OptionDataValueNumeric | OptionDataValueNumeric[] | TreemapSeriesNodeItemOption)[]
 }
 
 class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
@@ -362,7 +369,7 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
         // Create a virtual root.
         const root: TreemapSeriesNodeItemOption = {
             name: option.name,
-            children: option.data
+            children: option.data.map(item => item as TreemapSeriesNodeItemOption)
         };
 
         completeTreeValue(root);

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -661,12 +661,12 @@ class TreemapView extends ChartView {
         }
 
         (this._breadcrumb || (this._breadcrumb = new Breadcrumb(this.group)))
-            .render(seriesModel, api, targetInfo.node, (node) => {
-                if (this._state !== 'animating') {
-                    helper.aboveViewRoot(seriesModel.getViewRoot(), node)
-                        ? this._rootToNode({node: node})
-                        : this._zoomToNode({node: node});
-                }
+        .render(seriesModel, api, targetInfo.node, (node) => {
+            if (this._state !== 'animating') {
+                helper.aboveViewRoot(seriesModel.getViewRoot(), node)
+                    ? this._rootToNode({node: node})
+                    : this._zoomToNode({node: node});
+            }
         });
     }
 

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -667,7 +667,7 @@ class TreemapView extends ChartView {
                         ? this._rootToNode({node: node})
                         : this._zoomToNode({node: node});
                 }
-            });
+        });
     }
 
     /**
@@ -876,6 +876,9 @@ function renderNode(
         setAsHighDownDispatcher(group, !isDisabled);
         // Only for enabling highlight/downplay.
         data.setItemGraphicEl(thisNode.dataIndex, group);
+
+        const cursorStyle = nodeModel.getShallow('cursor');
+        cursorStyle && content.attr('cursor', cursorStyle);
 
         enableHoverFocus(group, focusOrIndices, blurScope);
     }

--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -661,13 +661,13 @@ class TreemapView extends ChartView {
         }
 
         (this._breadcrumb || (this._breadcrumb = new Breadcrumb(this.group)))
-        .render(seriesModel, api, targetInfo.node, (node) => {
-            if (this._state !== 'animating') {
-                helper.aboveViewRoot(seriesModel.getViewRoot(), node)
-                    ? this._rootToNode({node: node})
-                    : this._zoomToNode({node: node});
-            }
-        });
+            .render(seriesModel, api, targetInfo.node, (node) => {
+                if (this._state !== 'animating') {
+                    helper.aboveViewRoot(seriesModel.getViewRoot(), node)
+                        ? this._rootToNode({node: node})
+                        : this._zoomToNode({node: node});
+                }
+            });
     }
 
     /**

--- a/test/treemap-cursor.html
+++ b/test/treemap-cursor.html
@@ -1,0 +1,195 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<style>
+    .chart {
+        width: 100%;
+        height: 50%;
+    }
+</style>
+
+<body>
+    <div id="main1" class="chart"></div>
+    <div id="main2" class="chart"></div>
+    <script>
+
+        require([
+            'echarts'
+        ], function (echarts) {
+
+            var chart = echarts.init(document.getElementById('main1'), null, {
+
+            });
+
+            chart.setOption({
+                cursor:'crosshair',
+
+                series: [
+                    {
+                        name: '矩形树图',
+                        type: 'treemap',
+                        label: {
+                            normal: {
+                                // show: false,
+                                position: 'insideRight'
+                                // position: ['100%', 10],
+                                // textStyle: {
+                                //     align: 'right'
+                                // }
+                            },
+                            emphasis: {
+                                show: true
+                            }
+                        },
+                        breadcrumb: {
+                            emphasis: {
+                                itemStyle: {
+                                    color: 'blue',
+                                    opacity: 0.6,
+                                    textStyle: {
+                                        color: 'green'
+                                    }
+                                },
+                            }
+                        },
+                        levels: [
+                            {
+                                itemStyle: {
+                                    normal: {
+                                        borderWidth: 15,
+                                        gapWidth: 30,
+                                        borderColor: '#999'
+                                    }
+                                }
+                            },
+                            {
+                                itemStyle: {
+                                    normal: {
+                                        borderWidth: 15,
+                                        gapWidth: 40,
+                                        borderColor: '#333'
+                                    }
+                                }
+                            },
+                            {
+                                itemStyle: {
+                                    normal: {
+                                        borderWidth: 10,
+                                        borderColor: '#555570'
+                                    }
+                                }
+                            }
+                        ],
+                        cursor:'crosshair', /* it should be able to set crosshair for treemap */
+                        data: [
+                            {
+                                name: '三星',
+                                value: 6,
+                            },
+                            {
+                                name: '小米',
+                                value: 4,
+                                children: [
+                                    {
+                                        name: '小米0',
+                                        value: 10,
+                                        children: [
+                                            {
+                                                itemStyle: {
+                                                    normal: {
+                                                        color: 'yellow'
+                                                    }
+                                                },
+                                                name: '小尺',
+                                                value: 400
+                                            },
+                                            {
+                                                name: '小寸',
+                                                value: 200
+                                            },
+                                            {
+                                                name: '小光年',
+                                                value: 100
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        name: '小米1',
+                                        value: 4
+                                    },
+                                    {
+                                        name: '小米2',
+                                        value: 4
+                                    }
+                                ]
+                            },
+                            {
+                                name: '中兴',
+                                value: 1
+                            }
+                        ]
+                    }
+                ]
+            });
+
+            var chart1 = echarts.init(document.getElementById('main2'));
+            option = {
+                series: [{
+                    label: {
+                        show: false
+                    },
+                    emphasis: {
+                        label: {
+                            show: true,
+                            formatter() {
+                                return 11111;
+                            }
+                        }
+                    },
+                    type: 'treemap',
+                    data: [{
+                        name: 'nodeA',            // First tree
+                        value: 10,
+                        children: [{
+                            name: 'nodeAa',       // First leaf of first tree
+                            value: 4
+                        }, {
+                            name: 'nodeAb',       // Second leaf of first tree
+                            value: 6
+                        }]
+                    }]
+                }]
+            };
+
+            chart1.setOption(option);
+        });
+
+    </script>
+</body>
+
+</html>

--- a/test/treemap-cursor.html
+++ b/test/treemap-cursor.html
@@ -47,8 +47,6 @@ under the License.
             });
 
             chart.setOption({
-                cursor:'crosshair',
-
                 series: [
                     {
                         name: '矩形树图',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of: 

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?
Adding custom cursor properties for Treemap

### Fixed issues
- #13632 

## Details
### Before: What was the problem?
In treemap, there is no way to customize the cursor style through cursor, and it can only default to "pointer"
### After: How does it behave after the fixing?
Users can set the cursor style in option like other series graph
```javascript
series: [
 {
    name: 'TreeMap Cursor',
    type: 'treemap',
    label: ... ,
    breadcrumb: ... ,
    levels: ... ,
    cursor:'crosshair',  // it should be able to set crosshair for treemap
    data: 
  }
]
```
<img width="1366" alt="image" src="https://github.com/apache/echarts/assets/55272646/e7ee9f81-f833-4e2a-a524-d03e18fa317d">

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
