### PR TITLE
fix(legend): symbolRotate for legend is neither inherited nor being set 

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -404,7 +404,8 @@ class LegendView extends ComponentView {
         }
         else {
             // Use default legend icon policy for most series
-            const rotate = legendIconType === 'inherit' && seriesModel.getData().getVisual('symbol')
+            const rotate = (!legendIconType || legendIconType === 'inherit')
+             && seriesModel.getData().getVisual('symbol')
                 ? (iconRotate === 'inherit'
                     ? seriesModel.getData().getVisual('symbolRotate')
                     : iconRotate

--- a/test/legend-style.html
+++ b/test/legend-style.html
@@ -37,6 +37,9 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
+        <div id="main4"></div>
+        <div id="main5"></div>
+        <div id="main6"></div>
 
         <script>
             function getData(seriesId) {
@@ -46,9 +49,16 @@ under the License.
                 }
                 return data;
             }
+            function getScatterData(seriesId) {
+                var data = [];
+                for (var i = 0; i < 7; ++i) {
+                    data.push([Math.random() * 100, Math.random() * 100]);
+                }
+                return data;
+            }
         </script>
 
-        <script>
+         <script>
         require(['echarts'], function (echarts) {
             var option = {
                 xAxis: {
@@ -331,5 +341,107 @@ under the License.
             });
         });
     </script>
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                textStyle: {
+                    color: 'green'
+                },
+                legend: {
+                    show: true,
+                    symbolRotate: 'inherit',
+                    itemWidth:15,
+                    itemHeight:15
+                },
+                xAxis: {},
+                yAxis: {},
+                series: [
+                    {
+                    name: 'triangle',
+                    symbolSize: 20,
+                    symbol: 'triangle',
+                    symbolRotate: 180,
+                    data: getScatterData(0),
+                    type: 'scatter'
+                    },
+                ],
+            };
+
+            var chart = testHelper.create(echarts, 'main4', {
+                title: [
+                    'Symbol should have **rotate inherit** in legend'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    textStyle: {
+                        color: 'green'
+                    },
+                    legend: {
+                        show: true,
+                        symbolRotate: 45,
+                        itemWidth:15,
+                        itemHeight:15
+                    },
+                    xAxis: {},
+                    yAxis: {},
+                    series: [
+                        {
+                        name: 'rect',
+                        symbolSize: 20,
+                        symbol: 'rect',
+                        data: getScatterData(0),
+                        type: 'scatter'
+                        },
+                    ],
+                };
+
+                var chart = testHelper.create(echarts, 'main5', {
+                    title: [
+                        'Symbol should have **rotate 45** in legend'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    textStyle: {
+                        color: 'green'
+                    },
+                    legend: {
+                        show: true,
+                        itemWidth:15,
+                        itemHeight:15
+                    },
+                    xAxis: {},
+                    yAxis: {},
+                    series: [
+                        {
+                        name: 'arrow',
+                        symbolSize: 20,
+                        symbol: 'arrow',
+                        data: getScatterData(0),
+                        type: 'scatter'
+                        },
+                    ],
+                };
+
+                var chart = testHelper.create(echarts, 'main6', {
+                    title: [
+                        'Symbol should have **rotate 0** as default in legend'
+                    ],
+                    option: option
+                });
+            });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

#20559 
#17955




## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`symbolRotate` for legend is neither inherited nor being set in case of scatter series.


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`symbolRotate` work well in legend

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
