### PR TITLE
fix(dataZoom): restrict range on brushEnd

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -994,20 +994,24 @@ class SliderZoomView extends DataZoomView {
         const viewExtend = this._getViewExtent();
         const percentExtent = [0, 100];
 
-        this._range = asc([
-            linearMap(brushShape.x, viewExtend, percentExtent, true),
-            linearMap(brushShape.x + brushShape.width, viewExtend, percentExtent, true)
-        ]);
-
-        // Restrict range.
+        const handleEnds = this._handleEnds = [brushShape.x, brushShape.x + brushShape.width];
         const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
+        // Restrict range.
+        sliderMove(
+            0,
+            handleEnds,
+            viewExtend,
+            0,
+            minMaxSpan.minSpan != null
+                ? linearMap(minMaxSpan.minSpan, percentExtent, viewExtend, true) : null,
+            minMaxSpan.maxSpan != null
+                ? linearMap(minMaxSpan.maxSpan, percentExtent, viewExtend, true) : null
+        );
 
-        sliderMove(0, this._range, viewExtend, 0, minMaxSpan.minSpan, minMaxSpan.maxSpan);
-
-        this._handleEnds = [
-            linearMap(this._range[0], [0, 100], viewExtend, true),
-            linearMap(this._range[1], [0, 100], viewExtend, true)
-        ];
+        this._range = asc([
+            linearMap(handleEnds[0], viewExtend, percentExtent, true),
+            linearMap(handleEnds[1], viewExtend, percentExtent, true)
+        ]);
 
         this._updateView();
 

--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -999,7 +999,15 @@ class SliderZoomView extends DataZoomView {
             linearMap(brushShape.x + brushShape.width, viewExtend, percentExtent, true)
         ]);
 
-        this._handleEnds = [brushShape.x, brushShape.x + brushShape.width];
+        // Restrict range.
+        const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
+
+        sliderMove(0, this._range, viewExtend, 0, minMaxSpan.minSpan, minMaxSpan.maxSpan);
+
+        this._handleEnds = [
+            linearMap(this._range[0], [0, 100], viewExtend, true),
+            linearMap(this._range[1], [0, 100], viewExtend, true)
+        ];
 
         this._updateView();
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

- minMaxSpan could restrict brushSelect



### Fixed issues

fixed #20807 
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![2025-03-10 18-04-41 2025-03-10 18_05_03](https://github.com/user-attachments/assets/9f77d8b5-74df-48d8-9c75-646a0208a242)




### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

![2025-03-10 18-03-17 2025-03-10 18_03_47](https://github.com/user-attachments/assets/14c48506-2322-43c3-b815-9efd6afa3258)




## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
