### PR TITLE
feat(bar): provide more options for emphasis focus ('stack', …

### DIFF
--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -58,6 +58,7 @@ import ExtensionAPI from '../core/ExtensionAPI';
 import ComponentModel from '../model/Component';
 import { error } from './log';
 import type ComponentView from '../view/Component';
+import { BarSeriesOption } from '../chart/bar/BarSeries';
 
 // Reserve 0 as default.
 let _highlightNextDigit = 1;
@@ -427,6 +428,7 @@ export function allLeaveBlur(api: ExtensionAPI) {
 
 export function blurSeries(
     targetSeriesIndex: number,
+    targetDataIndex: number,
     focus: InnerFocus,
     blurScope: BlurScope,
     api: ExtensionAPI
@@ -450,6 +452,7 @@ export function blurSeries(
     }
 
     const targetSeriesModel = ecModel.getSeriesByIndex(targetSeriesIndex);
+    const targetStack = targetSeriesModel.option.type === 'bar' && (targetSeriesModel.option as BarSeriesOption).stack;
     let targetCoordSys: CoordinateSystemMaster | CoordinateSystem = targetSeriesModel.coordinateSystem;
     if (targetCoordSys && (targetCoordSys as CoordinateSystem).master) {
         targetCoordSys = (targetCoordSys as CoordinateSystem).master;
@@ -460,6 +463,9 @@ export function blurSeries(
     ecModel.eachSeries(function (seriesModel) {
 
         const sameSeries = targetSeriesModel === seriesModel;
+        const sameStack = targetStack && seriesModel.option.type === 'bar'
+            && (seriesModel.option as BarSeriesOption).stack === targetStack;
+
         let coordSys: CoordinateSystemMaster | CoordinateSystem = seriesModel.coordinateSystem;
         if (coordSys && (coordSys as CoordinateSystem).master) {
             coordSys = (coordSys as CoordinateSystem).master;
@@ -478,11 +484,21 @@ export function blurSeries(
         )) {
             const view = api.getViewOfSeriesModel(seriesModel);
             view.group.traverse(function (child) {
+                const sameDataIndex = (child as any).__dataIndex === targetDataIndex;
                 // For the elements that have been triggered by other components,
                 // and are still required to be highlighted,
                 // because the current is directly forced to blur the element,
                 // it will cause the focus self to be unable to highlight, so skip the blur of this element.
                 if ((child as ExtendedElement).__highByOuter && sameSeries && focus === 'self') {
+                    return;
+                }
+                if (sameDataIndex && focus === 'dataIndex') {
+                    return;
+                }
+                if (sameStack && focus === 'stackSeries') {
+                    return;
+                }
+                if (sameStack && sameDataIndex && focus === 'stack') {
                     return;
                 }
                 singleEnterBlur(child);
@@ -570,7 +586,7 @@ export function blurSeriesFromHighlightPayload(
     if (el) {
         const ecData = getECData(el);
         blurSeries(
-            seriesIndex, ecData.focus, ecData.blurScope, api
+            seriesIndex, ecData.dataIndex, ecData.focus, ecData.blurScope, api
         );
     }
     else {
@@ -579,7 +595,7 @@ export function blurSeriesFromHighlightPayload(
         const focus = seriesModel.get(['emphasis', 'focus']);
         const blurScope = seriesModel.get(['emphasis', 'blurScope']);
         if (focus != null) {
-            blurSeries(seriesIndex, focus, blurScope, api);
+            blurSeries(seriesIndex, dataIndex, focus, blurScope, api);
         }
     }
 }
@@ -659,7 +675,7 @@ export function handleGlobalMouseOverForHighDown(
     else {
         // Try blur all in the related series. Then emphasis the hoverred.
         // TODO. progressive mode.
-        blurSeries(ecData.seriesIndex, ecData.focus, ecData.blurScope, api);
+        blurSeries(ecData.seriesIndex, ecData.dataIndex, ecData.focus, ecData.blurScope, api);
         if (ecData.focus === 'self') {
             blurComponent(ecData.componentMainType, ecData.componentIndex, api);
         }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1486,7 +1486,7 @@ export interface DefaultStatesMixin {
     blur?: any
 }
 
-export type DefaultEmphasisFocus = 'none' | 'self' | 'series';
+export type DefaultEmphasisFocus = 'none' | 'self' | 'series' | 'stack' | 'stackSeries' | 'dataIndex';
 
 export interface DefaultStatesMixinEmphasis {
     /**


### PR DESCRIPTION
…'stackSeries', and 'dataIndex'). close #20723

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Implement new options for `emphasis.focus`: 'stack' | 'stackSeries' | 'dataIndex'



### Fixed issues

- #20723


## Details

### Before: What was the problem?

On stacked bar charts, on hover, need to be able to emphasize the stack (not just 'self'):
![image](https://github.com/user-attachments/assets/8448bf53-522e-4b53-9ef9-b6f293dc330f)




### After: How does it behave after the fixing?

You can specify `emphasis: { focus: 'stack' }` in the options.


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [X] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- [X] Test case and examples should be added later


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

What tests I should add?

