### PR TITLE
fix(AxisPointer): Correct alignment for rich text tooltip labels

### DIFF
--- a/src/component/axisPointer/viewHelper.ts
+++ b/src/component/axisPointer/viewHelper.ts
@@ -19,7 +19,6 @@
 
 import * as zrUtil from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
-import * as textContain from 'zrender/src/contain/text';
 import * as formatUtil from '../../util/format';
 import * as matrix from 'zrender/src/core/matrix';
 import * as axisHelper from '../../coord/axisHelper';
@@ -96,7 +95,7 @@ export function buildLabelElOption(
     const paddings = formatUtil.normalizeCssArray(labelModel.get('padding') || 0);
 
     const font = labelModel.getFont();
-    const textRect = textContain.getBoundingRect(text, font);
+    const textRect = labelModel.getTextRect(text);
 
     const position = labelPos.position;
     const width = textRect.width + paddings[1] + paddings[3];


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fixes the alignment for axisPointer rich labels

### Fixed issues

- #20523 

## Details

### Before: What was the problem?

The alignment for rich text tooltip labels are incorrect, not in the center



### After: How does it behave after the fixing?

The alignment for rich text tooltip labels are now correctly centered



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
