### PR TITLE
fix(pie): fix labelLine may be not removed and cause error when single label position is not in outside

### DIFF
--- a/src/chart/pie/PieView.ts
+++ b/src/chart/pie/PieView.ts
@@ -205,7 +205,7 @@ class PiePiece extends graphic.Sector {
             z2: 10
         });
 
-        const labelPosition = seriesModel.get(['label', 'position']);
+        const labelPosition = itemModel.get(['label', 'position']);
         if (labelPosition !== 'outside' && labelPosition !== 'outer') {
             sector.removeTextGuideLine();
         }

--- a/test/pie-label.html
+++ b/test/pie-label.html
@@ -734,9 +734,29 @@ under the License.
                             name: '访问来源1',
                             type: 'pie',
                             radius: '50%',
+                            center: ['50%', '50%'],
+                            data: [
+                                { value: 1, name: '搜索引擎' },
+                            ],
+                            emphasis: {
+                                itemStyle: {
+                                    shadowBlur: 10,
+                                    shadowOffsetX: 0,
+                                    shadowColor: 'rgba(0, 0, 0, 0.5)'
+                                }
+                            },
+                            label: {
+                                position: 'outside'
+                            }
+                        },
+                        {
+                            name: '访问来源3',
+                            type: 'pie',
+                            radius: '50%',
                             center: ['75%', '50%'],
                             data: [
                                 { value: 1, name: '搜索引擎' },
+                                { value: 1, name: '直接访问', label: { position: 'inside' } },
                             ],
                             emphasis: {
                                 itemStyle: {
@@ -768,12 +788,41 @@ under the License.
                     chart.setOption(option);
                 }, 6000);
 
+                setTimeout(() => {
+                    option.series[2].data[0].label = { position: 'inside' };
+                    chart.setOption(option);
+                }, 100);
+
                 var chart = testHelper.create(echarts, 'main8', {
-                    title: 'labelLine should be hidden when position is not \'outside\'',
+                    title: [
+                        'labelLine should be **HIDDEN** when position is not \'outside\'',
+                        // https://github.com/apache/echarts/issues/20904
+                        // https://github.com/apache/echarts/issues/20905
+                        'The item **\'直接访问\'** of the third chart **SHOULD NOT** display labelLine'
+                    ],
                     height: 300,
                     option: option
                 });
-
+                // should have no error in SVG renderer
+                try {
+                    const dataUrl = chart.getDataURL()
+                    // console.log(dataUrl)
+                } catch (e) {
+                    console.error(e.stack)
+                    chart.setOption({
+                        title: {
+                            right: 10,
+                            top: 10,
+                            text: 'ERROR: ' + e.toString(),
+                            textStyle: {
+                                width: 250,
+                                color: 'red',
+                                fontWeight: 'bold',
+                                overflow: 'break'
+                            }
+                        }
+                    })
+                }
             });
         </script>
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

This fixes an error introduced in #14017, which gets label position from series model rather than data item model.

### Fixed issues

- Resolves #20904
- Resolves #20905

## Comparison

![image](https://github.com/user-attachments/assets/d1deb1bc-4997-4c78-aa0e-e65a045866e4)

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Please refer to the 9th test case in `test/pie-label.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
