### PR TITLE
fix(legend): Fix legend text overflow and improve layout handling

### DIFF
--- a/src/component/legend/LegendView.ts
+++ b/src/component/legend/LegendView.ts
@@ -130,14 +130,14 @@ class LegendView extends ComponentView {
             selectorPosition = orient === 'horizontal' ? 'end' : 'start';
         }
 
-        this.renderInner(itemAlign, legendModel, ecModel, api, selector, orient, selectorPosition);
-
         // Perform layout.
         const positionInfo = legendModel.getBoxLayoutParams();
         const viewportSize = {width: api.getWidth(), height: api.getHeight()};
         const padding = legendModel.get('padding');
 
         const maxSize = layoutUtil.getLayoutRect(positionInfo, viewportSize, padding);
+
+        this.renderInner(itemAlign, legendModel, ecModel, api, selector, orient, selectorPosition, maxSize);
 
         const mainRect = this.layoutInner(legendModel, itemAlign, maxSize, isFirstRender, selector, selectorPosition);
 
@@ -173,7 +173,8 @@ class LegendView extends ComponentView {
         api: ExtensionAPI,
         selector: LegendSelectorButtonOption[],
         orient: LegendOption['orient'],
-        selectorPosition: LegendOption['selectorPosition']
+        selectorPosition: LegendOption['selectorPosition'],
+        maxSize: layoutUtil.LayoutRect,
     ) {
         const contentGroup = this.getContentGroup();
         const legendDrawnMap = zrUtil.createHashMap();
@@ -221,7 +222,8 @@ class LegendView extends ComponentView {
                 const itemGroup = this._createItem(
                     seriesModel, name, dataIndex,
                     legendItemModel, legendModel, itemAlign,
-                    lineVisualStyle, style, legendIcon, selectMode, api
+                    lineVisualStyle, style, legendIcon, selectMode, api,
+                    maxSize,
                 );
 
                 itemGroup.on('click', curry(dispatchSelectAction, name, null, api, excludeSeriesId))
@@ -276,7 +278,8 @@ class LegendView extends ComponentView {
                         const itemGroup = this._createItem(
                             seriesModel, name, dataIndex,
                             legendItemModel, legendModel, itemAlign,
-                            {}, style, legendIcon, selectMode, api
+                            {}, style, legendIcon, selectMode, api,
+                            maxSize,
                         );
 
                         // FIXME: consider different series has items with the same name.
@@ -387,7 +390,8 @@ class LegendView extends ComponentView {
         itemVisualStyle: PathStyleProps,
         legendIcon: string,
         selectMode: LegendOption['selectedMode'],
-        api: ExtensionAPI
+        api: ExtensionAPI,
+        maxSize: layoutUtil.LayoutRect,
     ) {
         const drawType = seriesModel.visualDrawType;
         const itemWidth = legendModel.get('itemWidth');
@@ -469,7 +473,8 @@ class LegendView extends ComponentView {
                 y: itemHeight / 2,
                 fill: textColor,
                 align: textAlign,
-                verticalAlign: 'middle'
+                verticalAlign: 'middle',
+                width: maxSize.width - textX,
             }, {inheritColor: textColor})
         }));
 

