### PR TITLE
fix(title): title text style width type should not include string #20799

### DIFF
--- a/src/component/title/install.ts
+++ b/src/component/title/install.ts
@@ -38,6 +38,9 @@ import ExtensionAPI from '../../core/ExtensionAPI';
 import {windowOpen} from '../../util/format';
 import { EChartsExtensionInstallRegisters } from '../../extension';
 
+interface TitleTextStyleOption extends LabelOption {
+    width?: number
+}
 
 export interface TitleOption extends ComponentOption, BoxLayoutOptionMixin, BorderOptionMixin {
 
@@ -75,9 +78,9 @@ export interface TitleOption extends ComponentOption, BoxLayoutOptionMixin, Bord
      */
     itemGap?: number
 
-    textStyle?: LabelOption
+    textStyle?: TitleTextStyleOption
 
-    subtextStyle?: LabelOption
+    subtextStyle?: TitleTextStyleOption
 
     /**
      * If trigger mouse or touch event


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Title text style type should not include string.

doc:

![image](https://github.com/user-attachments/assets/e3e48d2c-d65a-42f9-a923-0d2cb1262894)

ts:

![image](https://github.com/user-attachments/assets/6c50c328-ae1f-4f52-902f-472be0aec8b5)




### Fixed issues

#20799 

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
