### PR TITLE
feat(label): enforce labelLayout for all state

### DIFF
--- a/src/label/LabelManager.ts
+++ b/src/label/LabelManager.ts
@@ -18,6 +18,7 @@
 */
 
 // TODO: move labels out of viewport.
+import { DISPLAY_STATES } from '../util/states';
 
 import {
     Text as ZRText,
@@ -359,23 +360,19 @@ class LabelManager {
             let needsUpdateLabelLine = false;
             if (layoutOption.x != null) {
                 // TODO width of chart view.
-                label.x = parsePercent(layoutOption.x, width);
                 label.setStyle('x', 0);  // Ignore movement in style. TODO: origin.
                 needsUpdateLabelLine = true;
             }
             else {
-                label.x = defaultLabelAttr.x;
                 label.setStyle('x', defaultLabelAttr.style.x);
             }
 
             if (layoutOption.y != null) {
                 // TODO height of chart view.
-                label.y = parsePercent(layoutOption.y, height);
                 label.setStyle('y', 0);  // Ignore movement in style.
                 needsUpdateLabelLine = true;
             }
             else {
-                label.y = defaultLabelAttr.y;
                 label.setStyle('y', defaultLabelAttr.style.y);
             }
 
@@ -390,36 +387,53 @@ class LabelManager {
 
             const labelLayoutStore = labelLayoutInnerStore(label);
             labelLayoutStore.needsUpdateLabelLine = needsUpdateLabelLine;
-
-            label.rotation = layoutOption.rotate != null
-                ? layoutOption.rotate * degreeToRadian : defaultLabelAttr.rotation;
-
-            label.scaleX = defaultLabelAttr.scaleX;
-            label.scaleY = defaultLabelAttr.scaleY;
-
-            for (let k = 0; k < LABEL_OPTION_TO_STYLE_KEYS.length; k++) {
-                const key = LABEL_OPTION_TO_STYLE_KEYS[k];
-                label.setStyle(key, layoutOption[key] != null ? layoutOption[key] : defaultLabelAttr.style[key]);
-            }
-
-
-            if (layoutOption.draggable) {
-                label.draggable = true;
-                label.cursor = 'move';
-                if (hostEl) {
-                    let hostModel: Model<LabelLineOptionMixin> =
-                        labelItem.seriesModel as SeriesModel<LabelLineOptionMixin>;
-                    if (labelItem.dataIndex != null) {
-                        const data = labelItem.seriesModel.getData(labelItem.dataType);
-                        hostModel = data.getItemModel<LabelLineOptionMixin>(labelItem.dataIndex);
-                    }
-                    label.on('drag', createDragHandler(hostEl, hostModel.getModel('labelLine')));
+            for (const state of DISPLAY_STATES) {
+                const labelState = state === 'normal' ? label : label.ensureState(state);
+                if (layoutOption.x != null) {
+                    labelState.x = parsePercent(layoutOption.x, width);
                 }
-            }
-            else {
-                // TODO Other drag functions?
-                label.off('drag');
-                label.cursor = defaultLabelAttr.cursor;
+                else {
+                    labelState.x = defaultLabelAttr.x;
+                }
+
+                if (layoutOption.y != null) {
+                    labelState.y = parsePercent(layoutOption.y, height);
+                }
+                else {
+                    labelState.y = defaultLabelAttr.y;
+                }
+
+
+                labelState.rotation = layoutOption.rotate != null
+                    ? layoutOption.rotate * degreeToRadian : defaultLabelAttr.rotation;
+
+                labelState.scaleX = defaultLabelAttr.scaleX;
+                labelState.scaleY = defaultLabelAttr.scaleY;
+
+                for (let k = 0; k < LABEL_OPTION_TO_STYLE_KEYS.length; k++) {
+                    const key = LABEL_OPTION_TO_STYLE_KEYS[k];
+                    label.setStyle(key, layoutOption[key] != null ? layoutOption[key] : defaultLabelAttr.style[key]);
+                }
+
+
+                if (layoutOption.draggable) {
+                    label.draggable = true;
+                    label.cursor = 'move';
+                    if (hostEl) {
+                        let hostModel: Model<LabelLineOptionMixin> =
+                            labelItem.seriesModel as SeriesModel<LabelLineOptionMixin>;
+                        if (labelItem.dataIndex != null) {
+                            const data = labelItem.seriesModel.getData(labelItem.dataType);
+                            hostModel = data.getItemModel<LabelLineOptionMixin>(labelItem.dataIndex);
+                        }
+                        label.on('drag', createDragHandler(hostEl, hostModel.getModel('labelLine')));
+                    }
+                }
+                else {
+                    // TODO Other drag functions?
+                    label.off('drag');
+                    label.cursor = defaultLabelAttr.cursor;
+                }
             }
         }
     }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Make sure [`labelLayout`](https://echarts.apache.org/zh/option.html#series-sunburst.labelLayout) is enforced to all four state of label.



### Fixed issues

`labelLayout` option ignored in blur state for sunburst chart.

[Example](https://echarts.apache.org/examples/zh/editor.html?c=sunburst-drink&lang=ts&code=G4QwTgBAJiAuIQLwQNoCgIQN4cxAdiALYCmAXBAOQBiANgPZgiUA0umAlrCUQMqwBPWuWzs8AY3oMwFSgGIYABigA2AByUxAXzZ4I4gBYdaUMCXwV0ezDmt5CpWQCFaIcQGsIAFRLNddiFBaAFcRAEZ_Oy4efiERWwDMSWlZOQBOAHYAVhIVKE1ErTFMHWLRRIcRGmkQWlYyzm4-QWEKBMTkxlSSRQywtPECgNKOoxMzC1QGvHbEgmIqgGEDYnoiYxJ6ubwg0IoI6b1o5ri2w-tOmSo5ADM0tJIwwfOS85G52YqF2QAlegBnTaROa7cLAxLHWKtcrbCRSLrXEg3LIgDIaF4QIrbd6JT4BSqyABSIH-63wQIxoP24ICkJa8QxSXhV3kNwyNzCACN8hisXM-XYALplAUQYUlfyzAlUahgYJcARbPB004wvSXVIwMJQABMAGYhhKxIZjKZzJYynjMNLKE4SGAwIqaY0YvSztsNdcoFAACziLJhQ3WHEXMZmyZWD4Ym0uNzuTn2x1K7ZUiAHWEQFXQq0BT3yPU9PVhDJBwpvZ0zaPfKg_EkABwTDqdlNqezTFaOTShDIzTJSiJUOrSKjSpeG5fOOb0MZCJEbSY7O1bYIxWZ7vbzchUWRHnMUY7sosPi6n9mrlH4TAA7vPmxnU-nYWv3Rvmd0bjqoHqVAfg29puKwY0jmNoACJgBwJBQBAsryrAybWM-aq5m-1ziGkPogD6Pq_iG6phhMFrbKe1rnrWHD_Bw-AIYkD6Li6JzZoy-iofInJZHq7E4byE7EVWjhUAACnK5I0QEdGrl2brIR6rFyCAWTYSoNy_noR5_okgFqcB0w2gA8rABj2jBcpcGJDHdi-HRyd6foBrhFYmuM5pTHxGY2os9CSPgwTwfRgTLtSkmuqqJFwv2rI6uoPqcqpeDqdpk78UsRlNuZ1gSRmSFhX2CLyCQGR6j69k8diJ7JbIglrCQADmTCENw6V6JlT5SaFzGbrkO47nFrxlUl7nnoJVG-HWdbCE1S6zkFWVtUxvYsRFtxqGkIBPL1mK8VGg0CZQADiTB1hS96Be2wWMeuGabiAc5pDqzwZgl8XlTtVQAIJjRN_ktds2UdXJPpzmoPqjqV_IvbCNqCb4hiTZgP1zH9C2bjc6gKQ9sJPUabmQ0NvhgHDAXTWds0hfNr5LZyIAgCoepZBtWObZpIo6V8u2LFwcr_CZcHpUjcwoxka06uihSOQRLmRriFVUAdIBHTcpl-S2xOPr9c2XbCKNRXT9Ng2LA247ten1TVx2wgjEIa1ZWtySQOthJs-vDBD2w2gAMjw9DUd9p1q4j1syQLck3FAJA-oo3GPVt0uvbI7scKQhOW7Sgc5YteVyBkc5hHqouY_-zOHmIgHvFK568PQwRgAA9AAOvg1D2qQ-DcPkwL8-qducpyEcqdowJOeGRHWCBFdVwTFadyhS2POIRZ6wboymoRrnbUbVSV9XEBvWAaxwBw4j_Mnfv-dPslLQ8qJhPn2IxwEYU2m94gkLAh87-IHDtyrbb-1bZOawvpnDCqJlIM3vnYR-54nC-QEBBcQH8v4n1VmfNO_0lpQEUJyHUPp-7R36jjN254ACS_x6BBHtO_Z-SDfYoPOpZIO1klpqDnCoH0P5nbHkNkQ9mnMqGf2_idOhpMLo2yASyW4N0bi9HAQQ9ePCqgAFlaj8JoT_FcIiGHp03OILkIAZGcI0gELSz1LS6XPG9WgkgDBSHro3MwLc258zQeI1Ie5Mh6gNNMPCEgJYRm4XMG0AB1Ead4Lan3odJbRck1Acn9F4_B4MAlsyqEEow_x3AkDCSmCJmionoMzpyIqig9Sg0SUveRgTzyyh4OYJxtDf6oIAWI4OlMQB3T1DqWRSTCFVONsARMHAjrIMaZE9qyMYmcjYaU7pZYi5GMwKXSUYgbQHRIOYOxAA1Wqr8D4DIQufDOEib5Cx1Hg0x-EV6SzMSk2QelaAcAGRAPSxh0opwsvk1x1wQA6j3EOXCLMbn4jIiAK8bzcmp2aYw8Kmc-grU8QCrhkDzG7TWRshu2yzbwDfvsqeLjWmZz1NTHUWRF4u2mEPVeUsH4y0oAAVXwGHMAABaCCwyGkaNalC6JS0fk91-bM8lvTblCVGvQQR4ThFctEdCuwm5BzUz1BjO-cjY4b1kDU_4BgRmcvVtygpEiSk0w4oKpFlSRWUFAuATwaKfbqJmtKrRBrUglLUIpMpBdVU0rjlQTFuycXmxyVKvVMqeWZxFr3GKpqgLJOBbtAAEiAAQzKHmZJ1Q6kNTqJm8qJWoPU-5DGJWFXGqo8b7SchTRwNNHKM0B31dm2Fbgwg-kDIW-KAFAXIotXaEA-BskZQhVEfFTDM45FWmoAtcyFlilwGXFZ54DKpQOcOmFhrFXsSDCGSl1yu0lsqvLe0Aga6KOCP8QQzj60EokWkKA2DOQlm8eLK5_ji12BtPwWogaQSDrraG511w1CcjUOhSdnqenmr3VQRY4Bb30Bg-mkmjrPkU0KXOHUGQOHlKFRBt9Q0D0LntYhzNyGrohyREiKOYGKlqoUbIIJ9BxX9toj-_-f6G0SIyNhQs0ai04esDaRRUgoBHqtUQOsCG_6QrYyhiRIAiXfnOSq8DNG-lKNPYIGuoF1NMfEixqTWaZOpHQuxPNPGLl8enOeE9Z6j0AFFwCGR03Yd5iEV1fPkJkNQwMH1YbNSpi1b18CJxUYMGtRHf0GdI5fKAmR2RmexhZs8u1FG-EEBAJwe9HMSaadJqLmdxDiAyFM5gbaEv-cg5QQSRl8BSEPtlsZ5M8sSNvWwlQJXfPTr0CYsrlYLXLB4IfWoF7csz1hSocQihxCxUfRSvxI9yu4d2k4Lg3BJ6Eck0Oy9TXUgTpACtHkHXeMLf4xXWo56wsbdc1t22GCkRnIO1R7Dx3LPJagofKiQ2Ls5cizdxtaQqZO0O-Z57SWqjQ1gHvYQwQiD1byeMwz1wSlpBuEB-LmJXaqdkLwdwwR8DuCcwO4NEWSO_YkTkDIFPptA567u2jNZgg93tLDpD8PtvXDCDqSbk20dPW60zPASzcDl12n8Ek9SxCHJ0RhNI-bN2Dzm2vPQY9drDSOt4egVMCv0HBUTzs125VyXENTdhZLi5-d6xVrwGu3CSB16M1jP2DcYJR1AbOiKY205O0t6urdhuO4uHJBMagVC0wcrN5983vXqqoM_CCEqg325Z410nbjVrYQ9Up6jUe6eUDelqgnzU9ObZG-5uQK00jwp5xji1vAiD0Hx8z4jrOU_fOLD6TiVfY2LaqBl-gV58AsAgKLs9jfifN9LytH0agwigcz-OeZR2Lfd9kIse0vg6h4v1wHjBMBUatqz5c5yL7EukVRUwKio-Hck9L_etIigwGlfR13r3SizuX_09fq93ROQ3qyIp_khcxiIoJcs6yyL2m8dYh8JAx8HcbmRyqQIAuoucgOwO-gCu1KNgKKYOuOZsvuFYLmhyXcS0GQGE2QXS3inao8WBlUJAY0TO-BRemYcBRB-W88vo--8-HuVB3ae8_eEAvAkBL8fun-LBEinIzaUAWQPmT2oYEeiu2emOMeQWgI7-xe_uI6EihW8KmGj25unuFqAAcr5KQDVKoVdiXl_gBuIEOPdJ3q-i_ivlRA4N7GYXrhYRod0FIYOCgXPnodwdHpQIsAwLiutt9iIaNrJmEONiiDzh2mbgLqAULvOrtEYbABpg3J5JIH4BLnAddGoEVmwnLsaOgUCsvlQKkedtMIQaukZmiMHhnlwXKiUfYeATQb2r5DAaEQ1oApYfIL6IgRznYSfvMAmiAAAF4kC0A-TKxCKJ5N7J6l6_7t4JK6GNEKEBa0B16MquHKjMERFGYrQ3CmaP686UFK7UFQZeRwbCHj7b6FL3psLKprGH7DzyH6EVbLBXGuCNRfbdEtIeHXAjg6hrQNFToH7-E55WpgCeCfHJBwBfrMa64f63EAnyA-gZD36RyxEL7tpdaJGYGtFUC8BXjrIzG7Fb6dTbh5rkGL7brH7nE8F974D8HBA1TgA3ELF3HNbFQKSgmoEvFUrP6EmUCCauD_CAidGzG6pj6cmolyBFjKCKD_5gkyHvFlEinyzCD8FwLBDia_Fw6yn7HfIkBFRhDKmcHgkMkBHQZMCkAPITHx7fpIlqHhFO6Zyu5eb6hDEg6n6lrexZI7EfIolGl9HoxmnYlAF-HK5VCbK9rGCuB27SluHqE1HXBHHjqz6dZP5qkjExlxm0APJ2qIlzHmEpm5QSI3B6gYacbu6L4EkVZ6QDJMAFn8EkmvyJm1rJmunwGIjZBTK3xZk-LRlY5tmwA7x7xEAHxHwdnhZdnBnlmaiKCKR_61m4kJGvCCgADcaAaA9AdYb83sSAMIb8sAye3AAAHrAHRnpD8O7KBBAIsHpNQNQLZrZkPrZrwLZm9D8IsPGvwbZgYbwDeQAJoQDuy2YAAaxCj5BhCE_wDOF5V5RJE8L8FABgaRdY_wZANcNcV4jAJgkgNwNw6yZggI4AhgAAdIwDVLhYwO4DXICPgGQo6CmiQOeYfN7DXAhIhf7jcN7LALwBwBMfsD6DSCojVJMJQC_K3EzgPGIPBZyDxZ_uJZJdJatkUXoApYWe4LIOhbAJhdhbRWAARfQERSRdAfjJRdRUZfRYxcxcmsIOxd5FxfiRAICBBNATbIIEdLIPBfgJyNXCPmwGIDAPABQKFSAMCEwFABwKepYIoIPpQGkFkAAKSUCCjAjMVIW45hw3AjRQDBV6A8B1grCURYVBw4UQB8XiBxVUC9ovxnqMCsDQAUQgCcjCBQAUAQ6hByViDCADK0DlUYHYBDnTBgCKCyBhCpXpQsh0xpWb7uF4CciMBMohJQCGQUA6gzaJCuAJi0D_F4CZbwmyDwD4C4FvxDYUFRljUTVUBzUzWyAYnzXTC7WTEHWYAqWyAQQ1ToWrk07QrjWPWKDPWJAsgZA6gg0BCvX7WyoQB1gAhcAcDeyyBVywCURhyTR1iIExVnUUB6iLiUTCCtwUA3C1CAjbXImGmYDLVgCrVfwbUQB6hXXToZV9VtWTHuxJqo0UAAAUdYAAlEgAAHwQA814jnlkDTB1gUXQ0_AkDiCwAUXnkQAi1EACDLAOYUVYprWGQ82C01wQA6gQAAD8EAatGtYAit2t9NBgetEAzKaYigigEA-wTtNIdeAyjZ9orgdYvlRgNwsAwFYkR13AFACVZQn1cNMt7NtActCtStKtZt6tKwltWtr8Ottt-thtJtVAwgAdlALtVA31v1NITZb8RutAliHAElsg6w3oE02g_Nrl7V1cNs0NLSfFYAk5aR9osgEF_d_dm6s6aAWgm5QAA)


## Details

### Before: What was the problem?

Current impl of sunburst chart calculates label position in [SunburstPiece.ts](https://github.com/apache/echarts/blob/ca12fb489a83285040da20db4ea991ba90d4c685/src/chart/sunburst/SunburstPiece.ts#L185-L288), and apply it to all display state. However, this impl didn't take `labelLayout` into account and causes conflict as `labelLayout` is only applied to normal state for now.

This inconsistency causes strange animation on mouse hover.



### After: How does it behave after the fixing?

Now with this pr, `labelLayout` always takes priority.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

As an inexperienced front-end developer, this PR may require more reviews to avoid breaking any existing use cases. Also, I am currently unable to add unit tests for this PR, which may require further processing.