### PR TITLE
Relax tslib requirement specifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "2.3.0",
+        "tslib": "^2.3.0",
         "zrender": "5.6.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint:dist": "echo 'It might take a while. Please wait ...' && npx jshint --config .jshintrc-dist dist/echarts.js"
   },
   "dependencies": {
-    "tslib": "2.3.0",
+    "tslib": "^2.3.0",
     "zrender": "5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

Relax dependency specifier of tslib



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

I was testing my library with vite v6.beta, and found that tslib@2.3.0 did not work; later version of tslib did work.



### After: How does it behave after the fixing?

echarts now allows users to pick their own version of tslib - so a. it now works with vite v6 and b. users aren't unecessarily shipping two copies of tslib


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [x] This PR depends on ZRender changes (ecomfe/zrender#1097).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
