### PR TITLE
fix(tooltip): fix potential NPE when setting option with `notMerge` strategy

### DIFF
--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -461,7 +461,7 @@ class TooltipHTMLContent {
 
     getSize() {
         const el = this.el;
-        return [el?.offsetWidth, el?.offsetHeight];
+        return el ? [el.offsetWidth, el.offsetHeight] : [0, 0];
     }
 
     moveTo(zrX: number, zrY: number) {
@@ -469,7 +469,7 @@ class TooltipHTMLContent {
         makeStyleCoord(styleCoord, this._zr, this._container, zrX, zrY);
 
         if (styleCoord[0] != null && styleCoord[1] != null) {
-            const style: any = this.el?.style || {};
+            const style: any = this.el ? (this.el.style || {}) : {}
             const transforms = assembleTransform(styleCoord[0], styleCoord[1]) as string[][];
             each(transforms, (transform) => {
               style[transform[0] as any] = transform[1];

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -465,11 +465,14 @@ class TooltipHTMLContent {
     }
 
     moveTo(zrX: number, zrY: number) {
+        if (!this.el) {
+            return;
+        }
         const styleCoord = this._styleCoord;
         makeStyleCoord(styleCoord, this._zr, this._container, zrX, zrY);
 
         if (styleCoord[0] != null && styleCoord[1] != null) {
-            const style: any = this.el ? (this.el.style || {}) : {};
+            const style = this.el.style;
             const transforms = assembleTransform(styleCoord[0], styleCoord[1]) as string[][];
             each(transforms, (transform) => {
               style[transform[0] as any] = transform[1];

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -469,7 +469,7 @@ class TooltipHTMLContent {
         makeStyleCoord(styleCoord, this._zr, this._container, zrX, zrY);
 
         if (styleCoord[0] != null && styleCoord[1] != null) {
-            const style: any = this.el ? (this.el.style || {}) : {}
+            const style: any = this.el ? (this.el.style || {}) : {};
             const transforms = assembleTransform(styleCoord[0], styleCoord[1]) as string[][];
             each(transforms, (transform) => {
               style[transform[0] as any] = transform[1];

--- a/src/component/tooltip/TooltipHTMLContent.ts
+++ b/src/component/tooltip/TooltipHTMLContent.ts
@@ -461,7 +461,7 @@ class TooltipHTMLContent {
 
     getSize() {
         const el = this.el;
-        return [el.offsetWidth, el.offsetHeight];
+        return [el?.offsetWidth, el?.offsetHeight];
     }
 
     moveTo(zrX: number, zrY: number) {
@@ -469,7 +469,7 @@ class TooltipHTMLContent {
         makeStyleCoord(styleCoord, this._zr, this._container, zrX, zrY);
 
         if (styleCoord[0] != null && styleCoord[1] != null) {
-            const style = this.el.style;
+            const style: any = this.el?.style || {};
             const transforms = assembleTransform(styleCoord[0], styleCoord[1]) as string[][];
             each(transforms, (transform) => {
               style[transform[0] as any] = transform[1];


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

- Fix #20335 
- Optional chaining for tooltip `offsetWidth` and `offsetHeight`

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
