### PR TITLE
fix(boxplot) correctly handle series.encode with category axis

### DIFF
--- a/src/chart/helper/whiskerBoxCommon.ts
+++ b/src/chart/helper/whiskerBoxCommon.ts
@@ -58,7 +58,7 @@ class WhiskerBoxCommonMixin<Opts extends CommonOption> {
     _hasEncodeRule(key: string) {
         const encodeRules = this.getEncode();
         if (encodeRules && encodeRules.data && encodeRules.data.has(key)) {
-            return encodeRules.data.get(key) !== null;
+            return encodeRules.data.get(key) != null;
         }
         return false;
     }

--- a/src/chart/helper/whiskerBoxCommon.ts
+++ b/src/chart/helper/whiskerBoxCommon.ts
@@ -53,6 +53,17 @@ class WhiskerBoxCommonMixin<Opts extends CommonOption> {
     defaultValueDimensions: CoordDimensionDefinition['dimsDef'];
 
     /**
+     * @private
+     */
+    _hasEncodeRule(key: string) {
+        const encodeRules = this.getEncode();
+        if (encodeRules && encodeRules.data && encodeRules.data.has(key)) {
+            return encodeRules.data.get(key) !== null;
+        }
+        return false;
+    }
+
+    /**
      * @override
      */
     getInitialData(option: Opts, ecModel: GlobalModel): SeriesData {
@@ -74,12 +85,12 @@ class WhiskerBoxCommonMixin<Opts extends CommonOption> {
         if (xAxisType === 'category') {
             option.layout = 'horizontal';
             ordinalMeta = xAxisModel.getOrdinalMeta();
-            addOrdinal = true;
+            addOrdinal = !this._hasEncodeRule('x');
         }
         else if (yAxisType === 'category') {
             option.layout = 'vertical';
             ordinalMeta = yAxisModel.getOrdinalMeta();
-            addOrdinal = true;
+            addOrdinal = !this._hasEncodeRule('y');
         }
         else {
             option.layout = option.layout || 'horizontal';

--- a/test/boxplot-category.html
+++ b/test/boxplot-category.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <!-- <script src="ut/lib/canteen.js"></script> -->
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+<style>
+</style>
+
+
+
+<div id="main0"></div>
+
+
+
+
+
+
+<script>
+    require([
+        'echarts',
+    ], function (echarts) {
+        let layout = 'horizontal';
+        var categoryAxis = {
+            type: 'category',
+            boundaryGap: true,
+            nameGap: 30,
+            splitArea: {
+                show: false
+            },
+            splitLine: {
+                show: false
+            }
+        };
+        var valueAxis = {
+            type: 'value',
+            splitArea: {
+                show: true
+            }
+        };
+
+        function getOption(layout) {
+            return {
+                aria: {
+                    show: true
+                },
+                legend: {
+                    left: 'right'
+                },
+                tooltip: {
+                    trigger: 'item',
+                    axisPointer: {
+                        type: 'shadow'
+                    }
+                },
+                grid: {
+                    left: '10%',
+                    right: '10%',
+                    bottom: '15%'
+                },
+                xAxis: layout === 'horizontal' ? categoryAxis : valueAxis,
+                yAxis: layout === 'vertical' ? categoryAxis : valueAxis,
+                series: [
+                    {
+                        name: 'boxplot',
+                        type: 'boxplot',
+                        encode: layout === 'horizontal' ? {x: [5], y: [0, 1, 2, 3, 4]} : {y: [5], x: [0, 1, 2, 3, 4]},
+                        data: [
+                            [10, 20, 30, 40, 50, 'one'],
+                            [33, 38, 39, 40, 55, 'four'],
+                            [40, 45, 50, 52, 66, 'three']
+                        ]
+                    },
+                    {
+                        name: 'boxplot no encode',
+                        type: 'boxplot',
+                        data: [
+                            [10, 20, 30, 40, 50],
+                            [33, 38, 39, 40, 55],
+                            [40, 45, 50, 52, 66]
+                        ]
+                    },
+                ]
+            }
+        }
+
+        var chart = testHelper.create(echarts, 'main0', {
+            title: [
+                'Test Case - Boxplot Category axis values',
+                'Check that encoded values are used instead of ordinal values if they exist.',
+                'Use "Swap Axis" button below to test horizontal and vertical boxplots',
+                'Series "boxplot no encode" should show 0,1,2 on category axis while "boxplot" series should show "one","two","three" on category axis'
+            ],
+            option: getOption(layout),
+            button: {
+                name:'Swap Axis',
+                onClick:()=>{
+                    layout = layout === 'horizontal' ? 'vertical' : 'horizontal';
+                    chart.setOption(getOption(layout));
+                }
+            }
+        });
+    });
+</script>
+
+
+</body>
+</html>
+


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes issue with series.encode for boxplot when category axis is used.



### Fixed issues
#20319 


## Details

### Before: What was the problem?

When a category axis is used for a boxplot series, an ordinalValue is always inserted to the series.data which breaks any encoding rules. if the category axis does not set it's own data then the axis labels will be the integer ordinalValue.



### After: How does it behave after the fixing?

Now if an encode rule is applied for the associated axis (x/y) then the ordinalValue is not inserted and the encoding rules work as expected.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/boxplot-category.html added to show visual example.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
