### PR TITLE
feat(calendar): add `silent` option for `dayLabel`/`monthLabel`/`yearLabel`

### DIFF
--- a/src/component/calendar/CalendarView.ts
+++ b/src/component/calendar/CalendarView.ts
@@ -337,7 +337,8 @@ class CalendarView extends ComponentView {
             z2: 30,
             style: createTextStyle(yearLabel, {
                 text: content
-            })
+            }),
+            silent: yearLabel.get('silent')
         });
         yearText.attr(this._yearTextPositionControl(yearText, posPoints[pos], orient, pos, margin));
 
@@ -422,6 +423,8 @@ class CalendarView extends ComponentView {
         margin = pos === 'start' ? -margin : margin;
         const isCenter = (align === 'center');
 
+        const labelSilent = monthLabel.get('silent');
+
         for (let i = 0; i < termPoints[idx].length - 1; i++) {
 
             const tmp = termPoints[idx][i].slice();
@@ -449,7 +452,8 @@ class CalendarView extends ComponentView {
                 style: extend(
                     createTextStyle(monthLabel, {text: content}),
                     this._monthTextPositionControl(tmp, isCenter, orient, pos, margin)
-                )
+                ),
+                silent: labelSilent
             });
 
             group.add(monthText);
@@ -533,6 +537,8 @@ class CalendarView extends ComponentView {
             margin = -margin;
         }
 
+        const labelSilent = dayLabel.get('silent');
+
         for (let i = 0; i < 7; i++) {
 
             const tmpD = coordSys.getNextNDay(start, i);
@@ -544,7 +550,8 @@ class CalendarView extends ComponentView {
                 style: extend(
                     createTextStyle(dayLabel, {text: nameMap[day]}),
                     this._weekTextPositionControl(point, orient, pos, margin, cellSize)
-                )
+                ),
+                silent: labelSilent
             });
 
             group.add(weekText);

--- a/test/calendar-simple.html
+++ b/test/calendar-simple.html
@@ -73,7 +73,16 @@ under the License.
                         max: 1000
                     },
                     calendar: {
-                        range: '2017'
+                        range: '2017',
+                        dayLabel: {
+                            silent: true
+                        },
+                        monthLabel: {
+                            silent: true
+                        },
+                        yearLabel: {
+                            silent: true
+                        }
                     },
                     series: {
                         type: 'heatmap',


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add `silent` option for `dayLabel`/`monthLabel`/`yearLabel` to allow the users to disable the label interaction.

[Demo](https://echarts.apache.org/examples/editor.html?c=calendar-simple&code=GYVwdgxgLglg9mABAcwKZQGowE5RAQwBsARfKfACgE9V9sBKRAbwChFEIEBnKRAEzKpEAXkQBqVBAAWdKFwB0sALap5ABzpdU1WtnGIA5AFoADAEZTZg_QDcbDt16owfEeMkzcC5ao3YtOnT6xmYATEYAzFa29pxgPPz4VAAqMCpuEQBsJiaIAFSIoQAs-YhmOSZ27HEJAuRuANoAulWIwHB6FIToiD5udag2vWlCADyiznxDfWKiAikjjKzs7HX46iBcUhQN9iuIHrLeI_Lt2EpkFD4ANIZMVA9UAL5GTACyby9MfHxPBrfAIhaejXPYrN5kKSnQhwDoUCFQKHYfAuOBKCiMArlCr0MFNGLsJ72bDoEDYJBrOxEuBqWAINzLRAANxgXAIhAhagAXMwwVs4AB3HmAwhaUH7JQwMA8kzilYXAAePOxOXsTzlECIkzoPMZ7GRYDQPIMoXMAHZ_mD5gAZfAAI1QhF1YPYXBg3TAUB5UGwIFQYPVYKUCERtodTt5-1d7ucXt6vv9-0D-xodDDjudUcQbo9cZ9foDarlWmwMFQXEzKygVDUqGNUloUAuakt-04HT4UsEAGUqDxUEpjZqPQJsK2VmseWhMDg8ERSOQKCbzdY1SwnnYWAB6LeIAUdADWdDg4D4293SioAGFPFB5AglySXKgSXx_ogMSIAHy8nfy6-3ueUbyNObxwHwjoYkB-zyLQ0hXmiagILGFBMIgFxSskNZ1oYw7amOiDqh-nBKEhYCxmBEGEIwwg_qwf5ZjUvAkWRsZYKgApuJeN6yCB6DsQKADywAIaRyGepRkEseJUCSdRdgMVG0nkZ6Amwfg0gAEqTC-qB8BQFCOjRdHQVmiAwMAH6Ooo2EiMIogGFAqAKlA1i_ruZkrNZOaxm4-aDKZWZEopSYxCFhFhbuTy2EAA&version=PR-20492)


### Fixed issues

- Resolves #20437
- Resolves #9858


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

See `test/calendar-simple.html`


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
