### PR TITLE
fix(bar): remove unused `startValue` option from the `BarSeriesOption` interface

### DIFF
--- a/src/chart/bar/BarSeries.ts
+++ b/src/chart/bar/BarSeries.ts
@@ -81,8 +81,6 @@ export interface BarSeriesOption
 
     showBackground?: boolean
 
-    startValue?: number
-
     backgroundStyle?: ItemStyleOption & {
         borderRadius?: number | number[]
     }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others

### What does this PR do?

Fix https://github.com/apache/echarts/pull/17078#discussion_r1648347405 by removing the unused `startValue` option from the `BarSeriesOption` interface. This option is for the axis rather than the bar series.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
