### PR TITLE
feat(aria): allows excluding data in aria-label

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1734,7 +1734,7 @@ export interface AriaLabelOption {
             middle?: string;
             end?: string;
         },
-        excludeDataId?: number[]
+        excludeDimensionId?: number[]
     }
 }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1733,7 +1733,8 @@ export interface AriaLabelOption {
         separator?: {
             middle?: string;
             end?: string;
-        }
+        },
+        excludeDataId?: number[]
     }
 }
 

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -218,11 +218,13 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
 
                     const middleSeparator = labelModel.get(['data', 'separator', 'middle']);
                     const endSeparator = labelModel.get(['data', 'separator', 'end']);
+                    const excludeDataId = labelModel.get(['data', 'excludeDataId']);
                     const dataLabels = [];
                     for (let i = 0; i < data.count(); i++) {
                         if (i < maxDataCnt) {
                             const name = data.getName(i);
-                            const value = data.getValues(i);
+                            const value = !excludeDataId ? data.getValues(i)
+                                : zrUtil.filter(data.getValues(i), (v, j) => zrUtil.indexOf(excludeDataId, j) === -1);
                             const dataLabel = labelModel.get(['data', name ? 'withName' : 'withoutName']);
                             dataLabels.push(
                                 replace(dataLabel, {

--- a/src/visual/aria.ts
+++ b/src/visual/aria.ts
@@ -218,13 +218,14 @@ export default function ariaVisual(ecModel: GlobalModel, api: ExtensionAPI) {
 
                     const middleSeparator = labelModel.get(['data', 'separator', 'middle']);
                     const endSeparator = labelModel.get(['data', 'separator', 'end']);
-                    const excludeDataId = labelModel.get(['data', 'excludeDataId']);
+                    const excludeDimensionId = labelModel.get(['data', 'excludeDimensionId']);
                     const dataLabels = [];
                     for (let i = 0; i < data.count(); i++) {
                         if (i < maxDataCnt) {
                             const name = data.getName(i);
-                            const value = !excludeDataId ? data.getValues(i)
-                                : zrUtil.filter(data.getValues(i), (v, j) => zrUtil.indexOf(excludeDataId, j) === -1);
+                            const value = !excludeDimensionId ? data.getValues(i)
+                                : zrUtil.filter(data.getValues(i), (v, j) =>
+                                    zrUtil.indexOf(excludeDimensionId, j) === -1);
                             const dataLabel = labelModel.get(['data', name ? 'withName' : 'withoutName']);
                             dataLabels.push(
                                 replace(dataLabel, {

--- a/test/ut/spec/series/aria-columns-exclude.test.ts
+++ b/test/ut/spec/series/aria-columns-exclude.test.ts
@@ -26,7 +26,7 @@ describe('aria, omit data', function () {
         'aria': {
             'enabled': true,
             'data': {
-                'excludeDataId': [0, 1, 2]
+                'excludeDimensionId': [0, 1, 2]
             },
         },
         'dataset': [

--- a/test/ut/spec/series/aria-columns-exclude.test.ts
+++ b/test/ut/spec/series/aria-columns-exclude.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getECModel } from '../../core/utHelper';
+
+describe('aria, omit data', function () {
+    let chart: EChartsType;
+    const option = {
+        'aria': {
+            'enabled': true,
+            'data': {
+                'excludeDataId': [0, 1, 2]
+            },
+        },
+        'dataset': [
+            {
+                'dimensions': [
+                    'lng',
+                    'lat',
+                    'name',
+                    'value',
+                    'capacity',
+                ],
+                'source': [
+                    [
+                        1.58285827,
+                        42.099784969,
+                        'Llosa del Cavall (Navès)',
+                        17.945,
+                        80,
+                    ],
+                    [
+                        0.960270444,
+                        41.134931354,
+                        'Riudecanyes',
+                        0.401,
+                        5.32,
+                    ],
+                ]
+
+            }
+        ],
+        'series': [
+            {
+                'coordinateSystem': 'geo',
+                'encode': {
+                    'itemName': 'name'
+                },
+                'type': 'scatter',
+            }
+        ],
+    };
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('specified columns should be omitted from Aria (geolocation and name)', () => {
+        chart.setOption(option);
+        const el = chart.getDom();
+        const ariaValue = el.getAttribute('aria-label');
+        expect(ariaValue).toContain('Llosa del Cavall (Navès) is 17.945, 80');
+        expect(ariaValue).toContain('Riudecanyes is 0.401, 5.32');
+        expect(ariaValue).not.toContain(1.58285827);
+        expect(ariaValue).not.toContain(42.099784969);
+        expect(ariaValue).not.toContain(0.960270444);
+        expect(ariaValue).not.toContain(41.134931354);
+    });
+
+    it('should not modify the data of the chart', async () => {
+        chart.setOption(option);
+        const listData = getECModel(chart).getSeries()[0].getData();
+        expect(listData.getValues(0)).toEqual([1.58285827, 42.099784969, 'Llosa del Cavall (Navès)', 17.945, 80]);
+        expect(listData.getValues(1)).toEqual([0.960270444, 41.134931354, 'Riudecanyes', 0.401, 5.32]);
+    });
+
+});


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Allows excluding data in aria-label



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

All data was present in the aria-label. My use case was for a map chart, where the coordinates should be excluded.



### After: How does it behave after the fixing?

Add column indexes to be excluded to aria.data.excludeDataId and they will not appear in the data in aria.label.



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in https://github.com/apache/echarts-doc/pull/414



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
