### PR TITLE
dataZoom inside with option pinned 'start' 'end'

### DIFF
--- a/src/component/dataZoom/DataZoomModel.ts
+++ b/src/component/dataZoom/DataZoomModel.ts
@@ -579,12 +579,13 @@ class DataZoomModel<Opts extends DataZoomOption = DataZoomOption> extends Compon
 /**
  * Retrieve those raw params from option, which will be cached separately,
  * because they will be overwritten by normalized/calculated values in the main
- * process.
+ * process. Get parameter 'anchor' to add option to pin the chart to 'start' or
+ # 'ene' while using default dataZoom
  */
 function retrieveRawOption<T extends DataZoomOption>(option: T) {
     const ret = {} as T;
     each(
-        ['start', 'end', 'startValue', 'endValue', 'throttle'] as const,
+        ['start', 'end', 'startValue', 'endValue', 'throttle', 'anchor'] as const,
         function (name) {
             option.hasOwnProperty(name) && ((ret as any)[name] = option[name]);
         }

--- a/src/component/dataZoom/InsideZoomView.ts
+++ b/src/component/dataZoom/InsideZoomView.ts
@@ -114,9 +114,14 @@ const getRangeHandlers: {
             ) / directionInfo.pixelLength * (range[1] - range[0]) + range[0];
 
         const scale = Math.max(1 / e.scale, 0);
-        range[0] = (range[0] - percentPoint) * scale + percentPoint;
-        range[1] = (range[1] - percentPoint) * scale + percentPoint;
-
+// add logic to pin the dataZoom to 'end' or 'start'
+        var anchor = this.__model?.option?.anchor || null;
+        if (anchor !== 'start') { // pin zoom to left side of the X axis viewBox
+            range[0] = (range[0] - percentPoint) * scale + percentPoint;
+        }
+        if (anchor !== 'end') { // pin zoom to the right side of the X axis viewBox
+            range[1] = (range[1] - percentPoint) * scale + percentPoint;
+        }
         // Restrict range.
         const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
 


### PR DESCRIPTION
example: option {
  dataZoom: [
    {
      type: 'inside',
      xAxisIndex: [0, 1],
      start: 10,
      end: 100,
      anchor: 'end',  // acceptable values 'start', 'end'
    },

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x ] new feature
- [ ] others



### What does this PR do?

during dataZoom type 'inside' optionally pins the zoom feature to 'start' or 'end' of chart



### Fixed issues

<!--
not applicable - new feature
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
