### PR TITLE
feat(axis): support dataMin/dataMax to calc a nice axis range

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -116,6 +116,20 @@ export interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {
      * Will be ignored if interval is set.
      */
     alignTicks?: boolean
+
+    /**
+     * Data min value to be included in axis extent calculation.
+     * The final min value will be the minimum of this value and the data min.
+     * Only works for value axis.
+     */
+    dataMin?: ScaleDataValue;
+
+    /**
+     * Data max value to be included in axis extent calculation.
+     * The final max value will be the maximum of this value and the data max.
+     * Only works for value axis.
+     */
+    dataMax?: ScaleDataValue;
 }
 
 export interface CategoryAxisBaseOption extends AxisBaseOptionCommon {

--- a/src/coord/scaleRawExtentInfo.ts
+++ b/src/coord/scaleRawExtentInfo.ts
@@ -21,7 +21,7 @@ import { assert, isArray, eqNaN, isFunction } from 'zrender/src/core/util';
 import Scale from '../scale/Scale';
 import { AxisBaseModel } from './AxisBaseModel';
 import { parsePercent } from 'zrender/src/contain/text';
-import { AxisBaseOption, CategoryAxisBaseOption } from './axisCommonTypes';
+import { AxisBaseOption, CategoryAxisBaseOption, NumericAxisBaseOptionCommon } from './axisCommonTypes';
 import { ScaleDataValue } from '../util/types';
 
 
@@ -69,6 +69,11 @@ export class ScaleRawExtentInfo {
     // Make that the `rawExtentInfo` can not be modified any more.
     readonly frozen: boolean;
 
+    // custom dataMin/dataMax
+    private _dataMinRaw: ScaleDataValue;
+    private _dataMaxRaw: ScaleDataValue;
+    private _dataMinNum: number;
+    private _dataMaxNum: number;
 
     constructor(
         scale: Scale,
@@ -97,6 +102,19 @@ export class ScaleRawExtentInfo {
 
         const isOrdinal = this._isOrdinal = scale.type === 'ordinal';
         this._needCrossZero = scale.type === 'interval' && model.getNeedCrossZero && model.getNeedCrossZero();
+
+        if (scale.type === 'interval' || scale.type === 'log') {
+            // Process custom dataMin/dataMax
+            this._dataMinRaw = (model as AxisBaseModel<NumericAxisBaseOptionCommon>).get('dataMin', true);
+            if (this._dataMinRaw != null) {
+                this._dataMinNum = parseAxisModelMinMax(scale, this._dataMinRaw);
+            }
+
+            this._dataMaxRaw = (model as AxisBaseModel<NumericAxisBaseOptionCommon>).get('dataMax', true);
+            if (this._dataMaxRaw != null) {
+                this._dataMaxNum = parseAxisModelMinMax(scale, this._dataMaxRaw);
+            }
+        }
 
         let axisMinValue = model.get('min', true);
         if (axisMinValue == null) {
@@ -173,8 +191,20 @@ export class ScaleRawExtentInfo {
         // (3) If no data, it should be ensured that `scale.setBlank` is set.
 
         const isOrdinal = this._isOrdinal;
-        const dataMin = this._dataMin;
-        const dataMax = this._dataMax;
+        let dataMin = this._dataMin;
+        let dataMax = this._dataMax;
+
+        // Include custom dataMin/dataMax in calculation
+        // If dataMin is set and less than current data minimum, update the minimum value
+        if (this._dataMinNum != null && isFinite(dataMin) && this._dataMinNum < dataMin) {
+            dataMin = this._dataMinNum;
+        }
+
+        // If dataMax is set and greater than current data maximum, update the maximum value
+        if (this._dataMaxNum != null && isFinite(dataMax) && this._dataMaxNum > dataMax) {
+            dataMax = this._dataMaxNum;
+        }
+
         const axisDataLen = this._axisDataLen;
         const boundaryGapInner = this._boundaryGapInner;
 

--- a/test/axis-data-min-max.html
+++ b/test/axis-data-min-max.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+        .chart {
+            height: 350px;
+            margin: 20px 0;
+        }
+    </style>
+
+    <div id="main0" class="chart"></div>
+    <div id="main1" class="chart"></div>
+    <div id="main2" class="chart"></div>
+    <div id="main3" class="chart"></div>
+    <div id="main4" class="chart"></div>
+    <div id="main5" class="chart"></div>
+    <div id="main6" class="chart"></div>
+    <div id="main7" class="chart"></div>
+    <div id="main8" class="chart"></div>
+
+    <script>
+        require(['echarts'], function (echarts) {
+            // Basic data
+            var baseData = [820, 932, 901, 934, 1290, 1330, 1320];
+            var days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+            // Data with negative values
+            var negativeData = [120, -132, 201, -234, 290, -330, 320];
+
+            // Log axis data (must be positive)
+            var logData = [5, 20, 36, 100, 500, 1200, 3500];
+
+            // Test 1: Basic dataMax usage (dataMax > actual data maximum)
+            var chart1 = testHelper.create(echarts, 'main0', {
+                title: 'dataMax > actual data',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        dataMax: 1555, // Greater than actual data maximum 1330
+                    },
+                    series: [
+                        {
+                            data: baseData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 2: dataMax < actual data maximum (should not affect range)
+            var chart2 = testHelper.create(echarts, 'main1', {
+                title: 'dataMax < actual data (no effect on range)',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        dataMax: 1000, // Less than actual data maximum 1330, should not affect
+                    },
+                    series: [
+                        {
+                            data: baseData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 3: Negative data + dataMin usage (dataMin < actual data minimum)
+            var chart3 = testHelper.create(echarts, 'main2', {
+                title: 'Negative data + dataMin < actual data',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        dataMin: -500, // Less than actual data minimum -330
+                    },
+                    series: [
+                        {
+                            data: negativeData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 4: Negative data + dataMin > actual data minimum (should not affect range)
+            var chart4 = testHelper.create(echarts, 'main3', {
+                title: 'Negative data + dataMin > actual data (no effect on range)',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        dataMin: -100, // Greater than actual data minimum -330, should not affect
+                    },
+                    series: [
+                        {
+                            data: negativeData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 5: Negative data + using both dataMin and dataMax
+            var chart5 = testHelper.create(echarts, 'main4', {
+                title: 'Negative data + using both dataMin and dataMax',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        dataMin: -500,
+                        dataMax: 500,
+                    },
+                    series: [
+                        {
+                            data: negativeData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 6: Comparing with min/max properties
+            var chart6 = testHelper.create(echarts, 'main5', {
+                title: 'min/max vs dataMin/dataMax (negative data)',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'value',
+                        min: -500,
+                        max: 500,
+                    },
+                    series: [
+                        {
+                            data: negativeData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 7: Using dataMin/dataMax on category axis (should have no effect)
+            var chart7 = testHelper.create(echarts, 'main6', {
+                title: 'dataMin/dataMax on category axis (no effect)',
+                option: {
+                    yAxis: {
+                        type: 'category',
+                        data: days,
+                        dataMin: 2, // No effect on category axis
+                        dataMax: 5, // No effect on category axis
+                    },
+                    xAxis: {
+                        type: 'value'
+                    },
+                    series: [
+                        {
+                            data: negativeData,
+                            type: 'bar'
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 8: Log axis + dataMin usage
+            var chart8 = testHelper.create(echarts, 'main7', {
+                title: 'Log axis + dataMin usage',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'log',
+                        dataMin: 0.5, // Using a smaller fraction, much less than actual data minimum 5
+                    },
+                    series: [
+                        {
+                            data: logData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+
+            // Test 9: Log axis + dataMax usage
+            var chart9 = testHelper.create(echarts, 'main8', {
+                title: 'Log axis + dataMax usage',
+                option: {
+                    xAxis: {
+                        type: 'category',
+                        data: days
+                    },
+                    yAxis: {
+                        type: 'log',
+                        dataMax: 100000, // Greater than actual data maximum 3500
+                    },
+                    series: [
+                        {
+                            data: logData,
+                            type: 'line',
+                            smooth: true
+                        }
+                    ],
+                    tooltip: {
+                        trigger: 'axis'
+                    }
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add `dataMin` and `dataMax` properties for value axes to extend the axis range while preserving nice scale algorithm.

### Fixed issues

<!--
- #xxxx: ...
-->
- #20770

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

Currently, ECharts provides two ways to set axis range:
1. Let ECharts auto-calculate nice values by default
1. Use `min`/`max` to set fixed values, but this disables the nice scale algorithm

There was no way to ensure a specific data point would be included in the axis range while still benefiting from the nice scale algorithm.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

With the new `dataMin`/`dataMax` properties, users can:
- Specify values that should be included in the axis range
- Only affect the range if the specified value extends beyond the actual data range
- Still benefit from ECharts' nice scale algorithm for rounding values

These properties are only effective for value axes (`value`, `log`) and have no effect on category axes.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Test cases have been included in `test/axis-data-min-max.html` to verify different scenarios including:
- Basic usage with standard value axes
- Scenarios with negative values
- Usage with log axes
- Verification that they don't affect category axes

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information 
