### PR TITLE
fix(bar): polar bar should update roundCap when changes #20567

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -364,6 +364,14 @@ class BarView extends ChartView {
                     }
                 }
 
+                const roundCapChanged = el && (el.type === 'sector' && roundCap || el.type === 'sausage' && !roundCap);
+                if (roundCapChanged) {
+                    // roundCap changed, there is no way to use animation from a `sector` to a `sausage` shape,
+                    // so remove the old one and create a new shape
+                    el && removeElementWithFadeOut(el, seriesModel, oldIndex);
+                    el = null;
+                }
+
                 if (!el) {
                     el = elementCreator[coord.type](
                         seriesModel,
@@ -373,7 +381,7 @@ class BarView extends ChartView {
                         isHorizontalOrRadial,
                         animationModel,
                         baseAxis.model,
-                        !!el,
+                        true,
                         roundCap
                     );
                 }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Update bar shape when `roundCap` changes.

### Fixed issues

- #20567

## Details

### Before: What was the problem?

When `roundCap` changes in later `setOption`, the bar shape doesn't change from sector to sausage shape.


### After: How does it behave after the fixing?

Bar shape changes when `roundCap` updates.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
