### PR TITLE
fix(series): mismatched dimension index when canOmitUnusedDimensions is true

### DIFF
--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -316,11 +316,16 @@ class SeriesData<
             if (dimensionInfo.createInvertedIndices) {
                 invertedIndicesMap[dimensionName] = [];
             }
+
+            let dimIdx = i;
+            if (zrUtil.isNumber(dimensionInfo.storeDimIndex)) {
+                dimIdx = dimensionInfo.storeDimIndex;
+            }
             if (otherDims.itemName === 0) {
-                this._nameDimIdx = i;
+                this._nameDimIdx = dimIdx;
             }
             if (otherDims.itemId === 0) {
-                this._idDimIdx = i;
+                this._idDimIdx = dimIdx;
             }
 
             if (__DEV__) {


### PR DESCRIPTION
Close https://github.com/apache/echarts/issues/20672

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

fix(series): mismatched dimension index when `canOmitUnusedDimensions` is true


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

https://github.com/apache/echarts/issues/20672


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
