### PR TITLE
fix(sample): fix minmax sampling behaviour

### DIFF
--- a/src/data/DataStore.ts
+++ b/src/data/DataStore.ts
@@ -1035,13 +1035,18 @@ class DataStore {
 
         let offset = 0;
         for (let i = 0; i < len; i += frameSize) {
-            let minIndex = this.getRawIndex(i);
-            let minValue = dimStore[minIndex];
-            let maxIndex = this.getRawIndex(i);
-            let maxValue = dimStore[maxIndex];
+            let minIndex = i;
+            let minValue = dimStore[this.getRawIndex(minIndex)];
+            let maxIndex = i;
+            let maxValue = dimStore[this.getRawIndex(maxIndex)];
 
+            let thisFrameSize = frameSize;
+            // Handle final smaller frame
+            if (i + frameSize > len) {
+                thisFrameSize = len - i;
+            }
             // Determine min and max within the current frame
-            for (let k = 0; k < frameSize; k++) {
+            for (let k = 0; k < thisFrameSize; k++) {
                 const rawIndex = this.getRawIndex(i + k);
                 const value = dimStore[rawIndex];
 

--- a/src/data/DataStore.ts
+++ b/src/data/DataStore.ts
@@ -1013,6 +1013,70 @@ class DataStore {
         return target;
     }
 
+    /**
+     * Large data down sampling using min-max
+     * @param {string} valueDimension
+     * @param {number} rate
+     */
+    minmaxDownSample(
+        valueDimension: DimensionIndex,
+        rate: number
+    ): DataStore {
+        const target = this.clone([valueDimension], true);
+        const targetStorage = target._chunks;
+
+        const frameSize = Math.floor(1 / rate);
+
+        const dimStore = targetStorage[valueDimension];
+        const len = this.count();
+
+        // Each frame results in 2 data points, one for min and one for max
+        const newIndices = new (getIndicesCtor(this._rawCount))(Math.ceil(len / frameSize) * 2);
+
+        let offset = 0;
+        for (let i = 0; i < len; i += frameSize) {
+            let minIndex = this.getRawIndex(i);
+            let minValue = dimStore[minIndex];
+            let maxIndex = this.getRawIndex(i);
+            let maxValue = dimStore[maxIndex];
+
+            // Determine min and max within the current frame
+            for (let k = 0; k < frameSize; k++) {
+                const rawIndex = this.getRawIndex(i + k);
+                const value = dimStore[rawIndex];
+
+                if (value < minValue) {
+                    minValue = value;
+                    minIndex = i + k;
+                }
+                if (value > maxValue) {
+                    maxValue = value;
+                    maxIndex = i + k;
+                }
+            }
+
+            const rawMinIndex = this.getRawIndex(minIndex);
+            const rawMaxIndex = this.getRawIndex(maxIndex);
+
+            // Set the order of the min and max values, based on their ordering in the frame
+            if (minIndex < maxIndex) {
+                newIndices[offset++] = rawMinIndex;
+                newIndices[offset++] = rawMaxIndex;
+            }
+            else {
+                newIndices[offset++] = rawMaxIndex;
+                newIndices[offset++] = rawMinIndex;
+            }
+        }
+
+        target._count = offset;
+        target._indices = newIndices;
+
+        target._updateGetRawIdx();
+
+        return target;
+    }
+
 
     /**
      * Large data down sampling on given dimension

--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -254,10 +254,10 @@ class SeriesData<
 
     // Methods that create a new list based on this list should be listed here.
     // Notice that those method should `RETURN` the new list.
-    TRANSFERABLE_METHODS = ['cloneShallow', 'downSample', 'lttbDownSample', 'map'] as const;
+    TRANSFERABLE_METHODS = ['cloneShallow', 'downSample', 'minmaxDownSample', 'lttbDownSample', 'map'] as const;
     // Methods that change indices of this list should be listed here.
     CHANGABLE_METHODS = ['filterSelf', 'selectRange'] as const;
-    DOWNSAMPLE_METHODS = ['downSample', 'lttbDownSample'] as const;
+    DOWNSAMPLE_METHODS = ['downSample', 'minmaxDownSample', 'lttbDownSample'] as const;
 
     /**
      * @param dimensionsInput.dimensions
@@ -1094,6 +1094,23 @@ class SeriesData<
             rate,
             sampleValue,
             sampleIndex
+        );
+        return list as SeriesData<HostModel>;
+    }
+
+    /**
+     * Large data down sampling using min-max
+     * @param {string} valueDimension
+     * @param {number} rate
+     */
+    minmaxDownSample(
+        valueDimension: DimensionLoose,
+        rate: number
+    ): SeriesData<HostModel> {
+        const list = cloneListForMapAndSample(this);
+        list._store = this._store.minmaxDownSample(
+            this._getStoreDimIndex(valueDimension),
+            rate
         );
         return list as SeriesData<HostModel>;
     }

--- a/src/processor/dataSample.ts
+++ b/src/processor/dataSample.ts
@@ -61,22 +61,6 @@ const samplers: Dictionary<Sampler> = {
         // NaN will cause illegal axis extent.
         return isFinite(min) ? min : NaN;
     },
-    minmax: function (frame) {
-        let turningPointAbsoluteValue = -Infinity;
-        let turningPointOriginalValue = -Infinity;
-
-        for (let i = 0; i < frame.length; i++) {
-            const originalValue = frame[i];
-            const absoluteValue = Math.abs(originalValue);
-
-            if (absoluteValue > turningPointAbsoluteValue) {
-                turningPointAbsoluteValue = absoluteValue;
-                turningPointOriginalValue = originalValue;
-            }
-        }
-
-        return isFinite(turningPointOriginalValue) ? turningPointOriginalValue : NaN;
-    },
     // TODO
     // Median
     nearest: function (frame) {
@@ -114,6 +98,9 @@ export default function dataSample(seriesType: string): StageHandler {
                 if (isFinite(rate) && rate > 1) {
                     if (sampling === 'lttb') {
                         seriesModel.setData(data.lttbDownSample(data.mapDimension(valueAxis.dim), 1 / rate));
+                    }
+                    else if (sampling === 'minmax') {
+                        seriesModel.setData(data.minmaxDownSample(data.mapDimension(valueAxis.dim), 1 / rate));
                     }
                     let sampler;
                     if (isString(sampling)) {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

This fixes the minmax sampling behaviour to follow the standard as described [here](https://www.ni.com/docs/en-US/bundle/labview/page/memory-management-for-large-data-sets.html#d87745e217).


### Fixed issues

No open issue, but the problem was discussed in the original PR for this feature: https://github.com/apache/echarts/pull/19279#issuecomment-2131424868

## Details

### Before: What was the problem?

I generated some fake data, 16000 data points for each graph (green random walk, yellow sine wave, and blue pseudo-random).
I added two artificial "spikes" for each graph: a downward spike at index 7000, and an upward spike at index 9000.

| No downsampling | Original minmax downsampling implementation |
|----------|-----------|
| ![NoDownsampling_16kpoints_across_1604pixels](https://github.com/user-attachments/assets/d9da9cf2-525b-4cb6-8282-a890318e337f) | ![OriginalMinMaxDownsampling](https://github.com/user-attachments/assets/a2dc46f8-d776-42ca-84d6-507876fd8e70) |

The original minmax implementation appears to act just like the "max" downsampling method for data points that are above y=0, and thereby it misses out on any downward spikes. 

### After: How does it behave after the fixing?

| No downsampling | New minmax downsampling implementation (2pts per px) |
|----------|-----------|
| ![NoDownsampling_16kpoints_across_1604pixels](https://github.com/user-attachments/assets/d9da9cf2-525b-4cb6-8282-a890318e337f) | ![NewMinMaxDownsampling_2points_per_pixel](https://github.com/user-attachments/assets/605d7dff-fd82-426a-b345-02602129f29c) |

The new implementation more closely follows the actual trend, and ensures that it captures all up and down spikes.

Brief example of the minmax downsampling method, as described [here](https://www.ni.com/docs/en-US/bundle/labview/page/memory-management-for-large-data-sets.html#d87745e217):

1. Example data: [4, 1, 7, 8, 3, 6, 5, 9, 2, 7, 8, 1]
2. Frame size of 3: [(4, 1, 7), (8, 3, 6), (5, 9, 2), (7, 8, 1)]
3. Identify the min and max within each frame: [(4, <ins>1</ins>, <ins>7</ins>), (<ins>8</ins>, <ins>3</ins>, 6), (5, <ins>9</ins>, <ins>2</ins>), (7, <ins>8</ins>, <ins>1</ins>)]
4. Keep the order of the min and max within each group, and those become the resulting downsampled set: [1, 7, 8, 3, 9, 2, 8, 1]

<ins>Discussion Point A</ins>: the link above suggests using two frames for each pixel, whereby each frame results in two data points, for a total density of 4 data points per pixel. Personally I think this is a bit overkill, as it results in less performance for minimal graph quality increase.
The current implementation in this PR has 2 data points per pixel, however this could be halved to 1 data point if you agree. The benefit of 1 data point per pixel is that the graph is more likely to allow graph animations, whereas the higher density may be above the threshold for animations still to play.
See comparison below:

| No downsampling | New minmax downsampling implementation (2pts per px) |
|----------|-----------|
| ![NoDownsampling_16kpoints_across_1604pixels](https://github.com/user-attachments/assets/d9da9cf2-525b-4cb6-8282-a890318e337f) | ![NewMinMaxDownsampling_2points_per_pixel](https://github.com/user-attachments/assets/605d7dff-fd82-426a-b345-02602129f29c) |

| As suggested by link (4pts per px) | Doubled rate for 1pt per px |
|-------|--------|
| ![NewMinMaxDownsampling_4points_per_pixel](https://github.com/user-attachments/assets/bcd264ba-5046-4128-ad30-ba05325b6bb9) | ![NewMinMaxDownsampling_1point_per_pixel](https://github.com/user-attachments/assets/b2e60af6-4910-434e-b2ef-1f715b778f23) |

I suggest opening the images in fullscreen for a better comparison.

<ins>Discussion Point B</ins>: Regarding the code, I referenced the lttb method for implementing this minmax method in a similar way (i.e. having a separate function for downsampling), since the regular downsampling method would not work due to the minmax method requiring the ability to output two samples per frame. It may be needed to add an extra condition to the downsample method selection logic, to check if the rate is high enough (>2) to warrant downsampling, since this method isn't as efficient as the others. However, this will depend on the decision for Discussion Point A above.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Other information
