### PR TITLE
fix(dataZoom): data zoom length should take the handle icon width into account

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -292,8 +292,14 @@ class SliderZoomView extends DataZoomView {
 
         // Position barGroup
         const rect = thisGroup.getBoundingRect([sliderGroup]);
-        thisGroup.x = location.x - rect.x;
-        thisGroup.y = location.y - rect.y;
+        // there is only scaleX on sliderGroup.
+        thisGroup.scaleX = this._size[0] / rect.width;
+        // scaleY on sliderGroup is a bad idea.
+        // Because of the moveHandleSize maybe greater than zoom bar height.
+        // clip is better than scale hard.
+        const scaleY = this._size[1] / rect.height;
+        thisGroup.x = location.x - rect.x * thisGroup.scaleX;
+        thisGroup.y = location.y - rect.y * scaleY;
         thisGroup.markRedraw();
     }
 

--- a/test/dataZoom-clip.html
+++ b/test/dataZoom-clip.html
@@ -39,6 +39,7 @@ under the License.
 
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
         <div class="chart" id="b"></div>
 
 
@@ -289,6 +290,54 @@ under the License.
         </script>
 
 
+
+        <script>
+
+            require(['echarts'], function (echarts) {
+                var option = {
+                    color: ["#3398DB"],
+                    tooltip: {
+                        trigger: "axis"
+                    },
+                    grid: {
+                        left: 0,
+                        right: 0
+                    },
+                    xAxis: {
+                        data: ["2015-02-23", "2015-02-24"]
+                    },
+                    yAxis: {
+                        show: false,
+                    },
+                    dataZoom: [{
+                        showDetail: false,
+                        left: 0,
+                        right: 0,
+                        moveHandleStyle: {
+                            color: "rgba(215, 59, 59, 1)"
+                        },
+                        fillerColor:"rgba(0,0,0,0)",
+                        moveHandleSize: 7,
+                        handleSize: "100%",
+                        borderRadius:100,
+                        borderWidth:0
+                    }],
+                    series: {
+                        name: "Beijing AQI",
+                        type: "bar",
+                        data: [86, 207]
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'HandleIcon and dataZoomBar should be complete on default with **dataZoom.left = 0 and dataZoom.right = 0**',
+                    ],
+                    option: option
+                });
+            });
+
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

fix data zoom length should take the handle icon width into account

### Fixed issues

#20686  


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![Image](https://github.com/user-attachments/assets/94f695ed-4e12-464b-a13d-d9c27da93550)


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![image](https://github.com/user-attachments/assets/1fb54693-468b-4bf4-b27e-5ea2ab273ad1)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
