### PR TITLE
fix(Axis): Correct time axis bandwidth calculation

### DIFF
--- a/test/axis-axisPointer.html
+++ b/test/axis-axisPointer.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="lib/reset.css">
+    </head>
+    <body>
+
+        <div id="main" style="width: 600px;height:400px;"></div>
+
+        <script>
+
+            var echarts;
+
+            require(['echarts'], function (ec) {
+                echarts = ec;
+                chart = echarts.init(document.getElementById('main'));
+
+                option =  {
+                    title: {
+                        text: 'Shadowy axis pointer for time axis'
+                    },
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: {
+                            type: 'shadow'
+                        }
+                    },
+                    legend: {
+                        "show": true,
+                        "right": 'right',
+                        "orient": 'vertical'
+                    },
+                    xAxis: {
+                        type: "time"
+                    },
+                    yAxis: {
+
+                    },
+                    series: [
+                    {
+                        name: 'Param1',
+                        type: 'bar',
+                        data: [["2019-01-12", 5], ["2019-01-13", 20], ["2019-01-14", 36], ["2019-01-15", 10], ["2019-01-16", 10], ["2019-01-17", 20]]
+                    },
+                    {
+                        name: 'Param2',
+                        type: 'bar',
+                        data: [["2019-01-12", 39], ["2019-01-13", 13], ["2019-01-14", 13], ["2019-01-15", 23], ["2019-01-16", 8], ["2019-01-17", 23]]
+                        },
+                ]
+                };
+
+                chart.setOption(option);
+            });
+
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Added a method to calculate the bandwidth of the time axis, and fixed the problem of not displaying the width when the axisPointer type is shadow.
添加时间坐标轴关于bandwidth的计算方法，修复axisPointer type为shadow时，不显示宽度的问题

### Fixed issues

<!--
- #9843
- #15411 
-->

## Details

### Before: What was the problem?
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
The intervals between timestamp data may be uneven, so the difference in data length cannot accurately reflect the number of data points, resulting in the inability to calculate the correct bandwidth value for the time type axis. When the `axisPointer` type is `shadow`, only a line close to 0 is displayed.
时间戳数据之间的间隔可能不均匀，因此数据长度的差值无法准确反映数据点数量，导致时间类型的轴无法计算得到正确的bandwidth值，当axispointer的type为shadow的时候，只显示一条接近于0的线
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="610" alt="截屏2024-08-07 01 45 14" src="https://github.com/user-attachments/assets/4672b4a0-ac97-4e99-b1c0-8448fb557df8">

### After: How does it behave after the fixing?
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
Added a method to calculate data length. When the axis type is time, the `_approxInterval` attribute is used to represent the average interval of the time scale. By dividing by this interval and rounding up, the number of data points can be estimated more accurately.
添加数据长度的计算方法，当轴的类型为时间时，利用_approxInterval 属性代表时间刻度的平均间隔，通过除以这个间隔并向上取整，可以更准确地估算出数据点的数量，从而得到有宽度的矩形高亮区
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="601" alt="截屏2024-08-07 01 44 39" src="https://github.com/user-attachments/assets/73ed1d10-a009-409f-9e02-ad074a8e08a5">

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
