### PR TITLE
fix-18151: When using pictorialbar, the y-axis cannot adapt, resulting in some column charts being offset

### DIFF
--- a/test/pictorialBar-scale.html
+++ b/test/pictorialBar-scale.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="data/pie-texture.js"></script>
+    <script src="data/symbols.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="lib/reset.css">
+</head>
+
+<body>
+    <style>
+        .chart {
+            position: relative;
+            height: 500px;
+            max-width: 1000px;
+            margin: 0 auto;
+        }
+
+        h2 {
+            text-align: center;
+            font-size: 16px;
+            line-height: 30px;
+            font-weight: normal;
+            background: #dde;
+            margin: 0;
+        }
+
+        strong {
+            color: #971f3c;
+        }
+    </style>
+
+    <h2>pictorialBar | scale</h2>
+    <div class="chart" id="paper-and-hill"></div>
+
+    <script>
+
+        function makeChart(id, option, cb) {
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                if (typeof option === 'function') {
+                    option = option(echarts);
+                }
+
+                var main = document.getElementById(id);
+                if (main) {
+                    var chartMain = document.createElement('div');
+                    chartMain.style.cssText = 'height:100%';
+                    main.appendChild(chartMain);
+                    var chart = echarts.init(chartMain);
+                    chart.setOption(option);
+
+                    window.addEventListener('resize', chart.resize);
+
+                    cb && cb(echarts, chart);
+                }
+
+            });
+        }
+
+    </script>
+
+
+    <script>
+        makeChart('paper-and-hill', {
+            xAxis: {
+                type: 'category',
+                data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+            },
+            yAxis: {
+                name: '',
+                nameLocation: 'end',
+                nameGap: 50,
+                nameTextStyle: {
+                    fontSize: 12,
+                    fontFamily: 'SourceHanSansCN-Regular',
+                    color: '#A9DDD5',
+                    // align: 'left',
+                    padding: [0, 50, 0, 20]
+                },
+                type: 'value',
+                scale: true,
+                // min: 0,
+                axisLine: {
+                    show: false,
+                    lineStyle: {
+                        color: '#7B8EA2',
+                        width: 0.5
+                    }
+                },
+                axisTick: {
+                    show: false
+                },
+                axisLabel: {
+                    show: true,
+                    fontSize: 12,
+                    fontFamily: 'SourceHanSansCN-Regular',
+                    color: '#A9DDD5',
+                    margin: 12
+
+                },
+                splitLine: {
+                    show: true,
+                    lineStyle: {
+                        color: 'rgba(26,245,248,0.2)',
+                        width: 0.5,
+                        type: 'dashed'
+                    }
+                }
+            },
+            series: [
+                {
+                    data: [120, 200, 150, 80, 70, 110, 130],
+                    name: '',
+                    type: 'pictorialBar',
+                    animationDuration: 10,
+                    legendHoverLink: false,
+                    symbolRepeat: 'true',
+                    symbolMargin: '20%',
+                    symbol: 'rect',
+                    symbolSize: [14, 5],
+                    itemStyle: {
+                        color: '#FFBA60'
+                    },
+                    z: 1,
+                    animationEasing: '',
+                }
+            ]
+        });
+    </script>
+
+
+
+</body>
+
+</html>


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

- This PR fixes the issue where the y-axis does not adapt when using pictorial bar charts, resulting in some column charts being offset.


### Fixed issues

- #18151: Fixed the y-axis adaptation issue in pictorial bar charts.


## Details

### Before: What was the problem?

- The y-axis was not adapting correctly when using pictorial bar charts, causing some column charts to be offset or misaligned.
![Uploading 111.png…]()



### After: How does it behave after the fixing?

- The y-axis now correctly adapts to the pictorial bar charts, ensuring that all column charts are properly aligned and displayed without offset.
![Uploading 222.png…]()


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
