### PR TITLE
fix(svg): remove SVG support check in `getSvgDataURL`

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -767,10 +767,6 @@ class ECharts extends Eventful<ECEventDefinition> {
      * Get svg data url
      */
     getSvgDataURL(): string {
-        if (!env.svgSupported) {
-            return;
-        }
-
         const zr = this._zr;
         const list = zr.storage.getDisplayList();
         // Stop animations


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Remove the check for SVG support in the `getSvgDataURL` function since SVG based on Virtual DOM has been supported since v5.3.0.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
