### PR TITLE
perf(line): reduce runtime memory cost

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -624,6 +624,8 @@ class LineView extends ChartView {
 
         this._symbolDraw = symbolDraw;
         this._lineGroup = lineGroup;
+
+        this._changePolyState = zrUtil.bind(this._changePolyState, this);
     }
 
     render(seriesModel: LineSeriesModel, ecModel: GlobalModel, api: ExtensionAPI) {
@@ -885,9 +887,7 @@ class LineView extends ChartView {
             toggleHoverEmphasis(polygon, focus, blurScope, emphasisDisabled);
         }
 
-        const changePolyState = (toState: DisplayState) => {
-            this._changePolyState(toState);
-        };
+        const changePolyState = this._changePolyState;
 
         data.eachItemGraphicEl(function (el) {
             // Switch polyline / polygon state if element changed its state.


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Prebind the context of the `_changePolyState` function to the current instance of `LineView` rather than create a new function to reduce runtime memory cost.

### Fixed issues

- Resolves #20151


## Details

| [Before](https://echarts.apache.org/examples/editor.html?code=G4QwTgBARiDOCmEC8EDUA7eB3CAREALvABQBMADAIwAsANBAJz0DMAlANwBQokA9pvgCeyCKWoQAVBGYA2cuUkRK88lx4QAJoUQoA2gF014TYRAjdAWUIALAHRgQ6DbwC2xVosoBWcoe7H0XhwUTBx8ImIYBA5OADMAV3QAYwIAS34IEA0NcJBiWGtU2IIPAG9OCAhA4IhdatsAc3gCADF4gBt2gE14cHd6eqaCC34Ca3c0JQGgxubwklZ9WwArXlT0YgByAHpNmMqtIlsAB3iC4mr9kwIQE7Px4isx-0dnNw8AWghyW2oPKWUk0OIF0wNs7Xg6AaYwgX0o-iuRQg-UKxTKFUq13gtgKRQI7i4mOut1xxQJGIAvhjqiJQnhtMQMNh6RFLpN-PAhDEqbFeJBiOpUiJKOwIEKADxKeSi1KoVDoypZHKmclU3jHNIZFDlSoADwAgrrUrAAFwQHWYgiCY7wM2bJLaBp8wSbWgYypQXiJLRgQQAcRAxzNsRA7QQbqJwLNh3glIjEEEhuNZotHq9TnA_sDZt05Homx8AFJNvp45UrTa7aB2vF4Js4xiEGBUvBTbV3eaO5V0CAXLaIJtAAhGgBK5V1diAV_ubdrrOtlzGwFy8XhjM0EMC1-eVbbbCAWACqAGUACoAQnP49gghcnvadvgLg1ggAwqkwEkIWOiZVYDckgBrO0QC_b9wF6Q8rQhFNx27PkXFDFMqW_CAKS3Ylo1MDskIgfROApLgEAIABJdAiDAatiASZJNXQZEFUybJcmIddayuFwX2scACBxZoAHkNXSDZUwgA0jTbYSDlMDCiCw-cmxbNtdHHCTMR7Ps7RHEDkKjYlx2wypcMqCluXoZRyA4IA&version=5.5.1) | [After](https://echarts.apache.org/examples/editor.html?code=G4QwTgBARiDOCmEC8EDUA7eB3CAREALvABQBMADAIwAsANBAJz0DMAlANwBQokA9pvgCeyCKWoQAVBGYA2cuUkRK88lx4QAJoUQoA2gF014TYRAjdAWUIALAHRgQ6DbwC2xVosoBWcoe7H0XhwUTBx8ImIYBA5OADMAV3QAYwIAS34IEA0NcJBiWGtU2IIPAG9OCAhA4IhdatsAc3gCADF4gBt2gE14cHd6eqaCC34Ca3c0JQGgxubwklZ9WwArXlT0YgByAHpNmMqtIlsAB3iC4mr9kwIQE7Px4isx-0dnNw8AWghyW2oPKWUk0OIF0wNs7Xg6AaYwgX0o-iuRQg-UKxTKFUq13gtgKRQI7i4mOut1xxQJGIAvhjqiJQnhtMQMNh6RFLpN-PAhDEqbFeJBiOpUiJKOwIEKADxKeSi1KoVDoypZHKmclU3jHNIZFDlSoADwAgrrUrAAFwQHWYgiCY7wM2bJLaBp8wSbWgYypQXiJLRgQQAcRAxzNsRA7QQbqJwLNh3glIjEEEhuNZotHq9TnA_sDZt05Homx8AFJNvp45UrTa7aB2vF4Js4xiEGBUvBTbV3eaO5V0CAXLaIJtAAhGgBK5V1diAV_ubdrrOtlzGwFy8XhjM0EMC1-eVbbbCAWACqAGUACoAQnP49gghcnvadvgLg1ggAwqkwEkIWOiZVYDckgBrO0QC_b9wF6Q8rQhFNx27PkXFDFMqW_CAKS3Ylo1MDskIgfROApLgEAIABJdAiDAatiASZJNXQZEFUybJcmIddayuFwX2scACBxZoAHkNXSDZUwgA0jTbYSDlMDCiCw-cmxbNtdHHCTMR7Ps7RHEDkKjYlx2wypcMqCluXoZRyA4IA&version=PR-20161) |
| :----: | :----: |
| ![image](https://github.com/user-attachments/assets/7c4003dd-e775-482e-9808-0c1451b59477) | ![image](https://github.com/user-attachments/assets/16818680-7dfa-410f-a71c-158c0a992da5) |

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

See the online [demo](https://echarts.apache.org/examples/editor.html?code=G4QwTgBARiDOCmEC8EDUA7eB3CAREALvABQBMADAIwAsANBAJz0DMAlANwBQokA9pvgCeyCKWoQAVBGYA2cuUkRK88lx4QAJoUQoA2gF014TYRAjdAWUIALAHRgQ6DbwC2xVosoBWcoe7H0XhwUTBx8ImIYBA5OADMAV3QAYwIAS34IEA0NcJBiWGtU2IIPAG9OCAhA4IhdatsAc3gCADF4gBt2gE14cHd6eqaCC34Ca3c0JQGgxubwklZ9WwArXlT0YgByAHpNmMqtIlsAB3iC4mr9kwIQE7Px4isx-0dnNw8AWghyW2oPKWUk0OIF0wNs7Xg6AaYwgX0o-iuRQg-UKxTKFUq13gtgKRQI7i4mOut1xxQJGIAvhjqiJQnhtMQMNh6RFLpN-PAhDEqbFeJBiOpUiJKOwIEKADxKeSi1KoVDoypZHKmclU3jHNIZFDlSoADwAgrrUrAAFwQHWYgiCY7wM2bJLaBp8wSbWgYypQXiJLRgQQAcRAxzNsRA7QQbqJwLNh3glIjEEEhuNZotHq9TnA_sDZt05Homx8AFJNvp45UrTa7aB2vF4Js4xiEGBUvBTbV3eaO5V0CAXLaIJtAAhGgBK5V1diAV_ubdrrOtlzGwFy8XhjM0EMC1-eVbbbCAWACqAGUACoAQnP49gghcnvadvgLg1ggAwqkwEkIWOiZVYDckgBrO0QC_b9wF6Q8rQhFNx27PkXFDFMqW_CAKS3Ylo1MDskIgfROApLgEAIABJdAiDAatiASZJNXQZEFUybJcmIddayuFwX2scACBxZoAHkNXSDZUwgA0jTbYSDlMDCiCw-cmxbNtdHHCTMR7Ps7RHEDkKjYlx2wypcMqCluXoZRyA4IA&version=5.5.1)


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
