### PR TITLE
fix(heatmap): fix labels not in calendar range are unexpectedly displayed

### DIFF
--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -266,9 +266,15 @@ class HeatmapView extends ChartView {
                     continue;
                 }
 
+                const contentShape = coordSys.dataToRect([data.get(dataDims[0], idx)]).contentShape;
+                // Ignore data that are not in range
+                if (isNaN(contentShape.x) || isNaN(contentShape.y)) {
+                    continue;
+                }
+
                 rect = new graphic.Rect({
                     z2: 1,
-                    shape: coordSys.dataToRect([data.get(dataDims[0], idx)]).contentShape,
+                    shape: contentShape,
                     style
                 });
             }

--- a/test/calendar-heatmap2.html
+++ b/test/calendar-heatmap2.html
@@ -1,0 +1,81 @@
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>calendar</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="lib/reset.css">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <script src="lib/jquery.min.js"></script>
+    </head>
+    <body>
+        <div id="main0"></div>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                var option = {
+                    visualMap: {
+                        show: false,
+                        min: 0,
+                        max: 10000
+                    },
+                    calendar: {
+                        range: '2016-01'
+                    },
+                    series: {
+                        type: 'heatmap',
+                        coordinateSystem: 'calendar',
+                        data: [
+                            ['2016-01-05', 500],
+                            ['2016-01-16', 100],
+                            ['2016-01-20', 670],
+                            ['2016-01-27', 300],
+                            ['2016-02-01', 800],
+                        ],
+                        label: {
+                            show: true,
+                            verticalAlign: 'top',
+                            align: 'left',
+                            formatter(params) {
+                                if (!params.value[0].startsWith('2016-01')) {
+                                    return 'UNEXPECTED LABELS!!!'
+                                }
+                                return ''
+                            },
+                            color: 'red',
+                            fontWeight: 'bold',
+                            fontSize: 20
+                        }
+                    }
+                };
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        `Labels that are not in calendar range **SHOULDN'T** display at the top left corner`
+                    ],
+                    option: option
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

Fix the bug that labels not in the calendar range are unexpectedly displayed, as a supplement fix of #12991.

[Demo](https://echarts.apache.org/examples/editor.html?code=PYBwLglsB2AEC8sDeAoWsBuEDOBXAhgDYCy-IAXMmurNgBbADulAZkdgKYA016AthGiUADDxqw--AB6UAjMIXDqAXzGwAxkQ7QAJvgBOlVOP35oAcw6UA5ACZhsgGwBaB9ZVrO-iB2xHesGAAniBWsNZ0HPhgkiDWaujqwMD6OoLRHADKQdhgHHw2moTaevrxAXpg-JQA2gHoNXYOLg6uAKzxsG0KALoJNI32Tq6yzk6d8sJ99bCDzSPO9p2OAOxT_Q1Nw622K50AzL0bs1sttiOdABy9AdPihPgARhyE_uLo9EyUYPq43DMYDj6SBFACChAg5iE4TAoHK71gREh0OsxRYYHh7xYKUkYDy-gAFCADPg-NgAJRUBHoCAsWAEgCExNMZIAdBgiH8alNWbkDGBsAB1CBgOgE04XcmU4zU9D6DhgXD6ODWACqADkAKIADQACpqAMIAFU1ABFYAAZUEAIU1FsyDMd1gA3DN0Mo3bB5YrleEXTNVDMkoQUjZ5TpMeJsdAwIKOJC6GAbI9gIQI8do2BMhAAF5hewBD3ulDKZ1AA&version=PR-20699)

### Fixed issues

Fix #20690

## Details

### Before: What was the problem?

![image](https://github.com/user-attachments/assets/53bf259f-fad8-460c-b667-f9276966b4f7)

### After: How does it behave after the fixing?

![image](https://github.com/user-attachments/assets/9caf8ddf-112a-4a7d-84ee-99f1f198a7e8)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to `test/calendar-heatmap2.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
