### PR TITLE
feat(custom): support compoundPath in custom series renderItem

### DIFF
--- a/src/animation/customGraphicTransition.ts
+++ b/src/animation/customGraphicTransition.ts
@@ -149,8 +149,25 @@ export function applyUpdateTransition(
     const propsToSet = {} as ElementProps;
 
     prepareTransformAllPropsFinal(el, elOption, propsToSet);
-    prepareShapeOrExtraAllPropsFinal('shape', elOption, propsToSet);
-    prepareShapeOrExtraAllPropsFinal('extra', elOption, propsToSet);
+
+    if (el.type === 'compound') {
+        /**
+         * We cannot directly clone shape for compoundPath,
+         * because it makes the path to be an object instead of a Path instance,
+         * and thus missing `buildPath` method.
+         */
+        const paths: Path[] = (el as Path).shape.paths;
+        const optionPaths = elOption.shape.paths as TransitionElementOption['shape']['paths'];
+        for (let i = 0; i < optionPaths.length; i++) {
+            const path = optionPaths[i];
+            prepareShapeOrExtraAllPropsFinal('shape', path, paths[i]);
+            prepareShapeOrExtraAllPropsFinal('extra', path, paths[i]);
+        }
+    }
+    else {
+        prepareShapeOrExtraAllPropsFinal('shape', elOption, propsToSet);
+        prepareShapeOrExtraAllPropsFinal('extra', elOption, propsToSet);
+    }
 
     if (!isInit && hasAnimation) {
         prepareTransformTransitionFrom(el, elOption, transFromProps);

--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -234,9 +234,24 @@ export interface CustomTextOption extends CustomDisplayableOption, TransitionOpt
     keyframeAnimation?: ElementKeyframeAnimationOption<TextProps> | ElementKeyframeAnimationOption<TextProps>[]
 }
 
+export interface CustomompoundPathOptionOnState extends CustomDisplayableOptionOnState {
+    style?: PathStyleProps;
+}
+export interface CustomCompoundPathOption extends CustomDisplayableOption, TransitionOptionMixin<PathProps> {
+    type: 'compoundPath';
+    shape?: PathProps['shape'];
+    style?: PathStyleProps & TransitionOptionMixin<PathStyleProps>;
+    emphasis?: CustomompoundPathOptionOnState;
+    blur?: CustomompoundPathOptionOnState;
+    select?: CustomompoundPathOptionOnState;
+
+    keyframeAnimation?: ElementKeyframeAnimationOption<PathProps> | ElementKeyframeAnimationOption<PathProps>[]
+}
+
 export type CustomElementOption = CustomPathOption
     | CustomImageOption
     | CustomTextOption
+    | CustomCompoundPathOption
     | CustomGroupOption;
 
 // Can only set focus, blur on the root element.

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -365,7 +365,7 @@ function createEl(elOption: CustomElementOption): Element {
         }
         const paths = map(shape.paths as Path[], function (path) {
             if (path.type === 'path') {
-                return createEl(path as unknown as CustomPathOption);
+                return graphicUtil.makePath(path.shape.pathData, path, null);
             }
             const Clz = graphicUtil.getShapeClass(path.type);
             if (!Clz) {

--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -364,8 +364,14 @@ function createEl(elOption: CustomElementOption): Element {
             throwError(errMsg);
         }
         const paths = map(shape.paths as Path[], function (path) {
+            if (path.type === 'path') {
+                return createEl(path as unknown as CustomPathOption);
+            }
             const Clz = graphicUtil.getShapeClass(path.type);
             if (!Clz) {
+                if (typeof path.buildPath === 'function') {
+                    return path;
+                }
                 let errMsg = '';
                 if (__DEV__) {
                     errMsg = 'graphic type "' + graphicType + '" can not be found.';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This PR supports compoundPath in custom series renderItem. It can be used as:

```js
renderItem(params, api) {
    return {
        type: 'compoundPath',
        shape: {
            paths: [rect, circle, ...]
        }
    }
}
```

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`compondPath` is not supported so that we cannot make complex objects that looks like the union of shapes. If such shapes have opacity and intersection, it's hard to implement without a compoundPath.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`compondPath` is supported.

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [x] This PR depends on ZRender changes (ecomfe/zrender#1096).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
