### PR TITLE
chore: enable prompt to use typescript from workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib"
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

In case some developers use a typescript version outside the workspace, which may be different from the fixed typescript version in package.json, it's better to enable a prompt.

![image](https://github.com/apache/echarts/assets/26999792/dab615ff-e136-4a89-8464-9ef35b031252)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
