### PR TITLE
test: visual test support compare with a PR id

### DIFF
--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -472,7 +472,9 @@ const app = new Vue({
             let ecVersion = test[version + 'Version'];
             let ecSource = test[version + 'Source'];
             if (ecVersion !== 'local') {
-                let distPath = ecSource === 'branch' ? 'branch/' + ecVersion : ecVersion;
+                let distPath = ecSource === 'PR'
+                    ? 'pr-' + ecVersion.replace(/^#/, '')
+                    : ecVersion;
                 searches.push('__ECDIST__=' + distPath);
             }
             if (test.useSVG) {

--- a/test/runTest/client/client.js
+++ b/test/runTest/client/client.js
@@ -21,6 +21,8 @@ const socket = io('/client');
 
 // const LOCAL_SAVE_KEY = 'visual-regression-testing-config';
 
+let handlingSourceChange = false;
+
 function getChangedObject(target, source) {
     let changedObject = {};
     Object.keys(source).forEach(key => {
@@ -83,9 +85,15 @@ function processTestsData(tests, oldTestsData) {
         // Keep select status not change.
         if (oldTestsData && oldTestsData[idx]) {
             test.selected = oldTestsData[idx].selected;
+            // Keep source information
+            test.expectedSource = oldTestsData[idx].expectedSource;
+            test.actualSource = oldTestsData[idx].actualSource;
         }
         else {
             test.selected = false;
+            // Initialize source information
+            test.expectedSource = app.runConfig.expectedSource;
+            test.actualSource = app.runConfig.actualSource;
         }
     });
     return tests;
@@ -101,6 +109,21 @@ try {
 }
 catch (e) {}
 
+function getVersionFromSource(source, versions, nightlyVersions) {
+    if (source === 'branch') {
+        return 'master';
+    }
+    else if (source === 'nightly') {
+        return nightlyVersions.length ? nightlyVersions[0] : null;
+    }
+    else if (source === 'local') {
+        return 'local';
+    }
+    else {
+        return versions.length ? versions[0] : null;
+    }
+}
+
 const app = new Vue({
     el: '#app',
     data: {
@@ -111,9 +134,6 @@ const app = new Vue({
 
         allSelected: false,
         lastSelectedIndex: -1,
-
-        expectedVersionsList: [],
-        actualVersionsList: [],
 
         loadingVersion: false,
 
@@ -128,21 +148,26 @@ const app = new Vue({
 
         pageInvisible: false,
 
+        versions: [],
+        nightlyVersions: [],
+        branchVersions: [],
+
         runConfig: Object.assign({
             sortBy: 'name',
-
-            isActualNightly: false,
-            isExpectedNightly: false,
             actualVersion: 'local',
             expectedVersion: null,
-
+            expectedSource: 'release',
+            actualSource: 'release',
             renderer: 'canvas',
             useCoarsePointer: 'auto',
             threads: 4
         }, urlRunConfig)
     },
 
-    mounted() {
+    async mounted() {
+        // Add call to fetch branches
+        await this.fetchBranchVersions();
+
         // Sync config from server when first time open
         // or switching back
         socket.emit('syncRunConfig', {
@@ -151,12 +176,37 @@ const app = new Vue({
             forceSet: Object.keys(urlRunConfig).length > 0
         });
         socket.on('syncRunConfig_return', res => {
-            this.expectedVersionsList = res.expectedVersionsList;
-            this.actualVersionsList = res.actualVersionsList;
-            // Only assign on changed object to avoid unnecessary vue change.
-            Object.assign(this.runConfig, getChangedObject(this.runConfig, res.runConfig));
+            this.versions = res.versions || [];
+            this.nightlyVersions = res.nightlyVersions || [];
 
-            updateUrl();
+            // Only set versions if they haven't been manually set
+            handlingSourceChange = true;
+            this.$nextTick(() => {
+                if (!this.runConfig.expectedVersion) {
+                    this.runConfig.expectedVersion = getVersionFromSource(
+                        this.runConfig.expectedSource,
+                        this.versions,
+                        this.nightlyVersions
+                    );
+                }
+
+                if (!this.runConfig.actualVersion) {
+                    this.runConfig.actualVersion = getVersionFromSource(
+                        this.runConfig.actualSource,
+                        this.versions,
+                        this.nightlyVersions
+                    );
+                }
+
+                // Only apply other config changes from server
+                const configWithoutVersions = { ...res.runConfig };
+                delete configWithoutVersions.expectedVersion;
+                delete configWithoutVersions.actualVersion;
+                Object.assign(this.runConfig, getChangedObject(this.runConfig, configWithoutVersions));
+
+                handlingSourceChange = false;
+                updateUrl();
+            });
         });
 
         setTimeout(() => {
@@ -254,6 +304,36 @@ const app = new Vue({
                 });
             },
             set() {}
+        },
+
+        expectedVersionsList() {
+            switch (this.runConfig.expectedSource) {
+                case 'release':
+                    return this.versions;
+                case 'nightly':
+                    return this.nightlyVersions;
+                case 'branch':
+                    return this.branchVersions;
+                case 'local':
+                    return ['local'];
+                default:
+                    return [];
+            }
+        },
+
+        actualVersionsList() {
+            switch (this.runConfig.actualSource) {
+                case 'release':
+                    return this.versions;
+                case 'nightly':
+                    return this.nightlyVersions;
+                case 'branch':
+                    return this.branchVersions;
+                case 'local':
+                    return ['local'];
+                default:
+                    return [];
+            }
         }
     },
 
@@ -266,6 +346,44 @@ const app = new Vue({
 
         'currentTestName'(newVal, oldVal) {
             updateUrl();
+        },
+
+        'runConfig.expectedSource': {
+            handler(newVal, oldVal) {
+                if (newVal === oldVal) {
+                    return;
+                }
+
+                handlingSourceChange = true;
+                this.$nextTick(() => {
+                    this.runConfig.expectedVersion = getVersionFromSource(
+                        newVal,
+                        this.versions,
+                        this.nightlyVersions
+                    );
+                    handlingSourceChange = false;
+                });
+            },
+            deep: false
+        },
+
+        'runConfig.actualSource': {
+            handler(newVal, oldVal) {
+                if (newVal === oldVal) {
+                    return;
+                }
+
+                handlingSourceChange = true;
+                this.$nextTick(() => {
+                    this.runConfig.actualVersion = getVersionFromSource(
+                        newVal,
+                        this.versions,
+                        this.nightlyVersions
+                    );
+                    handlingSourceChange = false;
+                });
+            },
+            deep: false
         }
     },
 
@@ -339,8 +457,10 @@ const app = new Vue({
             let searches = [];
 
             let ecVersion = test[version + 'Version'];
+            let ecSource = test[version + 'Source'];
             if (ecVersion !== 'local') {
-                searches.push('__ECDIST__=' + ecVersion);
+                let distPath = ecSource === 'branch' ? 'branch/' + ecVersion : ecVersion;
+                searches.push('__ECDIST__=' + distPath);
             }
             if (test.useSVG) {
                 searches.push('__RENDERER__=svg');
@@ -367,8 +487,6 @@ const app = new Vue({
             this.runConfig.expectedVersion = runResult.expectedVersion;
             this.runConfig.actualVersion = runResult.actualVersion;
             // TODO
-            this.runConfig.isExpectedNightly = runResult.expectedVersion.includes('-dev.');
-            this.runConfig.isActualNightly = runResult.actualVersion.includes('-dev.');
             this.runConfig.renderer = runResult.renderer;
             this.runConfig.useCoarsePointer = runResult.useCoarsePointer;
 
@@ -397,6 +515,17 @@ const app = new Vue({
 
         open(url, target) {
             window.open(url, target);
+        },
+
+        async fetchBranchVersions() {
+            try {
+                const response = await fetch('https://api.github.com/repos/apache/echarts/branches?per_page=100');
+                const branches = await response.json();
+                this.branchVersions = branches.map(branch => branch.name);
+            } catch (error) {
+                console.error('Failed to fetch branches:', error);
+                this.branchVersions = [];
+            }
         }
     }
 });
@@ -419,7 +548,9 @@ function runTests(tests, noHeadless) {
     app.running = true;
     socket.emit('run', {
         tests,
+        expectedSource: app.runConfig.expectedSource,
         expectedVersion: app.runConfig.expectedVersion,
+        actualSource: app.runConfig.actualSource,
         actualVersion: app.runConfig.actualVersion,
         threads: app.runConfig.threads,
         renderer: app.runConfig.renderer,
@@ -498,7 +629,7 @@ function updateUrl() {
 
 // Only update url when version is changed.
 app.$watch('runConfig', (newVal, oldVal) => {
-    if (!app.pageInvisible) {
+    if (!app.pageInvisible && !handlingSourceChange) {
         socket.emit('syncRunConfig', {
             runConfig: app.runConfig,
             // Override server config from URL.

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -1,4 +1,3 @@
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -148,11 +147,11 @@ under the License.
                             <el-select :disabled="running" size="mini" v-model="runConfig.expectedSource" style="width: 90px;">
                                 <el-option value="release" label="Release"></el-option>
                                 <el-option value="nightly" label="Nightly"></el-option>
-                                <el-option value="branch" label="Branch"></el-option>
+                                <el-option value="PR" label="PR"></el-option>
                                 <el-option value="local" label="Local"></el-option>
                             </el-select>
                             <el-select
-                                v-if="runConfig.expectedSource !== 'local'"
+                                v-if="runConfig.expectedSource !== 'local' && runConfig.expectedSource !== 'PR'"
                                 :disabled="running"
                                 size="mini"
                                 v-model="runConfig.expectedVersion"
@@ -161,18 +160,25 @@ under the License.
                             >
                                 <el-option v-for="version in expectedVersionsList" :key="version" :label="version" :value="version"></el-option>
                             </el-select>
-                            <!-- <i class="el-icon-link"></i> -->
+                            <el-input
+                                v-if="runConfig.expectedSource === 'PR'"
+                                :disabled="running"
+                                size="mini"
+                                v-model="runConfig.expectedVersion"
+                                placeholder="#123"
+                                style="width: 120px;"
+                            ></el-input>
                             <span class="label">
                                 Actual
                             </span>
                             <el-select :disabled="running" size="mini" v-model="runConfig.actualSource" style="width: 90px;">
                                 <el-option value="release" label="Release"></el-option>
                                 <el-option value="nightly" label="Nightly"></el-option>
-                                <el-option value="branch" label="Branch"></el-option>
+                                <el-option value="PR" label="PR"></el-option>
                                 <el-option value="local" label="Local"></el-option>
                             </el-select>
                             <el-select
-                                v-if="runConfig.actualSource !== 'local'"
+                                v-if="runConfig.actualSource !== 'local' && runConfig.actualSource !== 'PR'"
                                 :disabled="running"
                                 size="mini"
                                 v-model="runConfig.actualVersion"
@@ -181,6 +187,14 @@ under the License.
                             >
                                 <el-option v-for="version in actualVersionsList" :key="version" :label="version" :value="version"></el-option>
                             </el-select>
+                            <el-input
+                                v-if="runConfig.actualSource === 'PR'"
+                                :disabled="running"
+                                size="mini"
+                                v-model="runConfig.actualVersion"
+                                placeholder="#123"
+                                style="width: 120px;"
+                            ></el-input>
                         </div>
                         <div class="run-config-item">
                             <span class="label">Renderer</span>

--- a/test/runTest/client/index.html
+++ b/test/runTest/client/index.html
@@ -144,24 +144,40 @@ under the License.
                         <div class="run-config-item">
                             <span class="label">
                                 Expected
-                                <el-tooltip content="Use Nightly Build">
-                                    <el-checkbox :disabled="running" v-model="runConfig.isExpectedNightly" size="mini"></el-checkbox>
-                                </el-tooltip>
                             </span>
-                            <el-select :disabled="running" size="mini" v-model="runConfig.expectedVersion" placeholder="Select Version"
-                                :style="`width: ${runConfig.isExpectedNightly ? 160 : 80}px;`"
+                            <el-select :disabled="running" size="mini" v-model="runConfig.expectedSource" style="width: 90px;">
+                                <el-option value="release" label="Release"></el-option>
+                                <el-option value="nightly" label="Nightly"></el-option>
+                                <el-option value="branch" label="Branch"></el-option>
+                                <el-option value="local" label="Local"></el-option>
+                            </el-select>
+                            <el-select
+                                v-if="runConfig.expectedSource !== 'local'"
+                                :disabled="running"
+                                size="mini"
+                                v-model="runConfig.expectedVersion"
+                                placeholder="Select Version"
+                                :style="`width: ${runConfig.expectedSource === 'nightly' ? 160 : 80}px;`"
                             >
                                 <el-option v-for="version in expectedVersionsList" :key="version" :label="version" :value="version"></el-option>
                             </el-select>
                             <!-- <i class="el-icon-link"></i> -->
                             <span class="label">
                                 Actual
-                                <el-tooltip content="Use Nightly Build">
-                                    <el-checkbox :disabled="running" v-model="runConfig.isActualNightly" size="mini"></el-checkbox>
-                                </el-tooltip>
                             </span>
-                            <el-select :disabled="running" size="mini" v-model="runConfig.actualVersion" placeholder="Select Version"
-                                :style="`width: ${runConfig.isActualNightly ? 160 : 80}px;`"
+                            <el-select :disabled="running" size="mini" v-model="runConfig.actualSource" style="width: 90px;">
+                                <el-option value="release" label="Release"></el-option>
+                                <el-option value="nightly" label="Nightly"></el-option>
+                                <el-option value="branch" label="Branch"></el-option>
+                                <el-option value="local" label="Local"></el-option>
+                            </el-select>
+                            <el-select
+                                v-if="runConfig.actualSource !== 'local'"
+                                :disabled="running"
+                                size="mini"
+                                v-model="runConfig.actualVersion"
+                                placeholder="Select Version"
+                                :style="`width: ${runConfig.actualSource === 'nightly' ? 160 : 80}px;`"
                             >
                                 <el-option v-for="version in actualVersionsList" :key="version" :label="version" :value="version"></el-option>
                             </el-select>

--- a/test/runTest/store.js
+++ b/test/runTest/store.js
@@ -77,11 +77,19 @@ class Test {
  * It depends on two versions and rendering mode.
  */
 function getRunHash(params) {
+    // Replace # with PR- in the hash to avoid URL issues
+    const expectedVersion = params.expectedSource === 'PR'
+        ? params.expectedVersion.replace('#', 'PR-')
+        : params.expectedVersion;
+    const actualVersion = params.actualSource === 'PR'
+        ? params.actualVersion.replace('#', 'PR-')
+        : params.actualVersion;
+
     return [
         params.expectedSource,
-        params.expectedVersion,
+        expectedVersion,
         params.actualSource,
-        params.actualVersion,
+        actualVersion,
         params.renderer,
         params.useCoarsePointer
     ].join(TEST_HASH_SPLITTER);
@@ -92,11 +100,19 @@ function getRunHash(params) {
  */
 function parseRunHash(str) {
     const parts = str.split(TEST_HASH_SPLITTER);
+    // Convert back PR-123 to #123 for PR versions
+    const expectedVersion = parts[0] === 'PR'
+        ? parts[1].replace('PR-', '#')
+        : parts[1];
+    const actualVersion = parts[2] === 'PR'
+        ? parts[3].replace('PR-', '#')
+        : parts[3];
+
     return {
         expectedSource: parts[0],
-        expectedVersion: parts[1],
+        expectedVersion: expectedVersion,
         actualSource: parts[2],
-        actualVersion: parts[3],
+        actualVersion: actualVersion,
         renderer: parts[4],
         useCoarsePointer: parts[5]
     };

--- a/test/runTest/util.js
+++ b/test/runTest/util.js
@@ -81,12 +81,6 @@ module.exports.prepareEChartsLib = function (source, version, useCNMirror) {
     const ecDownloadPath = `${versionFolder}/echarts.js`;
     const testLibPath = `${versionFolder}/${module.exports.getEChartsTestFileName()}`;
 
-    // Check if both files exist and are not empty
-    if (fs.existsSync(ecDownloadPath) && fs.existsSync(testLibPath) &&
-        fs.statSync(ecDownloadPath).size > 0 && fs.statSync(testLibPath).size > 0) {
-        return Promise.resolve();
-    }
-
     fse.ensureDirSync(versionFolder);
 
     if (!version || version === 'local') {
@@ -94,6 +88,10 @@ module.exports.prepareEChartsLib = function (source, version, useCNMirror) {
         fse.copySync(path.join(__dirname, '../../dist/echarts.js'), ecDownloadPath);
         let code = modifyEChartsCode(fs.readFileSync(ecDownloadPath, 'utf-8'));
         fs.writeFileSync(testLibPath, code, 'utf-8');
+        return Promise.resolve();
+    }
+    else if (fs.existsSync(ecDownloadPath) && fs.existsSync(testLibPath) &&
+        fs.statSync(ecDownloadPath).size > 0 && fs.statSync(testLibPath).size > 0) {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Supports using PRs on GitHub in visual tests.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

We can use only a released version or nightly build to do visual tests.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://github.com/user-attachments/assets/f32b54a6-a9e7-4d7b-9865-62d374c7279f)

We can input a PR id on GitHub to do the visual test and the artifact of PR preview of `dist/echarts.js` will be used. This is helpful because I want to compare the changes of a v6 feature and want to compare with v6 branch.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
