### PR TITLE
fix(visualMap): fix some text style can't work on visualMap

### DIFF
--- a/src/component/visualMap/ContinuousView.ts
+++ b/src/component/visualMap/ContinuousView.ts
@@ -191,8 +191,10 @@ class ContinuousView extends VisualMapView {
             style: createTextStyle(textStyleModel, {
                 x: position[0],
                 y: position[1],
-                verticalAlign: orient === 'horizontal' ? 'middle' : align as TextVerticalAlign,
-                align: orient === 'horizontal' ? align as TextAlign : 'center',
+                verticalAlign: textStyleModel.get('verticalAlign')
+                    || (orient === 'horizontal' ? 'middle' : align as TextVerticalAlign),
+                align: textStyleModel.get('align')
+                    || (orient === 'horizontal' ? align as TextAlign : 'center'),
                 text
             })
         }));

--- a/src/component/visualMap/PiecewiseView.ts
+++ b/src/component/visualMap/PiecewiseView.ts
@@ -44,8 +44,6 @@ class PiecewiseVisualMapView extends VisualMapView {
         const visualMapModel = this.visualMapModel;
         const textGap = visualMapModel.get('textGap');
         const textStyleModel = visualMapModel.textStyleModel;
-        const textFont = textStyleModel.getFont();
-        const textFill = textStyleModel.getTextColor();
         const itemAlign = this._getItemAlign();
         const itemSize = visualMapModel.itemSize;
         const viewData = this._getViewData();
@@ -75,16 +73,17 @@ class PiecewiseVisualMapView extends VisualMapView {
             if (showLabel) {
                 const visualState = this.visualMapModel.getValueState(representValue);
                 itemGroup.add(new graphic.Text({
-                    style: {
+                    style: createTextStyle(textStyleModel, {
                         x: itemAlign === 'right' ? -textGap : itemSize[0] + textGap,
                         y: itemSize[1] / 2,
                         text: piece.text,
-                        verticalAlign: 'middle',
-                        align: itemAlign as TextAlign,
-                        font: textFont,
-                        fill: textFill,
-                        opacity: visualState === 'outOfRange' ? 0.5 : 1,
-                    },
+                        verticalAlign: textStyleModel.get('verticalAlign') || 'middle',
+                        align: textStyleModel.get('align') || itemAlign as TextAlign,
+                        opacity: zrUtil.retrieve2(
+                            textStyleModel.get('opacity'),
+                            visualState === 'outOfRange' ? 0.5 : 1
+                        ),
+                    }),
                     silent
                 }));
             }

--- a/src/component/visualMap/PiecewiseView.ts
+++ b/src/component/visualMap/PiecewiseView.ts
@@ -72,13 +72,14 @@ class PiecewiseVisualMapView extends VisualMapView {
 
             if (showLabel) {
                 const visualState = this.visualMapModel.getValueState(representValue);
+                const align = textStyleModel.get('align') || itemAlign as TextAlign;
                 itemGroup.add(new graphic.Text({
                     style: createTextStyle(textStyleModel, {
-                        x: itemAlign === 'right' ? -textGap : itemSize[0] + textGap,
+                        x: align === 'right' ? -textGap : itemSize[0] + textGap,
                         y: itemSize[1] / 2,
                         text: piece.text,
                         verticalAlign: textStyleModel.get('verticalAlign') || 'middle',
-                        align: textStyleModel.get('align') || itemAlign as TextAlign,
+                        align,
                         opacity: zrUtil.retrieve2(
                             textStyleModel.get('opacity'),
                             visualState === 'outOfRange' ? 0.5 : 1

--- a/test/visualMap-pieces.html
+++ b/test/visualMap-pieces.html
@@ -93,14 +93,19 @@ under the License.
                             {min: 10, max: 200, label: '10 到 200（自定义label）'},
                             {value: 123, label: '123（自定义特殊颜色）', color: 'grey'},
                             {min: 5, max: 5, label: '5（自定义特殊颜色）', color: 'black'},
-                            {max: 5}
+                            {max: 5, label: '< 5 （测试文本溢出测试文本溢出测试文本溢出）'}
                         ],
                         color: ['#E0022B', '#E09107', '#A3E00B'],
                         textStyle: {
                             textShadowColor: "rgba(255, 0, 255, 1)",
                             textShadowBlur: 5,
                             textShadowOffsetX: 5,
-                            textShadowOffsetY: 5
+                            textShadowOffsetY: 5,
+                            width: 200,
+                            overflow: 'truncate',
+                            // opacity: 0,
+                            // align: 'left',
+                            // verticalAlign: 'top'
                         }
                     },
                     toolbox: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix some text style (`width/overflow/align/verticalAlign...`) can't work on visualMap (piecewise & continuous). This PR also improves the previous fix in #16679.

### Fixed issues

- Resolves #20956
- Resolves #18882
- Resolves #15644

## Details

### Before: What was the problem?

![image](https://github.com/user-attachments/assets/214d0303-9b57-4a16-828d-9b3866e99416)

### After: How does it behave after the fixing?

![image](https://github.com/user-attachments/assets/b64a2e5e-ea8f-4759-8e75-40b61d2c9e1a)


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

See `test/visualMap-pieces.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
