### PR TITLE
fix #20265 when dataZomm.filterMode is “empty” or ‘none’， the line graph is scaled to only one category, it is not filtered correctly

### DIFF
--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -127,6 +127,9 @@ export function contain(val: number, extent: [number, number]): boolean {
 }
 
 export function normalize(val: number, extent: [number, number]): number {
+    if (isNaN(val)) {
+        return NaN;
+    }
     if (extent[1] === extent[0]) {
         return 0.5;
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- fix bug #20265 issue-->



### Fixed issues

<!--
- #20265 : datazoom.filterMode设为'empty'时line图在缩放至只剩一条数据时所有数据都依旧会渲然，未依照empty的规则进行筛选。
-->


## Details

### Before: What was the problem?

<!-- when dataZomm.filterMode is “empty” or ‘none’， the line graph is scaled to only one category, it is not filtered correctly -->

<!-- 
![image](https://github.com/user-attachments/assets/852d4109-e975-4186-b5b6-a79575942b2c)
 -->



### After: How does it behave after the fixing?

<!-- The data is correctly filtered. And The bug is caused by calling the normalize method when calculating rendering values. When extra [1]==extra [0], it does not consider the possibility of NaN and returns 0.5 directly-->

<!--![8182f6148467cd28dbf5856e39d95bb](https://github.com/user-attachments/assets/f609277e-fa0a-43af-8b3d-afcb997d3603) -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
