### PR TITLE
Fixed the problem that the rich style does not take effect when tooltip is in renderMode=richText

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -537,6 +537,8 @@ class TooltipView extends ComponentView {
         // Only for legacy: `Serise['formatTooltip']` returns a string.
         const markupTextArrLegacy: string[] = [];
         const markupStyleCreator = new TooltipMarkupStyleCreator();
+		// @ts-ignore
+		Object.assign(markupStyleCreator.richTextStyles, singleTooltipModel.get('textStyle.rich'));
 
         each(dataByCoordSys, function (itemCoordSys) {
             each(itemCoordSys.dataByAxis, function (axisItem) {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Fixed the problem that the rich style does not take effect when tooltip is in renderMode=richText


### Fixed issues

<!--
- #xxxx: ...
-->
#19966 


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
In previous versions, rich style did not work when using tooltip attribute renderMode=richText


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Now, when using the tooltip attribute renderMode=richText, the rich style will achieve the expected effect.

example:
![image](https://github.com/user-attachments/assets/c0a9f853-09b8-4beb-9a51-399c16d4cec2)

 result as shown below:
![image](https://github.com/user-attachments/assets/7ffe7f4a-39e5-4417-9a82-d3a66b86b6d4)


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#431



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
