### PR TITLE
Fix animation duration not applied for pie charts

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -315,13 +315,10 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
         // Animation type. Valid values: expansion, scale
         animationType: 'expansion',
 
-        animationDuration: 1000,
-
         // Animation type when update. Valid values: transition, expansion
         animationTypeUpdate: 'transition',
 
         animationEasingUpdate: 'cubicInOut',
-        animationDurationUpdate: 500,
         animationEasing: 'cubicInOut'
     };
 

--- a/test/pie-animation.html
+++ b/test/pie-animation.html
@@ -140,11 +140,11 @@ under the License.
             ];
 
             var option = {
+                animationDuration: 1000,
+                animationDurationUpdate: 10000,
                 series: [{
                     type: 'pie',
                     animationType: 'expansion',
-                    animationDuration: 1000,
-                    animationDurationUpdate: 10000,
                     animationTypeUpdate: 'expansion',
                     startAngle: 0,
                     endAngle: 360,

--- a/test/pie-animation.html
+++ b/test/pie-animation.html
@@ -91,10 +91,10 @@ under the License.
             ];
 
             var option = {
+                animationDuration: 10000,
+                animationDurationUpdate: 10000,
                 series: [{
                     type: 'pie',
-                    animationDuration: 1000,
-                    animationDurationUpdate: 10000,
                     startAngle: 0,
                     endAngle: 360,
                     radius: ['50%', '80%'],


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This PR aims to fix a bug that prevents `animationDuration` and `animationUpdateDuration` defined on option level to be applied. 

### Fixed issues
#20192


## Details

### Before: What was the problem?

See bug description in #20192 


### After: How does it behave after the fixing?

See: https://github.com/michaelwittmann/echarts/blob/3bcc9368f4206fdadafb5a07a391777301b9f75e/test/pie-animation.html

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

-  [x] Please squash the commits into a single one when merging.

### Other information
