### PR TITLE
fix(datazoom): prevent bar and scatter chart overflowing the graph . …

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -271,7 +271,22 @@ class AxisProxy {
         const valueWindow = this._valueWindow;
 
         if (filterMode === 'none') {
-            return;
+          each(seriesModels, function (seriesModel) {
+            if (seriesModel.subType === 'bar' || seriesModel.subType === 'scatter') {
+              // For series type bar and scatter, get the range bound data so that the
+              // bar and scatter bubbles should not exceed beyond the axis.
+              // Instead of clipping the bars in such scenario,
+              // it should show the whole bars within the range.
+              const seriesData = seriesModel.getData();
+              const dataDims = seriesData.mapDimensionsAll(axisDim);
+              each(dataDims, function (dim) {
+                const range: Dictionary<[number, number]> = {};
+                range[dim] = valueWindow;
+                seriesData.selectRange(range);
+              });
+            }
+          });
+          return;
         }
 
         // FIXME


### PR DESCRIPTION
…close #19972

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
The PR prevents bars and scatter chart from going outside of the graph when zoomed in


### Fixed issues

#19972


## Details

### Before: What was the problem?
In case the filtermode: 'none' and series type is bar or scatter and x axiis type is time, on zooming in too much, the bars would go outside of the graph (beyond axis)

### After: How does it behave after the fixing?

The bars and scatter chart stays within the axis.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
