### PR TITLE
fix(pictorialBar): symbol should not flip with zero data

### DIFF
--- a/src/chart/bar/PictorialBarView.ts
+++ b/src/chart/bar/PictorialBarView.ts
@@ -278,6 +278,7 @@ function getSymbolMeta(
         hoverScale: isAnimationEnabled && itemModel.get(['emphasis', 'scale']),
         z2: itemModel.getShallow('z', true) || 0
     } as SymbolMeta;
+    console.log(symbolMeta)
 
     prepareBarLength(itemModel, symbolRepeat, layout, opt, symbolMeta);
 
@@ -341,7 +342,7 @@ function prepareBarLength(
 
     // if 'pxSign' means sign of pixel,  it can't be zero, or symbolScale will be zero
     // and when borderWidth be settled, the actual linewidth will be NaN
-    outputSymbolMeta.pxSign = boundingLength > 0 ? 1 : -1;
+    outputSymbolMeta.pxSign = boundingLength >= 0 ? 1 : -1;
 }
 
 function convertToCoordOnAxis(axis: Axis2D, value: number) {

--- a/src/chart/bar/PictorialBarView.ts
+++ b/src/chart/bar/PictorialBarView.ts
@@ -278,7 +278,6 @@ function getSymbolMeta(
         hoverScale: isAnimationEnabled && itemModel.get(['emphasis', 'scale']),
         z2: itemModel.getShallow('z', true) || 0
     } as SymbolMeta;
-    console.log(symbolMeta)
 
     prepareBarLength(itemModel, symbolRepeat, layout, opt, symbolMeta);
 

--- a/test/pictorial-zero-value.html
+++ b/test/pictorial-zero-value.html
@@ -32,6 +32,7 @@ under the License.
 
         <div id="main"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
 
         <script>
             var chart;
@@ -166,6 +167,59 @@ under the License.
 
                 option && myChart.setOption(option);
             });
+        </script>
+
+
+
+        <script>
+            require(['echarts'], function (echarts) {
+                option = {
+                    xAxis: {
+                        type: 'value',
+                        boundaryGap: [0, 0.01]
+                    },
+                    yAxis: {
+                        type: 'category',
+                        data: ['Brazil', 'Indonesia']
+                    },
+                    series: [
+                        {
+                        name: '2011',
+                        type: 'bar',
+                        data: [0, 630230]
+                        },
+                        {
+                        type: 'pictorialBar',
+                        symbolPosition: 'end',
+                        symbolSize: 40,
+                        symbolOffset: [2, 0],
+                        zlevel: 2,
+                        data: [
+                            {
+                            value: 0,
+                            symbol:
+                                'image://https://fuss10.elemecdn.com/a/3f/3302e58f9a181d2509f3dc0fa68b0jpeg.jpeg'
+                            },
+                            {
+                            value: 630230,
+                            symbol:
+                                'image://https://fuss10.elemecdn.com/a/3f/3302e58f9a181d2509f3dc0fa68b0jpeg.jpeg'
+                            }
+                        ]
+                        }
+                    ]
+                };
+
+
+                var chart = testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Image should not be flipped when data is 0.',
+                    ],
+                    option: option
+                });
+
+            });
+
         </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When data value is 0, there was a bug that the item symbols are flipped. 

### Fixed issues

#20260

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Symbol filpped.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Symbol not flipped.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
