### PR TITLE
fix(polar): angleAxis extent when boundaryGap is false

### DIFF
--- a/src/coord/polar/polarCreator.ts
+++ b/src/coord/polar/polarCreator.ts
@@ -102,9 +102,15 @@ function updatePolarScale(this: Polar, ecModel: GlobalModel, api: ExtensionAPI) 
     // Fix extent of category angle axis
     if (angleAxis.type === 'category' && !angleAxis.onBand) {
         const extent = angleAxis.getExtent();
-        const diff = 360 / (angleAxis.scale as OrdinalScale).count();
-        angleAxis.inverse ? (extent[1] += diff) : (extent[1] -= diff);
-        angleAxis.setExtent(extent[0], extent[1]);
+        const angleModel = angleAxis.model;
+        const endAngle = angleModel.get('endAngle');
+        const spanAngle = (endAngle == null ? 360 : endAngle - angleModel.get('startAngle'))
+            * (angleAxis.inverse ? -1 : 1) ;
+        const diff = spanAngle / (angleAxis.scale as OrdinalScale).count();
+        if (Math.abs(spanAngle + diff) >= 360) {
+            extent[1] += Math.abs(diff);
+            angleAxis.setExtent(extent[0], extent[1]);
+        }
     }
 }
 

--- a/test/bar-polar-basic-radial.html
+++ b/test/bar-polar-basic-radial.html
@@ -37,12 +37,21 @@ under the License.
                 background: #fff;
             }
         </style>
-        <div id="main"></div>
+        <h2>
+            angleAxis range should adjust when `boundaryGap: false`.
+        </h2>
+        <p>
+            1. startAngle: 90, endAngle: -270, clockwise: true: `a` to `d` should take 3/4 of the circle so that pieces are not overlapped.
+        </p>
+        <p>
+            2. (click "textNext") startAngle: 90, endAngle: -90, clockwise: true: `a` to `d` should take 1/2 of the circle so that pieces are not overlapped.
+        </p>
         <div id="main2"></div>
+        <div id="main"></div>
 
 
 
-        <!-- <script>
+        <script>
 
             require(['echarts'], function (echarts) {
 
@@ -76,7 +85,7 @@ under the License.
 
                 window.onresize = chart.resize;
             });
-        </script> -->
+        </script>
 
 
 
@@ -89,23 +98,27 @@ under the License.
                 var config = {
                     startAngle: 90,
                     endAngle: -270,
-                    clockwise: false
+                    clockwise: true,
+                    testNext: () => {
+                        config.startAngle = 90;
+                        config.endAngle = -90;
+                        update();
+                    }
                 };
 
                 chart.setOption({
                     angleAxis: {
                         type: 'category',
                         data: [
-                        'a',
-                        'b',
-                        'c',
-                        'd'
+                            'a',
+                            'b',
+                            'c',
+                            'd'
                         ],
-                        // boundaryGap: false,
+                        boundaryGap: false,
                         startAngle: config.startAngle,
                         endAngle: config.endAngle,
                         clockwise: config.clockwise
-
                     },
                     radiusAxis: {
                     },
@@ -139,6 +152,7 @@ under the License.
                     .onChange(update);
                 gui.add(config, 'clockwise')
                     .onChange(update);
+                gui.add(config, 'testNext');
             });
         </script>
     </body>

--- a/test/bar-polar-basic-radial.html
+++ b/test/bar-polar-basic-radial.html
@@ -23,21 +23,26 @@ under the License.
         <meta charset="utf-8">
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
+        <script src="lib/dat.gui.min.js"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>
     <body>
         <style>
-            html, body, #main {
+            html, body, #main, #main2 {
                 width: 100%;
                 height: 100%;
                 margin: 0;
             }
-            #main {
+            #main, #main2 {
                 background: #fff;
             }
         </style>
         <div id="main"></div>
-        <script>
+        <div id="main2"></div>
+
+
+
+        <!-- <script>
 
             require(['echarts'], function (echarts) {
 
@@ -70,6 +75,70 @@ under the License.
                 });
 
                 window.onresize = chart.resize;
