### PR TITLE
fix(handleIcon): unexpected aspect ratio of handleIcon

### DIFF
--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -81,6 +81,7 @@ import {
  */
 export {updateProps, initProps, removeElement, removeElementWithFadeOut, isElementRemoved};
 
+/* global Image */
 
 const mathMax = Math.max;
 const mathMin = Math.min;
@@ -191,6 +192,10 @@ export function makeImage(
     rect: ZRRectLike,
     layout?: 'center' | 'cover'
 ) {
+    const resizeZRImg = (width: number, height:number) => {
+        const boundingRect = { width, height };
+        zrImg.setStyle(centerGraphic(rect, boundingRect));
+    };
     const zrImg = new ZRImage({
         style: {
             image: imageUrl,
@@ -201,14 +206,16 @@ export function makeImage(
         },
         onload(img) {
             if (layout === 'center') {
-                const boundingRect = {
-                    width: img.width,
-                    height: img.height
-                };
-                zrImg.setStyle(centerGraphic(rect, boundingRect));
+                resizeZRImg(img.width, img.height);
             }
         }
     });
+    if (layout === 'center') {
+        const img = new Image();
+        img.onload = () => resizeZRImg(img.width, img.height);
+        img.src = imageUrl;
+        resizeZRImg(img.width, img.height);
+    }
     return zrImg;
 }
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
The issue #18444 mentioned that when the handleIcon is customized as an image dataUrl, it becomes stretched when `setOption` or `resize` is called again. This issue was closed by author because the phenomenon did not occur when the custom handleIcon had equal width and height. However, I believe it's important to support images with an aspect ratio other than 1:1, so I made some modifications to handle that.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

This is a link to minimal reproduction:
https://stackblitz.com/edit/stackblitz-starters-whzflubq?file=index.html
In this example, the handleIcon is customized using a dataURL, and its aspect ratio is not 1:1.
1. Observe the aspect ratio of handleIcon when setOption is called for the first time:
 ![image](https://github.com/user-attachments/assets/8f7c592f-23f9-4e63-97a4-c0d91fec45e9)
2. Two seconds later, when setOption is called again, it is easy to observe that the aspect ratio of the handleIcon has changed:
 ![image](https://github.com/user-attachments/assets/d46f87f1-4505-423a-a558-309977a9efea)



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

In `./src/graphic.ts`, an `onload` callback is passed when creating a `ZRImage`, which calibrates the image's aspect ratio and is triggered only during the first rendering of the chart. Therefore, I appended an additional calibration step after creating `ZRImage`. I used a new `Image` object to load the dataURL and obtain the accurate dimensions of the image. Normally, the image dimensions are obtained via the `onload` callback, but this will cause the rendered image size to fluctuate:
![001](https://github.com/user-attachments/assets/888bf6a9-14da-4433-88c8-12f7a9fc1289)
I discovered that if the dataURL has been loaded before, the image dimensions can often be retrieved synchronously from cache. In such cases, I perform the aspect ratio calibration synchronously. However, since I'm not certain all browsers support this caching behavior reliably, I repeated the calibration within the onload callback to ensure that the obtained dimensions are ultimately accurate.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