--- a/src/component/legend/ScrollableLegendView.ts
+++ b/src/component/legend/ScrollableLegendView.ts
@@ -114,12 +114,13 @@ class ScrollableLegendView extends LegendView {
         api: ExtensionAPI,
         selector: LegendSelectorButtonOption[],
         orient: ScrollableLegendOption['orient'],
-        selectorPosition: ScrollableLegendOption['selectorPosition']
+        selectorPosition: ScrollableLegendOption['selectorPosition'],
+        maxSize: layoutUtil.LayoutRect,
     ) {
         const self = this;
 
         // Render content items.
-        super.renderInner(itemAlign, legendModel, ecModel, api, selector, orient, selectorPosition);
+        super.renderInner(itemAlign, legendModel, ecModel, api, selector, orient, selectorPosition, maxSize);
 
         const controllerGroup = this._controllerGroup;
 

--- a/test/legend-overflow.html
+++ b/test/legend-overflow.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+    </style>
+
+
+    <div id="main0"></div>
+
+
+    <script>
+        require(['echarts'], function (echarts) {
+            const firstColumnWidth = 128;
+            const option = {
+                grid: {
+                    left: firstColumnWidth,
+                },
+                legend: {
+                    data: [
+                        'Email Marketing', 'Affiliate Advertising', 'Video Advertising',
+                        'Direct Access', 'Search Engine',
+                        'Email Marketing 11111111', 'Affiliate Advertising 11111111',
+                        'Video Advertising 11111111', 'Direct Access 11111111', 'Search Engine 11111111'
+                    ],
+                    orient: 'vertical',
+                    left: 0,
+                    width: firstColumnWidth,
+                    textStyle: {
+                      overflow: 'break',
+                    },
+                },
+                xAxis: [{
+                    type: 'category',
+                    data: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+                    axisLabel: {
+                        rotate: 45,
+                        position: 'middle',
+                    },
+                    axisTick: {
+                        show: false,
+                    },
+                }],
+                yAxis: [{
+                    type: 'value',
+                    position: 'right',
+                }],
+                series: [
+                    {
+                        name: 'Email Marketing',
+                        type: 'line',
+                        data: [120, 132, 101, 134, 90, 230, 210],
+                    },
+                    {
+                        name: 'Affiliate Advertising',
+                        type: 'line',
+                        data: [220, 182, 191, 234, 290, 330, 310],
+                    },
+                    {
+                        name: 'Video Advertising',
+                        type: 'line',
+                        data: [150, 232, 201, 154, 190, 330, 410],
+                    },
+                    {
+                        name: 'Direct Access',
+                        type: 'line',
+                        data: [320, 332, 301, 334, 390, 330, 320],
+                    },
+                    {
+                        name: 'Search Engine',
+                        type: 'line',
+                        data: [820, 932, 901, 934, 1290, 1330, 1320],
+                    },
+                    {
+                        name: 'Email Marketing 11111111',
+                        type: 'line',
+                        data: [620, 732, 701, 734, 890, 930, 920],
+                    },
+                    {
+                        name: 'Affiliate Advertising 11111111',
+                        type: 'line',
+                        data: [120, 132, 101, 134, 90, 230, 210],
+                    },
+                    {
+                        name: 'Video Advertising 11111111',
+                        type: 'line',
+                        data: [220, 182, 191, 234, 290, 330, 310],
+                    },
+                    {
+                        name: 'Direct Access 11111111',
+                        type: 'line',
+                        data: [150, 232, 201, 154, 190, 330, 410],
+                    },
+                    {
+                        name: 'Search Engine 11111111',
+                        type: 'line',
+                        data: [320, 332, 301, 334, 390, 330, 320],
+                    },
+                ],
+
+            };
+            const chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Test Case Description of main0',
+                    'Legend text overflow should be handled correctly.'
+                ],
+                option: option,
+                width: 480,
+            });
+            chart.setOption(option);
+        });
+    </script>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Improve the overall user experience by ensuring legends are displayed properly, avoiding overflow issues with lengthy item labels or limited space. 

Additionally, a new test has been provided to demonstrate and verify the changes by comparing the behavior before and after applying the changes.


### Fixed issues

- #20237: [Bug] Plain legend label overflows container if text is too long


## Details

### Before: What was the problem?

The legend has a width of 128px and the overflow is configured to break words, but it doesn't do anything.

![image](https://github.com/user-attachments/assets/4e9d438a-5d7b-44c6-a06e-9215f015e941)


### After: How does it behave after the fixing?

The legend item text overflow is working correctly.

![image](https://github.com/user-attachments/assets/d6cc9050-2b30-47cc-841e-a4a6c8c9b145)



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- test/legend-overflow.html



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
