### PR TITLE
feat(grid): enhance `grid.containLabel`

### DIFF
--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -187,6 +187,12 @@ class Grid implements CoordinateSystemMaster {
         // Minus label size
         if (isContainLabel) {
             each(axesList, function (axis) {
+                if (
+                    (isContainLabel === 'horizontal' && !axis.isHorizontal())
+                    || (isContainLabel === 'vertical' && axis.isHorizontal())
+                ) {
+                    return;
+                }
                 if (!axis.model.get(['axisLabel', 'inside'])) {
                     const labelUnionRect = estimateLabelUnionRect(axis);
                     if (labelUnionRect) {

--- a/src/coord/cartesian/GridModel.ts
+++ b/src/coord/cartesian/GridModel.ts
@@ -28,8 +28,8 @@ export interface GridOption extends ComponentOption, BoxLayoutOptionMixin, Shado
 
     show?: boolean;
 
-    // Whether grid size contain label.
-    containLabel?: boolean;
+    // Whether grid size contain label from which direction the labels are contained
+    containLabel?: boolean | 'horizontal' | 'vertical';
 
     backgroundColor?: ZRColor;
     borderWidth?: number;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Enhances the `grid.containLabel` property in ECharts to allow specifying the direction (`horizontal` or `vertical`) for label containment.

### Fixed issues

[#20540](https://github.com/apache/echarts/issues/20540)

## Details

### Before: What was the problem?

The `grid.containLabel` property was a simple boolean flag, which only enabled or disabled label containment. It lacked granularity, making it difficult to handle specific directions (e.g., only horizontal or vertical).

### After: How does it behave after the fixing?

The `grid.containLabel` property now supports specifying the direction (`horizontal` or `vertical`) for label containment. This allows more precise control over grid size adjustments based on axis labels.Ï

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
