### PR TITLE
fix(line): Ensure null check to avoid `Cannot set properties of null (setting 'hoverState')` error

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -1031,7 +1031,6 @@ class LineView extends ChartView {
 
     _changePolyState(toState: DisplayState) {
         const polygon = this._polygon;
-        setStatesFlag(this._polyline, toState);
         polygon && setStatesFlag(polygon, toState);
     }
 

--- a/test/ut/jest.config.cjs
+++ b/test/ut/jest.config.cjs
@@ -42,6 +42,7 @@ module.exports = {
     testMatch: [
         '**/spec/api/*.test.ts',
         '**/spec/component/**/*.test.ts',
+        '**/spec/chart/**/*.test.ts',
         '**/spec/series/**/*.test.ts',
         '**/spec/data/*.test.ts',
         '**/spec/model/*.test.ts',

--- a/test/ut/spec/chart/line/LineView.test.ts
+++ b/test/ut/spec/chart/line/LineView.test.ts
@@ -1,0 +1,26 @@
+import LineView from "@/src/chart/line/LineView";
+import { HOVER_STATE_EMPHASIS } from "@/src/util/states";
+import { ECElement } from "@/src/util/types";
+
+describe('LineView', function () {
+
+    let lineView: LineView;
+    beforeEach(function () {
+        lineView = new LineView();
+        lineView.init();
+    });
+
+    it('should change poly state when polygon is set', function () {
+        lineView._polygon = lineView._newPolygon(
+            [], [],
+        );
+        lineView._changePolyState('emphasis');
+        expect((lineView._polygon as ECElement).hoverState).toBe(HOVER_STATE_EMPHASIS);
+    });
+
+    it('should not error on state change when polygon is not set', function () {
+        lineView._polygon = null;
+        expect(() => lineView._changePolyState('emphasis')).not.toThrow();
+    });
+
+});


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This PR fixes the following error:
```
Uncaught TypeError: Cannot set properties of null (setting 'hoverState')
    at setStatesFlag (states.js:117:1)
    at __webpack_modules__../node_modules/echarts/lib/chart/line/LineView.js.LineView._changePolyState (LineView.js:763:1)
    at Symbol.changePolyState [as onHoverStateChange] (LineView.js:667:1)
    at doChangeHoverState (states.js:72:1)
    at singleLeaveBlur (states.js:93:1)
    at states.js:311:1
    at __webpack_modules__../node_modules/zrender/lib/graphic/Group.js.Group.traverse (Group.js:131:1)
    at __webpack_modules__../node_modules/zrender/lib/graphic/Group.js.Group.traverse (Group.js:133:1)
    at states.js:310:1
    at Global.js:511:1
```
By removing a redundant call to `setStatesFlag` missing a null/undefined check

### Fixed issues

<!--
- #xxxx: ...
-->
I haven't created a separate issue, but I can if you would like

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
There can be a race condition between the tooltip and `instance.dispatchAction({type: 'downplay'})` that causes the chart to freeze with an exception

<img width="751" alt="image" src="https://github.com/user-attachments/assets/c3870f60-2948-45d2-ac1e-488ed06d9841">

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
There is no longer an error
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