+            });
+        </script> -->
+
+
+
+        <script>
+
+            require(['echarts'], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main2'));
+
+                var config = {
+                    startAngle: 90,
+                    endAngle: -270,
+                    clockwise: false
+                };
+
+                chart.setOption({
+                    angleAxis: {
+                        type: 'category',
+                        data: [
+                        'a',
+                        'b',
+                        'c',
+                        'd'
+                        ],
+                        // boundaryGap: false,
+                        startAngle: config.startAngle,
+                        endAngle: config.endAngle,
+                        clockwise: config.clockwise
+
+                    },
+                    radiusAxis: {
+                    },
+                    polar: {},
+                    series: [
+                        {
+                            type: 'bar',
+                            data: [10, 20, 30, 40],
+                            coordinateSystem: 'polar',
+                            itemStyle: {
+                                opacity: 0.5
+                            }
+                        }
+                    ]
+                });
+
+                function update() {
+                    chart.setOption({
+                        angleAxis: {
+                            startAngle: config.startAngle,
+                            endAngle: config.endAngle,
+                            clockwise: config.clockwise
+                        }
+                    });
+                }
+
+                var gui = new dat.GUI();
+                gui.add(config, 'startAngle', -360, 360)
+                    .onChange(update);
+                gui.add(config, 'endAngle', -360, 360)
+                    .onChange(update);
+                gui.add(config, 'clockwise')
+                    .onChange(update);
             });
         </script>
     </body>

--- a/test/runTest/actions/__meta__.json
+++ b/test/runTest/actions/__meta__.json
@@ -23,6 +23,7 @@
   "bar-large": 2,
   "bar-overflow-time-plot": 3,
   "bar-polar-animation": 2,
+  "bar-polar-basic-radial": 1,
   "bar-polar-clockwise": 1,
   "bar-polar-multi-series": 1,
   "bar-polar-multi-series-radial": 1,

--- a/test/runTest/actions/bar-polar-basic-radial.json
+++ b/test/runTest/actions/bar-polar-basic-radial.json
@@ -1,0 +1,1 @@
+[{"name":"Action 1","ops":[{"type":"mousemove","time":1158,"x":786,"y":251},{"type":"mousemove","time":1358,"x":661,"y":119},{"type":"mousemove","time":1558,"x":617,"y":90},{"type":"mousedown","time":1762,"x":617,"y":90},{"type":"mouseup","time":1855,"x":617,"y":90},{"time":1856,"delay":400,"type":"screenshot-auto"}],"scrollY":0,"scrollX":0,"timestamp":1721629682533}]


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When angleAxis in the polar system has `boundaryGap: false`, the extent is adjusted since [this commit](https://github.com/apache/echarts/commit/2fcdde6ea773514ff34e2eceece1c97bfe2ebb47#diff-43424e7431043adf45e3aba374fe74528fe1475b0e098246b6e4454578fc1aa5R127-R130) so that polar bars don't overlap each other. The main idea is to make extra space according to data count. But it may overkill in some situations.

### Fixed issues

NA.

This PR is not a fix to #20172 , which is not a bug.

## Details

### Before: What was the problem?

Consider the case when `startAngle: 90, endAngle: -90`, before this PR, it has the result of:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/114eb20d-d205-47f6-9923-ce8d34c19516">

This is not as expected because a developer set `startAngle: 90, endAngle: -90` would expect the range to be half a circle.

### After: How does it behave after the fixing?

The extent of angleAxis with `boundaryGap: false` should only be adjusted if it has the potential to overlap, that is to say, `startAngle: 90, endAngle: -90` should still get half a circle:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/208e9194-7c2a-4c4c-8df7-bd54a05a67bf">

while `startAngle: 90, endAngle: -270` should get 3/4 of a circle:

<img width="561" alt="image" src="https://github.com/user-attachments/assets/afd918b4-da27-464c-9682-5467302a2ba4">

Please also not that if the range of startAngle and endAngle itself is over 360 degrees, it won't adjust to be smaller than a circle because it is not expected to.

<img width="691" alt="image" src="https://github.com/user-attachments/assets/b960c4b0-0e30-48bd-a65f-6092839a1713">


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
