### PR TITLE
feat(dataZoom): change moveHandler cursor icon to move

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -686,7 +686,7 @@ class SliderZoomView extends DataZoomView {
 
         actualMoveZone.attr({
             draggable: true,
-            cursor: getCursor(this._orient),
+            cursor: 'move',
             drift: bind(this._onDragMove, this, 'all'),
             ondragstart: bind(this._showDataInfo, this, true),
             ondragend: bind(this._onDragEnd, this),

--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -686,7 +686,7 @@ class SliderZoomView extends DataZoomView {
 
         actualMoveZone.attr({
             draggable: true,
-            cursor: 'move',
+            cursor: 'default',
             drift: bind(this._onDragMove, this, 'all'),
             ondragstart: bind(this._showDataInfo, this, true),
             ondragend: bind(this._onDragEnd, this),


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Change cursor icon to more intuitive 'move', for dataZoom slider moveHandle


### Fixed issues

- #20303

## Details

### Before: What was the problem?

The Move/Drag icon is not intuitive, and it makes it difficult to know whether you're busy resizing or dragging, when the mouse is nearby the edge.

| Original Move/Drag icon | New Move/Drag icon | 
|--------|-------|
|  ![bad_move](https://github.com/user-attachments/assets/2f20f190-a06a-4aac-953a-46eed6391fa9)  | ![suggested_move](https://github.com/user-attachments/assets/22796011-df87-4a8b-ba5c-fad830354116)  |


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
