### PR TITLE
fix(line): Line Charts do not work when lte is set to null 

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -347,8 +347,8 @@ function getVisualGradient(
     }
 
     const tinyExtent = 10; // Arbitrary value: 10px
-    const minCoord = colorStopsInRange[0].coord - tinyExtent;
-    const maxCoord = colorStopsInRange[inRangeStopLen - 1].coord + tinyExtent;
+    const minCoord = (colorStopsInRange[0]?.coord || 0) - tinyExtent;
+    const maxCoord = (colorStopsInRange[inRangeStopLen - 1]?.coord || 0) + tinyExtent;
     const coordSpan = maxCoord - minCoord;
 
     if (coordSpan < 1e-3) {

--- a/test/visualMap-pieces.html
+++ b/test/visualMap-pieces.html
@@ -47,6 +47,7 @@ under the License.
 
         <div class="chart" id="map"></div>
         <div class="chart" id="line-symbol"></div>
+        <div class="chart" id="line-lte"></div>
 
         <script>
             require([
@@ -237,5 +238,75 @@ under the License.
             });
         </script>
 
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    yAxis: [
+                        {
+                            type: 'value'
+                        }
+                    ],
+                    xAxis: [
+                        {
+                            type: 'category'
+                        }
+                    ],
+                    legend: {
+                        show: false
+                    },
+                    grid: {},
+                    tooltip: {},
+                    series: [
+                        {
+                            type: 'line',
+                            name: 'profit'
+                        }
+                    ],
+                    dataset: [
+                        {
+                            dimensions: ['year', 'profit'],
+                            source: [
+                                {
+                                    year: '2010',
+                                    'profit': 100
+                                },
+                                {
+                                    year: '2011',
+                                    'profit': 200
+                                },
+                                {
+                                    year: '2012',
+                                    'profit': 150
+                                },
+                                {
+                                    year: '2013',
+                                    'profit': 300
+                                }
+                            ]
+                        }
+                    ],
+                    visualMap: {
+                        pieces: [
+                            {
+                                gte: 0,
+                                lte: null,
+                                color: 'blue'
+                            }
+                        ],
+                        top: 10,
+                        orient: 'horizontal',
+                        left: 'center'
+                    }
+                };
+                var chart = testHelper.create(echarts, 'line-lte', {
+                    option,
+                    title: [
+                        'Line Charts **should work** when lte is set to null'
+                    ]
+                })
+            })
+        </script> 
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x]  bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
fix: #18066


### Fixed issues

<!--
- #xxxx: ...
-->
 #18066

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
Set visualMap.pieces[].lte to null
1. Uncaught TypeError: Cannot read properties of undefined (reading 'coord')
2. Color should applied from 0 to max value.



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
1. No error reported
2. Color ranges from 0 to maximum value.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
