### PR TITLE
fix(sankey): avoid throwing errors when the `links` / `nodes` / `levels` option is undefined

### DIFF
--- a/src/chart/sankey/SankeySeries.ts
+++ b/src/chart/sankey/SankeySeries.ts
@@ -158,7 +158,7 @@ class SankeySeriesModel extends SeriesModel<SankeySeriesOption> {
     getInitialData(option: SankeySeriesOption, ecModel: GlobalModel) {
         const links = option.edges || option.links || [];
         const nodes = option.data || option.nodes || [];
-        const levels = option.levels;
+        const levels = option.levels || [];
         this.levelModels = [];
         const levelModels = this.levelModels;
 
@@ -172,10 +172,10 @@ class SankeySeriesModel extends SeriesModel<SankeySeriesOption> {
                 }
             }
         }
-        if (nodes && links) {
-            const graph = createGraphFromNodeEdge(nodes, links, this, true, beforeLink);
-            return graph.data;
-        }
+
+        const graph = createGraphFromNodeEdge(nodes, links, this, true, beforeLink);
+        return graph.data;
+
         function beforeLink(nodeData: SeriesData, edgeData: SeriesData) {
             nodeData.wrapMethod('getItemModel', function (model: Model, idx: number) {
                 const seriesModel = model.parentModel as SankeySeriesModel;

--- a/src/chart/sankey/SankeySeries.ts
+++ b/src/chart/sankey/SankeySeries.ts
@@ -156,8 +156,8 @@ class SankeySeriesModel extends SeriesModel<SankeySeriesOption> {
      * Init a graph data structure from data in option series
      */
     getInitialData(option: SankeySeriesOption, ecModel: GlobalModel) {
-        const links = option.edges || option.links;
-        const nodes = option.data || option.nodes;
+        const links = option.edges || option.links || [];
+        const nodes = option.data || option.nodes || [];
         const levels = option.levels;
         this.levelModels = [];
         const levelModels = this.levelModels;

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -38,6 +38,7 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
 
 
 
@@ -168,7 +169,7 @@ under the License.
                     title: 'emphasis trajectory',
                     option: option
                 });
-            
+
                 if (chart) {
                     window.onresize = function () {
                         chart.resize();
@@ -176,6 +177,32 @@ under the License.
                     chart.on('click', function (params) {
                        console.log(params, params.data);
                     });
+                }
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+
+                var option = {
+                    series: [{
+                        type: 'sankey',
+                        layout: 'none',
+                        data: undefined,
+                        links: undefined
+                    }]
+                }
+
+                var chart = testHelper.create(echarts, 'main3', {
+                    title: 'The sankey chart should be rendered without any error in console when `**nodes**` or `**links**` is set as `**undefined**`',
+                    option: option
+                });
+                if (chart) {
+                    window.onresize = function () {
+                        chart.resize();
+                    };
                 }
             });
         </script>

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -80,9 +80,8 @@ under the License.
                 });
 
                 if (chart) {
-                    window.onresize = function () {
-                        chart.resize();
-                    };
+                    window.addEventListener('resize', chart.resize);
+
                     chart.on('click', function (params) {
                         console.log(params, params.data);
                     });
@@ -132,9 +131,8 @@ under the License.
 
 
                 if (chart) {
-                    window.onresize = function () {
-                        chart.resize();
-                    };
+                    window.addEventListener('resize', chart.resize);
+
                     chart.on('click', function (params) {
                         console.log(params, params.data);
                     });
@@ -171,9 +169,8 @@ under the License.
                 });
 
                 if (chart) {
-                    window.onresize = function () {
-                        chart.resize();
-                    };
+                    window.addEventListener('resize', chart.resize);
+
                     chart.on('click', function (params) {
                        console.log(params, params.data);
                     });
@@ -191,7 +188,8 @@ under the License.
                         type: 'sankey',
                         layout: 'none',
                         data: undefined,
-                        links: undefined
+                        links: undefined,
+                        levels: undefined
                     }]
                 }
 
@@ -200,9 +198,7 @@ under the License.
                     option: option
                 });
                 if (chart) {
-                    window.onresize = function () {
-                        chart.resize();
-                    };
+                    window.addEventListener('resize', chart.resize);
                 }
             });
         </script>

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -182,8 +182,16 @@ under the License.
             require([
                 'echarts',
             ], function (echarts) {
-
+                var title = 'The sankey chart should be rendered without any error in console when `**nodes**` or `**links**` is set as `**undefined**`';
                 var option = {
+                    title: {
+                        text: title,
+                        top: 'center',
+                        left: 'center',
+                        textStyle: {
+                            overflow: 'break'
+                        }
+                    },
                     series: [{
                         type: 'sankey',
                         layout: 'none',
@@ -194,12 +202,21 @@ under the License.
                 }
 
                 var chart = testHelper.create(echarts, 'main3', {
-                    title: 'The sankey chart should be rendered without any error in console when `**nodes**` or `**links**` is set as `**undefined**`',
-                    option: option
+                    title,
+                    option
                 });
-                if (chart) {
-                    window.addEventListener('resize', chart.resize);
-                }
+                var resizeChart = function () {
+                    chart.resize();
+                    chart.setOption({
+                        title: {
+                            textStyle: {
+                                width: chart.getWidth() * 0.8
+                            }
+                        }
+                    });
+                };
+                resizeChart();
+                window.addEventListener('resize', resizeChart);
             });
         </script>
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

#20336


## Details

### Before: What was the problem?

getInitialData function may return uncatched undefined

### After: How does it behave after the fixing?

Catch undefined data like the other graph chart

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
