### PR TITLE
feat(theme): dynamically update the theme

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -404,11 +404,6 @@ class ECharts extends Eventful<ECEventDefinition> {
 
         opts = opts || {};
 
-        // Get theme by name
-        if (isString(theme)) {
-            theme = themeStorage[theme] as object;
-        }
-
         this._dom = dom;
 
         let defaultRenderer = 'canvas';
@@ -459,10 +454,7 @@ class ECharts extends Eventful<ECEventDefinition> {
         // Expect 60 fps.
         this._throttledZrFlush = throttle(bind(zr.flush, zr), 17);
 
-        theme = clone(theme);
-        theme && backwardCompat(theme as ECUnitOption, true);
-
-        this._theme = theme;
+        this._updateTheme(theme);
 
         this._locale = createLocaleObject(opts.locale || SYSTEM_LANG);
 
@@ -693,10 +685,30 @@ class ECharts extends Eventful<ECEventDefinition> {
     }
 
     /**
-     * @deprecated
+     * Update theme with name or theme option and repaint the chart.
+     * @param theme Theme name or theme option.
      */
-    private setTheme(): void {
-        deprecateLog('ECharts#setTheme() is DEPRECATED in ECharts 3.0');
+    setTheme(theme: string | ThemeOption): void {
+        this._updateTheme(theme);
+        if (this._model) {
+            this._model.setTheme(this._theme);
+            // Force refresh to apply theme changes
+            updateMethods.prepareAndUpdate.call(this, {
+                type: 'themeChanged'
+            });
+        }
+    }
+
+    private _updateTheme(theme: string | ThemeOption): void {
+        if (isString(theme)) {
+            theme = themeStorage[theme] as object;
+        }
+
+        if (theme) {
+            theme = clone(theme);
+            theme && backwardCompat(theme as ECUnitOption, true);
+            this._theme = theme;
+        }
     }
 
     // We don't want developers to use getModel directly.

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -692,10 +692,8 @@ class ECharts extends Eventful<ECEventDefinition> {
         this._updateTheme(theme);
         if (this._model) {
             this._model.setTheme(this._theme);
-            // Force refresh to apply theme changes
-            updateMethods.prepareAndUpdate.call(this, {
-                type: 'themeChanged'
-            });
+            // Just call update directly without event type
+            updateMethods.prepareAndUpdate.call(this);
         }
     }
 
@@ -1672,7 +1670,7 @@ class ECharts extends Eventful<ECEventDefinition> {
 
             prepareAndUpdate(this: ECharts, payload: Payload): void {
                 prepare(this);
-                updateMethods.update.call(this, payload, {
+                updateMethods.update.call(this, payload, payload && {
                     // Needs to mark option changed if newOption is given.
                     // It's from MagicType.
                     // TODO If use a separate flag optionChanged in payload?

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -545,9 +545,6 @@ echarts.use([${seriesImportName}]);`);
 
     setTheme(theme: object) {
         this._theme = new Model(theme);
-        // Merge theme with current option directly
-        mergeTheme(this.option, this._theme.option);
-        // Reset to apply theme changes
         this._resetOption('recreate', null);
     }
 

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -543,6 +543,14 @@ echarts.use([${seriesImportName}]);`);
         return option;
     }
 
+    setTheme(theme: object) {
+        this._theme = new Model(theme);
+        // Merge theme with current option directly
+        mergeTheme(this.option, this._theme.option);
+        // Reset to apply theme changes
+        this._resetOption('recreate', null);
+    }
+
     getTheme(): Model {
         return this._theme;
     }

--- a/src/model/globalDefault.ts
+++ b/src/model/globalDefault.ts
@@ -35,12 +35,12 @@ export default {
     colorBy: 'series',
 
     color: [
-        '#5470c6',
-        '#91cc75',
-        '#fac858',
-        '#ee6666',
-        '#73c0de',
-        '#3ba272',
+        '#5780fe',
+        '#b5e45a',
+        '#656990',
+        '#ffa75c',
+        '#5adfd3',
+        '#f47da3',
         '#fc8452',
         '#9a60b4',
         '#ea7ccc'

--- a/src/model/globalDefault.ts
+++ b/src/model/globalDefault.ts
@@ -35,12 +35,12 @@ export default {
     colorBy: 'series',
 
     color: [
-        '#5780fe',
-        '#b5e45a',
-        '#656990',
-        '#ffa75c',
-        '#5adfd3',
-        '#f47da3',
+        '#5470c6',
+        '#91cc75',
+        '#fac858',
+        '#ee6666',
+        '#73c0de',
+        '#3ba272',
         '#fc8452',
         '#9a60b4',
         '#ea7ccc'

--- a/test/theme.html
+++ b/test/theme.html
@@ -1,4 +1,3 @@
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -23,28 +22,24 @@ under the License.
         <meta charset="utf-8">
         <script src="lib/simpleRequire.js"></script>
         <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
     </head>
     <body>
         <style>
-            html, body, #main {
+            .chart {
                 width: 100%;
-                height: 100%;
-                margin: 0;
-            }
-            #main {
-                width: 100%;
-                background: #fff;
+                height: 400px;
             }
         </style>
-        <div id="main"></div>
+        <div id="main0" class="chart"></div>
+        <div id="main1" class="chart"></div>
         <script>
 
             require([
-                'echarts',
-                'theme/dark'
-            ], function (echarts, theme) {
+                'echarts'
+            ], function (echarts) {
 
-                var chart = echarts.init(document.getElementById('main'), 'dark');
+                var chart = echarts.init(document.getElementById('main0'), 'dark');
 
                 var xAxisData = [];
                 var data1 = [];
@@ -146,6 +141,85 @@ under the License.
                 console.profileEnd('setOption');
             })
 
+        </script>
+
+        <script>
+            require([
+                'echarts'
+            ], function (echarts) {
+                const darkTheme = {
+                    backgroundColor: '#333',
+                    title: {
+                        textStyle: {
+                            color: '#fff'
+                        }
+                    }
+                };
+                echarts.registerTheme('dark', darkTheme);
+
+                var option = {
+                    title: {
+                        text: 'ECharts example'
+                    },
+                    xAxis: {
+                        type: 'category',
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                    },
+                    yAxis: {
+                        type: 'value'
+                    },
+                    series: [{
+                        data: [120, 200, 150, 80, 70, 110, 130],
+                        type: 'bar'
+                    }]
+                };
+
+                var chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Test dynamic theme switching:',
+                        'Click buttons to switch between dark and forest themes',
+                        'The chart style should update **immediately**'
+                    ],
+                    option: option,
+                    height: 300,
+                    buttons: [{
+                        text: 'Dark',
+                        onclick: function () {
+                            chart.setTheme('dark');
+                        }
+                    }, {
+                        text: 'Forest',
+                        onclick: function () {
+                            const forestTheme = {
+                                backgroundColor: '#cfc',
+                                color: ['#090'],
+                                title: {
+                                    textStyle: {
+                                        color: '#030'
+                                    }
+                                }
+                            };
+                            echarts.registerTheme('forest', forestTheme);
+                            chart.setTheme('forest');
+                            chart.setOption(option);
+                        }
+                    }, {
+                        text: 'River',
+                        onclick: function () {
+                            const riverTheme = {
+                                backgroundColor: '#ccf',
+                                color: ['#00f'],
+                                title: {
+                                    textStyle: {
+                                        color: '#00f'
+                                    }
+                                }
+                            };
+                            chart.setTheme(riverTheme);
+                        }
+                    }]
+                });
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Add support for dynamically changing themes after chart initialization.

### Fixed issues

- Fix #19556
- Fix #18716

## Details

### Before: What was the problem?

Currently, themes can only be set before chart initialization.

```js
echarts.registerTheme('dark', darkTheme);
const chart = echarts.init(dom, 'dark');
// You cannot change theme after chart is created unless dispose and reinit it.
```

There's no way to change themes dynamically after the chart is created.

The deprecated `setTheme` method in ECharts 3.0 was removed without a replacement.

### After: How does it behave after the fixing?

Now users can:
1. Change themes dynamically using `chart.setTheme('themeName')` or `chart.setTheme(themeObject)` for registered themes
2. If `themeName` is used, both the themes registered before or after the chart was created can be applied.
3. Theme changes are applied immediately without needing to call `setOption`.

Example usage:

```js
// Using registered theme
echarts.registerTheme('dark', darkTheme);
const chart = echarts.init(dom);
chart.setTheme('dark');

// Dynamically register theme after chart is created
echarts.registerTheme('forest', forestTheme);
chart.setTheme('forest');

// The above is equivalent to:
chart.setTheme(forestTheme);
// The only difference is that forestTheme is an anonymous object, so it can't be reused for other charts.

// Using theme object directly
chart.setTheme({
    backgroundColor: '#333',
    title: {
        textStyle: {
            color: '#fff'
        }
    }
});
```

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc@8624290363b6751bfee6d483690c77b55ff75076

## Misc

### ZRender Changes

- [x] This PR doesn't depend on ZRender changes.

### Related test cases or examples to use the new APIs

- `test/theme.html`

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This PR is a pre-requisite for design token feature, with which we can dynamically change themes using design tokens.
