### PR TITLE
fix 20813 for custom charts added an option to use legend by category…

### DIFF
--- a/src/chart/custom/CustomSeries.ts
+++ b/src/chart/custom/CustomSeries.ts
@@ -74,6 +74,9 @@ import {
 import { TransformProp } from 'zrender/src/core/Transformable';
 import { ElementKeyframeAnimationOption } from '../../animation/customGraphicKeyframeAnimation';
 
+import * as zrUtil from 'zrender/src/core/util';
+import LegendVisualProvider from '../../visual/LegendVisualProvider';
+
 export type CustomExtraElementInfo = Dictionary<unknown>;
 
 // Also compat with ec4, where
@@ -329,6 +332,7 @@ export interface CustomSeriesOption extends
     SeriesOnCalendarOptionMixin {
 
     type?: 'custom'
+    useLegendByCategory?: boolean;
 
     // If set as 'none', do not depends on coord sys.
     coordinateSystem?: string | 'none';
@@ -375,6 +379,21 @@ export const customInnerStore = makeInner<{
 export default class CustomSeriesModel extends SeriesModel<CustomSeriesOption> {
 
     static type = 'series.custom';
+    /**
+     * @overwrite
+     */
+    init(option: CustomSeriesOption): void {
+        super.init.apply(this, arguments as any);
+
+        if (option.useLegendByCategory) {
+            // Enable legend selection for each data item
+            // Use a function instead of direct access because data reference may changed
+            this.legendVisualProvider = new LegendVisualProvider(
+                zrUtil.bind(this.getData, this), zrUtil.bind(this.getRawData, this)
+            );
+        }
+    }
+
     readonly type = CustomSeriesModel.type;
 
     static dependencies = ['grid', 'polar', 'geo', 'singleAxis', 'calendar'];


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

by default each charts creates legend by series. pie and funnel chart creates legend data by category names instead each serie. for custom chart added a condition to use legend same pie charts instead default serie based legend.



### Fixed issues

- #20813 


## Details

### Before: What was the problem?

I couldn't change the default behaviour of legend

![Screenshot from 2025-03-14 12-20-30](https://github.com/user-attachments/assets/4dd9c088-330c-4b5e-be19-7d21dbd4145e)




### After: How does it behave after the fixing?

with using useLegendByCategory prop I can use legend like pie charts, depends on category name with one series.

![Screenshot from 2025-03-14 12-30-11](https://github.com/user-attachments/assets/9674d3e8-8b18-4d76-aad4-95cb6415d455)




## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
