### PR TITLE
fix(time): fix bar bandWidth with inversed time axis

### DIFF
--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -115,7 +115,7 @@ function adjustScaleForOverflow(
 
     // Get Axis Length
     const axisExtent = model.axis.getExtent();
-    const axisLength = axisExtent[1] - axisExtent[0];
+    const axisLength = Math.abs(axisExtent[1] - axisExtent[0]);
 
     // Get bars on current base axis and calculate min and max overflow
     const barsOnCurrentAxis = retrieveColumnLayout(barWidthAndOffset, model.axis);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix bar series bandWidth with axis typed with `'time'` and `inverse: true`.

### Fixed issues

#20068

## Details

### Before: What was the problem?

Wrong bandWidth:

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/aee0d58c-8124-40df-9fe4-ecacfad63009">


### After: How does it behave after the fixing?

Correct bandWidth:

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/8a07123a-fb3c-48c2-a310-f3ae9df32cd2">



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
