### PR TITLE
fix(gauge): fix z2 is negative when maxVal is negative

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -451,7 +451,7 @@ class GaugeView extends ChartView {
                     r: r
                 }
             });
-            isOverlap && (progress.z2 = maxVal - (data.get(valueDim, idx) as number) % maxVal);
+            isOverlap && (progress.z2 = linearMap(data.get(valueDim, idx) as number, [minVal, maxVal], [100, 0], true));
             return progress;
         }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When `max` of a gauge is negative, the `z2` calculated is also negative. Thus the axisLine is on top of the progress bar. This PR fixes how `z2` is calculated to ensure it is always non-negative.

### Fixed issues

<!--
- #xxxx: ...
-->
fix #20097

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

The progress bar is beneath the axisLine.

![image](https://github.com/user-attachments/assets/9b030103-d821-4be0-9d2f-7469dd99246a)

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://github.com/user-attachments/assets/7a299430-0efa-417f-962d-34746cbd29ab)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
