### PR TITLE
Fix 20363

### DIFF
--- a/src/coord/polar/Polar.ts
+++ b/src/coord/polar/Polar.ts
@@ -214,7 +214,7 @@ class Polar implements CoordinateSystem, CoordinateSystemMaster {
         const angleExtent = angleAxis.getExtent();
 
         const RADIAN = Math.PI / 180;
-
+        const EPSILON = 1e-4;
         return {
             cx: this.cx,
             cy: this.cy,
@@ -233,7 +233,8 @@ class Polar implements CoordinateSystem, CoordinateSystemMaster {
                 const r0 = this.r0;
 
                 // minus a tiny value 1e-4 in double side to avoid being clipped unexpectedly
-                return (d2 - 1e-4) <= r * r && (d2 + 1e-4) >= r0 * r0;
+                // r == r0 contain nothing
+                return r !== r0 && (d2 - EPSILON) <= r * r && (d2 + EPSILON) >= r0 * r0;
             }
         };
     }

--- a/src/coord/polar/Polar.ts
+++ b/src/coord/polar/Polar.ts
@@ -228,12 +228,12 @@ class Polar implements CoordinateSystem, CoordinateSystemMaster {
                 // Start angle and end angle don't matter
                 const dx = x - this.cx;
                 const dy = y - this.cy;
-                // minus a tiny value 1e-4 to avoid being clipped unexpectedly
-                const d2 = dx * dx + dy * dy - 1e-4;
+                const d2 = dx * dx + dy * dy;
                 const r = this.r;
                 const r0 = this.r0;
 
-                return d2 <= r * r && d2 >= r0 * r0;
+                // minus a tiny value 1e-4 in double side to avoid being clipped unexpectedly
+                return (d2 - 1e-4) <= r * r && (d2 + 1e-4) >= r0 * r0;
             }
         };
     }

--- a/test/clip.html
+++ b/test/clip.html
@@ -1434,5 +1434,44 @@ under the License.
                 });
             });
         </script>
+
+        <div class="chart" id="polar-clip"></div>
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    polar: {
+                        center: ['50%', '54%']
+                    },
+                    angleAxis: {
+                        type: 'category',
+                        data: ['a', 'b', 'c'],
+                        boundaryGap: false,
+                    },
+                    radiusAxis: {
+                        min: 0
+                    },
+                    series: [{
+                        coordinateSystem: 'polar',
+                        symbolSize: 20,
+                        name: 'line',
+                        type: 'scatter',
+                        showSymbol: true,
+                        data: [
+                            [0, 0],
+                            [10, 2]
+                        ]
+                    }]
+                };
+                var chart = testHelper.create(echarts, 'polar-clip', {
+                    title: [
+                        'The polar coord clip should include center point in scatter'
+                    ],
+                    option: option,
+                    height: 400
+                });
+            });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

#20363 


## Details

### Before: What was the problem?

The maximum value symbol in polar coordinate system scatter chart of radiusAxis is not displayed



### After: How does it behave after the fixing?

Display the symbol

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
