### PR TITLE
feat(log): allows zero and negativ values

### DIFF
--- a/src/coord/axisAlignTicks.ts
+++ b/src/coord/axisAlignTicks.ts
@@ -26,8 +26,8 @@ import LogScale from '../scale/Log';
 import { warn } from '../util/log';
 import { increaseInterval, isValueNice } from '../scale/helper';
 
-const mathLog = Math.log;
-
+import * as myMath from '../util/math';
+const mathLog = myMath.log;
 
 export function alignScaleTicks(
     scale: IntervalScale | LogScale,

--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -37,7 +37,8 @@ const mathFloor = Math.floor;
 const mathCeil = Math.ceil;
 const mathPow = Math.pow;
 
-const mathLog = Math.log;
+import * as myMath from '../util/math';
+const mathLog = myMath.log;
 
 class LogScale extends Scale {
     static type = 'log';

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,0 +1,28 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+export function log(param: number): number {
+    if (param > 0.0) {
+       return Math.log(param);
+    }
+    if (param < 0.0) {
+       return -Math.log(-param);
+    }
+    return 0.0;
+}


### PR DESCRIPTION
There are problems when using axis of type 'log' with zero and negative values.

This change allow zero and negative values, when useing type 'log' for an axis.

src/coord/axisAlignTicks.ts and src/scale/Log.ts will use log() as mathLog from src/util/math.ts.
