### PR TITLE
feat(stack): able to reverse the stack order

### DIFF
--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -69,15 +69,31 @@ export default function dataStack(ecModel: GlobalModel) {
                 return;
             }
 
-            stackInfoList.length && data.setCalculationInfo(
-                'stackedOnSeries', stackInfoList[stackInfoList.length - 1].seriesModel
-            );
-
             stackInfoList.push(stackInfo);
         }
     });
 
-    stackInfoMap.each(calculateStack);
+    // Process each stack group
+    stackInfoMap.each(function (stackInfoList) {
+        // Check if stack order needs to be reversed
+        const firstSeries = stackInfoList[0].seriesModel;
+        const stackOrder = firstSeries.get('stackOrder');
+
+        if (stackOrder === 'reverse') {
+            stackInfoList.reverse();
+        }
+
+        // Set stackedOnSeries for each series in the final order
+        each(stackInfoList, function (stackInfo, index) {
+            stackInfo.data.setCalculationInfo(
+                'stackedOnSeries',
+                index > 0 ? stackInfoList[index - 1].seriesModel : null
+            );
+        });
+
+        // Calculate stack values
+        calculateStack(stackInfoList);
+    });
 }
 
 function calculateStack(stackInfoList: StackInfo[]) {

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -75,11 +75,14 @@ export default function dataStack(ecModel: GlobalModel) {
 
     // Process each stack group
     stackInfoMap.each(function (stackInfoList) {
+        if (stackInfoList.length === 0) {
+            return;
+        }
         // Check if stack order needs to be reversed
         const firstSeries = stackInfoList[0].seriesModel;
-        const stackOrder = firstSeries.get('stackOrder');
+        const stackOrder = firstSeries.get('stackOrder') || 'seriesAsc';
 
-        if (stackOrder === 'reverse') {
+        if (stackOrder === 'seriesDesc') {
             stackInfoList.reverse();
         }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1679,6 +1679,7 @@ export interface SeriesLargeOptionMixin {
 export interface SeriesStackOptionMixin {
     stack?: string
     stackStrategy?: 'samesign' | 'all' | 'positive' | 'negative';
+    stackOrder?: 'normal' | 'reverse';
 }
 
 type SamplingFunc = (frame: ArrayLike<number>) => number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1679,7 +1679,7 @@ export interface SeriesLargeOptionMixin {
 export interface SeriesStackOptionMixin {
     stack?: string
     stackStrategy?: 'samesign' | 'all' | 'positive' | 'negative';
-    stackOrder?: 'normal' | 'reverse';
+    stackOrder?: 'seriesAsc' | 'seriesDesc'; // default: seriesAsc
 }
 
 type SamplingFunc = (frame: ArrayLike<number>) => number;

--- a/test/bar-stack-reverse.html
+++ b/test/bar-stack-reverse.html
@@ -120,13 +120,13 @@
                     ],
                     series: [
                         // Normal order
-                        { name: 'Series 1', type: 'bar', stack: 'stack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 2', type: 'bar', stack: 'stack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 3', type: 'bar', stack: 'stack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 1', type: 'bar', stack: 'stack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'stack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'stack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
                         // Reverse order
-                        { name: 'Series 1', type: 'bar', stack: 'stack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 2', type: 'bar', stack: 'stack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 3', type: 'bar', stack: 'stack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
+                        { name: 'Series 1', type: 'bar', stack: 'stack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'stack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'stack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } }
                     ]
                 };
                 verticalChart.setOption(verticalOption);
@@ -151,13 +151,13 @@
                     ],
                     series: [
                         // Normal order
-                        { name: 'Series 1', type: 'bar', stack: 'hstack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 2', type: 'bar', stack: 'hstack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 3', type: 'bar', stack: 'hstack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 1', type: 'bar', stack: 'hstack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'hstack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'hstack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, label: { show: true, position: 'inside' } },
                         // Reverse order
-                        { name: 'Series 1', type: 'bar', stack: 'hstack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 2', type: 'bar', stack: 'hstack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
-                        { name: 'Series 3', type: 'bar', stack: 'hstack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
+                        { name: 'Series 1', type: 'bar', stack: 'hstack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'hstack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'hstack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, label: { show: true, position: 'inside' } }
                     ]
                 };
                 horizontalChart.setOption(horizontalOption);
@@ -182,13 +182,13 @@
                     ],
                     series: [
                         // Normal order
-                        { name: 'Series 1', type: 'line', stack: 'linestack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
-                        { name: 'Series 2', type: 'line', stack: 'linestack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
-                        { name: 'Series 3', type: 'line', stack: 'linestack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 1', type: 'line', stack: 'linestack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 2', type: 'line', stack: 'linestack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 3', type: 'line', stack: 'linestack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
                         // Reverse order
-                        { name: 'Series 1', type: 'line', stack: 'linestack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
-                        { name: 'Series 2', type: 'line', stack: 'linestack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
-                        { name: 'Series 3', type: 'line', stack: 'linestack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 }
+                        { name: 'Series 1', type: 'line', stack: 'linestack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 2', type: 'line', stack: 'linestack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 3', type: 'line', stack: 'linestack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, areaStyle: {}, symbol: 'circle', symbolSize: 6 }
                     ]
                 };
                 lineChart.setOption(lineOption);

--- a/test/bar-stack-reverse.html
+++ b/test/bar-stack-reverse.html
@@ -26,24 +26,72 @@
                 height: 400px;
                 margin-bottom: 20px;
             }
+            .small-chart-container {
+                width: 100%;
+                height: 350px;
+                margin-bottom: 20px;
+            }
+            .controls {
+                margin: 20px 0;
+                padding: 10px;
+                background-color: #f9f9f9;
+                border: 1px solid #ddd;
+            }
+            .control-group {
+                margin: 10px 0;
+            }
+            .control-group label {
+                font-weight: bold;
+                margin-right: 10px;
+            }
+            button {
+                padding: 5px 10px;
+                margin: 0 5px;
+                border: 1px solid #ccc;
+                background-color: #fff;
+                cursor: pointer;
+            }
+            button.active {
+                background-color: #5470c6;
+                color: white;
+                border-color: #5470c6;
+            }
         </style>
+
         <div class="test-title">Stack Order Test: 'normal' vs 'reverse'</div>
         
-        <!-- Vertical Bar Charts -->
-        <div class="test-title">1. Vertical Bar Charts (Default vs Reversed)</div>
-        <div id="verticalBar" class="chart-container"></div>
+        <!-- Part 1: Static Test -->
+        <div class="test-title">Vertical Bar Charts: Normal vs Reverse</div>
+        <div id="verticalChart" class="small-chart-container"></div>
         
-        <!-- Horizontal Bar Charts -->
-        <div class="test-title">2. Horizontal Bar Charts (Default vs Reversed)</div>
-        <div id="horizontalBar" class="chart-container"></div>
+        <div class="test-title">Horizontal Bar Charts: Normal vs Reverse</div>
+        <div id="horizontalChart" class="small-chart-container"></div>
         
-        <!-- Stacked Line Charts -->
-        <div class="test-title">3. Stacked Line Charts (Default vs Reversed)</div>
-        <div id="stackedLine" class="chart-container"></div>
-        
+        <div class="test-title">Stacked Line Charts: Normal vs Reverse</div>
+        <div id="lineChart" class="small-chart-container"></div>
+
+        <!-- Part 2: Interactive Test -->
+        <div class="test-title">2. Interactive Test - Based on Official Example</div>
+        <p>This section is based on the <a href="https://echarts.apache.org/examples/en/editor.html?c=bar-y-category-stack" target="_blank">official stacked bar example</a>, supporting dynamic switching between stack orders and chart types:</p>
+
+        <div class="controls">
+            <div class="control-group">
+                <label>Stack Order:</label>
+                <button id="normalBtn" class="active" onclick="setStackOrder('normal')">Normal (Default)</button>
+                <button id="reverseBtn" onclick="setStackOrder('reverse')">Reverse</button>
+            </div>
+            <div class="control-group">
+                <label>Chart Type:</label>
+                <button id="horizontalBtn" class="active" onclick="setChartType('horizontal')">Horizontal Bar</button>
+                <button id="verticalBtn" onclick="setChartType('vertical')">Vertical Bar</button>
+            </div>
+        </div>
+
+        <div id="interactiveChart" class="chart-container"></div>
+
         <script>
             require(['echarts'], function (echarts) {
-                // Original data
+                // ===== Part 1: Static Test =====
                 const data = [
                     { category: 'A', value1: 10, value2: 20, value3: 30 },
                     { category: 'B', value1: 15, value2: 25, value3: 35 },
@@ -51,408 +99,181 @@
                     { category: 'D', value1: 25, value2: 10, value3: 20 },
                     { category: 'E', value1: 30, value2: 20, value3: 10 }
                 ];
-                
-                // 1. Vertical Bar Charts
-                const verticalBarChart = echarts.init(document.getElementById('verticalBar'));
-                const verticalBarOption = {
-                    title: {
-                        text: 'Vertical Bar Charts',
-                        left: 'center'
-                    },
-                    tooltip: {
-                        trigger: 'axis',
-                        axisPointer: {
-                            type: 'shadow'
-                        }
-                    },
-                    legend: {
-                        data: ['Series 1', 'Series 2', 'Series 3'],
-                        top: 30
-                    },
+
+                // 1. Vertical bar chart
+                const verticalChart = echarts.init(document.getElementById('verticalChart'));
+                const verticalOption = {
+                    title: { text: 'Vertical Bar Charts', left: 'center' },
+                    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+                    legend: { data: ['Series 1', 'Series 2', 'Series 3'], top: 30 },
                     grid: [
                         { left: '5%', right: '55%', top: '15%', bottom: '10%' },
                         { left: '55%', right: '5%', top: '15%', bottom: '10%' }
                     ],
                     xAxis: [
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 0,
-                            name: 'Normal Order',
-                            nameLocation: 'middle',
-                            nameGap: 30
-                        },
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 1,
-                            name: 'Reverse Order',
-                            nameLocation: 'middle',
-                            nameGap: 30
-                        }
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 0, name: 'Normal Order', nameLocation: 'middle', nameGap: 30 },
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 1, name: 'Reverse Order', nameLocation: 'middle', nameGap: 30 }
                     ],
                     yAxis: [
-                        {
-                            type: 'value',
-                            gridIndex: 0
-                        },
-                        {
-                            type: 'value',
-                            gridIndex: 1
-                        }
+                        { type: 'value', gridIndex: 0 },
+                        { type: 'value', gridIndex: 1 }
                     ],
                     series: [
-                        // Default stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'bar',
-                            stack: 'stack1',
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#5470c6' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'bar',
-                            stack: 'stack1',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#91cc75' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'bar',
-                            stack: 'stack1',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#fac858' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        // Reversed stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'bar',
-                            stack: 'stack2',
-                            stackOrder: 'reverse',  // Reverse stacking order
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#5470c6' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'bar',
-                            stack: 'stack2',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#91cc75' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'bar',
-                            stack: 'stack2',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#fac858' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        }
+                        // Normal order
+                        { name: 'Series 1', type: 'bar', stack: 'stack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'stack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'stack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
+                        // Reverse order
+                        { name: 'Series 1', type: 'bar', stack: 'stack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'stack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'stack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
                     ]
                 };
-                verticalBarChart.setOption(verticalBarOption);
-                
-                // 2. Horizontal Bar Charts
-                const horizontalBarChart = echarts.init(document.getElementById('horizontalBar'));
-                const horizontalBarOption = {
-                    title: {
-                        text: 'Horizontal Bar Charts',
-                        left: 'center'
-                    },
-                    tooltip: {
-                        trigger: 'axis',
-                        axisPointer: {
-                            type: 'shadow'
-                        }
-                    },
-                    legend: {
-                        data: ['Series 1', 'Series 2', 'Series 3'],
-                        top: 30
-                    },
+                verticalChart.setOption(verticalOption);
+
+                // 2. Horizontal bar chart
+                const horizontalChart = echarts.init(document.getElementById('horizontalChart'));
+                const horizontalOption = {
+                    title: { text: 'Horizontal Bar Charts', left: 'center' },
+                    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+                    legend: { data: ['Series 1', 'Series 2', 'Series 3'], top: 30 },
                     grid: [
                         { left: '15%', right: '55%', top: '15%', bottom: '10%' },
                         { left: '55%', right: '15%', top: '15%', bottom: '10%' }
                     ],
                     xAxis: [
-                        {
-                            type: 'value',
-                            gridIndex: 0
-                        },
-                        {
-                            type: 'value',
-                            gridIndex: 1
-                        }
+                        { type: 'value', gridIndex: 0 },
+                        { type: 'value', gridIndex: 1 }
                     ],
                     yAxis: [
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 0,
-                            name: 'Normal Order',
-                            nameLocation: 'middle',
-                            nameGap: 50
-                        },
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 1,
-                            name: 'Reverse Order',
-                            nameLocation: 'middle',
-                            nameGap: 50
-                        }
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 0, name: 'Normal Order', nameLocation: 'middle', nameGap: 50 },
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 1, name: 'Reverse Order', nameLocation: 'middle', nameGap: 50 }
                     ],
                     series: [
-                        // Default stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'bar',
-                            stack: 'hstack1',
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#5470c6' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'bar',
-                            stack: 'hstack1',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#91cc75' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'bar',
-                            stack: 'hstack1',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#fac858' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        // Reversed stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'bar',
-                            stack: 'hstack2',
-                            stackOrder: 'reverse',  // Reverse stacking order
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#5470c6' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'bar',
-                            stack: 'hstack2',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#91cc75' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'bar',
-                            stack: 'hstack2',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#fac858' },
-                            label: {
-                                show: true,
-                                position: 'inside'
-                            }
-                        }
+                        // Normal order
+                        { name: 'Series 1', type: 'bar', stack: 'hstack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'hstack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'hstack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
+                        // Reverse order
+                        { name: 'Series 1', type: 'bar', stack: 'hstack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 2', type: 'bar', stack: 'hstack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 3', type: 'bar', stack: 'hstack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
                     ]
                 };
-                horizontalBarChart.setOption(horizontalBarOption);
-                
-                // 3. Stacked Line Charts
-                const stackedLineChart = echarts.init(document.getElementById('stackedLine'));
-                const stackedLineOption = {
-                    title: {
-                        text: 'Stacked Line Charts',
-                        left: 'center'
-                    },
-                    tooltip: {
-                        trigger: 'axis'
-                    },
-                    legend: {
-                        data: ['Series 1', 'Series 2', 'Series 3'],
-                        top: 30
-                    },
+                horizontalChart.setOption(horizontalOption);
+
+                // 3. Line chart
+                const lineChart = echarts.init(document.getElementById('lineChart'));
+                const lineOption = {
+                    title: { text: 'Stacked Line Charts', left: 'center' },
+                    tooltip: { trigger: 'axis' },
+                    legend: { data: ['Series 1', 'Series 2', 'Series 3'], top: 30 },
                     grid: [
                         { left: '5%', right: '55%', top: '15%', bottom: '10%' },
                         { left: '55%', right: '5%', top: '15%', bottom: '10%' }
                     ],
                     xAxis: [
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 0,
-                            name: 'Normal Order',
-                            nameLocation: 'middle',
-                            nameGap: 30
-                        },
-                        {
-                            type: 'category',
-                            data: data.map(item => item.category),
-                            gridIndex: 1,
-                            name: 'Reverse Order',
-                            nameLocation: 'middle',
-                            nameGap: 30
-                        }
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 0, name: 'Normal Order', nameLocation: 'middle', nameGap: 30 },
+                        { type: 'category', data: data.map(item => item.category), gridIndex: 1, name: 'Reverse Order', nameLocation: 'middle', nameGap: 30 }
                     ],
                     yAxis: [
-                        {
-                            type: 'value',
-                            gridIndex: 0
-                        },
-                        {
-                            type: 'value',
-                            gridIndex: 1
-                        }
+                        { type: 'value', gridIndex: 0 },
+                        { type: 'value', gridIndex: 1 }
                     ],
                     series: [
-                        // Default stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'line',
-                            stack: 'linestack1',
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#5470c6' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'line',
-                            stack: 'linestack1',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#91cc75' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'line',
-                            stack: 'linestack1',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 0,
-                            yAxisIndex: 0,
-                            itemStyle: { color: '#fac858' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        },
-                        // Reversed stacking order
-                        {
-                            name: 'Series 1',
-                            type: 'line',
-                            stack: 'linestack2',
-                            stackOrder: 'reverse',  // Reverse stacking order
-                            data: data.map(item => item.value1),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#5470c6' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        },
-                        {
-                            name: 'Series 2',
-                            type: 'line',
-                            stack: 'linestack2',
-                            data: data.map(item => item.value2),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#91cc75' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        },
-                        {
-                            name: 'Series 3',
-                            type: 'line',
-                            stack: 'linestack2',
-                            data: data.map(item => item.value3),
-                            xAxisIndex: 1,
-                            yAxisIndex: 1,
-                            itemStyle: { color: '#fac858' },
-                            areaStyle: {},
-                            symbol: 'circle',
-                            symbolSize: 6
-                        }
+                        // Normal order
+                        { name: 'Series 1', type: 'line', stack: 'linestack1', data: data.map(item => item.value1), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 2', type: 'line', stack: 'linestack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 3', type: 'line', stack: 'linestack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        // Reverse order
+                        { name: 'Series 1', type: 'line', stack: 'linestack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 2', type: 'line', stack: 'linestack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 3', type: 'line', stack: 'linestack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 }
                     ]
                 };
-                stackedLineChart.setOption(stackedLineOption);
-                
+                lineChart.setOption(lineOption);
+
+                // ===== Part 2: Interactive Test =====
+                let interactiveChart = echarts.init(document.getElementById('interactiveChart'));
+                let currentStackOrder = 'normal';
+                let currentChartType = 'horizontal';
+
+                // Data based on official example
+                const baseOption = {
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: { type: 'shadow' }
+                    },
+                    legend: {
+                        data: ['Direct', 'Mail Ad', 'Affiliate Ad', 'Video Ad', 'Search Engine']
+                    },
+                    grid: {
+                        left: '3%',
+                        right: '4%',
+                        bottom: '3%',
+                        containLabel: true
+                    }
+                };
+
+                const seriesData = [
+                    { name: 'Direct', type: 'bar', stack: 'total', label: { show: true }, emphasis: { focus: 'series' }, data: [320, 302, 301, 334, 390, 330, 320] },
+                    { name: 'Mail Ad', type: 'bar', stack: 'total', label: { show: true }, emphasis: { focus: 'series' }, data: [120, 132, 101, 134, 90, 230, 210] },
+                    { name: 'Affiliate Ad', type: 'bar', stack: 'total', label: { show: true }, emphasis: { focus: 'series' }, data: [220, 182, 191, 234, 290, 330, 310] },
+                    { name: 'Video Ad', type: 'bar', stack: 'total', label: { show: true }, emphasis: { focus: 'series' }, data: [150, 212, 201, 154, 190, 330, 410] },
+                    { name: 'Search Engine', type: 'bar', stack: 'total', label: { show: true }, emphasis: { focus: 'series' }, data: [820, 832, 901, 934, 1290, 1330, 1320] }
+                ];
+
+                function getInteractiveOption() {
+                    const option = JSON.parse(JSON.stringify(baseOption));
+                    
+                    if (currentChartType === 'horizontal') {
+                        option.xAxis = { type: 'value' };
+                        option.yAxis = { type: 'category', data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] };
+                    } else {
+                        option.xAxis = { type: 'category', data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] };
+                        option.yAxis = { type: 'value' };
+                    }
+
+                    option.series = seriesData.map((series, index) => {
+                        const newSeries = JSON.parse(JSON.stringify(series));
+                        if (index === 0 && currentStackOrder === 'reverse') {
+                            newSeries.stackOrder = 'reverse';
+                        }
+                        return newSeries;
+                    });
+
+                    return option;
+                }
+
+                function updateInteractiveChart() {
+                    const option = getInteractiveOption();
+                    interactiveChart.setOption(option, true);
+                }
+
+                // Global functions
+                window.setStackOrder = function(order) {
+                    currentStackOrder = order;
+                    document.getElementById('normalBtn').classList.toggle('active', order === 'normal');
+                    document.getElementById('reverseBtn').classList.toggle('active', order === 'reverse');
+                    updateInteractiveChart();
+                };
+
+                window.setChartType = function(type) {
+                    currentChartType = type;
+                    document.getElementById('horizontalBtn').classList.toggle('active', type === 'horizontal');
+                    document.getElementById('verticalBtn').classList.toggle('active', type === 'vertical');
+                    updateInteractiveChart();
+                };
+
+                // Initialize interactive chart
+                updateInteractiveChart();
+
                 // Responsive resize
                 window.addEventListener('resize', function() {
-                    verticalBarChart.resize();
-                    horizontalBarChart.resize();
-                    stackedLineChart.resize();
+                    verticalChart.resize();
+                    horizontalChart.resize();
+                    lineChart.resize();
+                    interactiveChart.resize();
                 });
             });
         </script>

--- a/test/bar-stack-reverse.html
+++ b/test/bar-stack-reverse.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            #main {
+                width: 100%;
+                height: 100%;
+            }
+            .test-title {
+                padding: 10px;
+                margin: 10px 0;
+                font-weight: bold;
+                font-size: 16px;
+            }
+            .chart-container {
+                width: 100%;
+                height: 400px;
+                margin-bottom: 20px;
+            }
+        </style>
+        <div class="test-title">Stack Order Test: 'normal' vs 'reverse'</div>
+        
+        <!-- Vertical Bar Charts -->
+        <div class="test-title">1. Vertical Bar Charts (Default vs Reversed)</div>
+        <div id="verticalBar" class="chart-container"></div>
+        
+        <!-- Horizontal Bar Charts -->
+        <div class="test-title">2. Horizontal Bar Charts (Default vs Reversed)</div>
+        <div id="horizontalBar" class="chart-container"></div>
+        
+        <!-- Stacked Line Charts -->
+        <div class="test-title">3. Stacked Line Charts (Default vs Reversed)</div>
+        <div id="stackedLine" class="chart-container"></div>
+        
+        <script>
+            require(['echarts'], function (echarts) {
+                // Original data
+                const data = [
+                    { category: 'A', value1: 10, value2: 20, value3: 30 },
+                    { category: 'B', value1: 15, value2: 25, value3: 35 },
+                    { category: 'C', value1: 20, value2: 15, value3: 25 },
+                    { category: 'D', value1: 25, value2: 10, value3: 20 },
+                    { category: 'E', value1: 30, value2: 20, value3: 10 }
+                ];
+                
+                // 1. Vertical Bar Charts
+                const verticalBarChart = echarts.init(document.getElementById('verticalBar'));
+                const verticalBarOption = {
+                    title: {
+                        text: 'Vertical Bar Charts',
+                        left: 'center'
+                    },
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: {
+                            type: 'shadow'
+                        }
+                    },
+                    legend: {
+                        data: ['Series 1', 'Series 2', 'Series 3'],
+                        top: 30
+                    },
+                    grid: [
+                        { left: '5%', right: '55%', top: '15%', bottom: '10%' },
+                        { left: '55%', right: '5%', top: '15%', bottom: '10%' }
+                    ],
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 0,
+                            name: 'Normal Order',
+                            nameLocation: 'middle',
+                            nameGap: 30
+                        },
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 1,
+                            name: 'Reverse Order',
+                            nameLocation: 'middle',
+                            nameGap: 30
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value',
+                            gridIndex: 0
+                        },
+                        {
+                            type: 'value',
+                            gridIndex: 1
+                        }
+                    ],
+                    series: [
+                        // Default stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'bar',
+                            stack: 'stack1',
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#5470c6' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'bar',
+                            stack: 'stack1',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#91cc75' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'bar',
+                            stack: 'stack1',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#fac858' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        // Reversed stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'bar',
+                            stack: 'stack2',
+                            stackOrder: 'reverse',  // Reverse stacking order
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#5470c6' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'bar',
+                            stack: 'stack2',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#91cc75' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'bar',
+                            stack: 'stack2',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#fac858' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        }
+                    ]
+                };
+                verticalBarChart.setOption(verticalBarOption);
+                
+                // 2. Horizontal Bar Charts
+                const horizontalBarChart = echarts.init(document.getElementById('horizontalBar'));
+                const horizontalBarOption = {
+                    title: {
+                        text: 'Horizontal Bar Charts',
+                        left: 'center'
+                    },
+                    tooltip: {
+                        trigger: 'axis',
+                        axisPointer: {
+                            type: 'shadow'
+                        }
+                    },
+                    legend: {
+                        data: ['Series 1', 'Series 2', 'Series 3'],
+                        top: 30
+                    },
+                    grid: [
+                        { left: '15%', right: '55%', top: '15%', bottom: '10%' },
+                        { left: '55%', right: '15%', top: '15%', bottom: '10%' }
+                    ],
+                    xAxis: [
+                        {
+                            type: 'value',
+                            gridIndex: 0
+                        },
+                        {
+                            type: 'value',
+                            gridIndex: 1
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 0,
+                            name: 'Normal Order',
+                            nameLocation: 'middle',
+                            nameGap: 50
+                        },
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 1,
+                            name: 'Reverse Order',
+                            nameLocation: 'middle',
+                            nameGap: 50
+                        }
+                    ],
+                    series: [
+                        // Default stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'bar',
+                            stack: 'hstack1',
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#5470c6' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'bar',
+                            stack: 'hstack1',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#91cc75' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'bar',
+                            stack: 'hstack1',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#fac858' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        // Reversed stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'bar',
+                            stack: 'hstack2',
+                            stackOrder: 'reverse',  // Reverse stacking order
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#5470c6' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'bar',
+                            stack: 'hstack2',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#91cc75' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'bar',
+                            stack: 'hstack2',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#fac858' },
+                            label: {
+                                show: true,
+                                position: 'inside'
+                            }
+                        }
+                    ]
+                };
+                horizontalBarChart.setOption(horizontalBarOption);
+                
+                // 3. Stacked Line Charts
+                const stackedLineChart = echarts.init(document.getElementById('stackedLine'));
+                const stackedLineOption = {
+                    title: {
+                        text: 'Stacked Line Charts',
+                        left: 'center'
+                    },
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    legend: {
+                        data: ['Series 1', 'Series 2', 'Series 3'],
+                        top: 30
+                    },
+                    grid: [
+                        { left: '5%', right: '55%', top: '15%', bottom: '10%' },
+                        { left: '55%', right: '5%', top: '15%', bottom: '10%' }
+                    ],
+                    xAxis: [
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 0,
+                            name: 'Normal Order',
+                            nameLocation: 'middle',
+                            nameGap: 30
+                        },
+                        {
+                            type: 'category',
+                            data: data.map(item => item.category),
+                            gridIndex: 1,
+                            name: 'Reverse Order',
+                            nameLocation: 'middle',
+                            nameGap: 30
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            type: 'value',
+                            gridIndex: 0
+                        },
+                        {
+                            type: 'value',
+                            gridIndex: 1
+                        }
+                    ],
+                    series: [
+                        // Default stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'line',
+                            stack: 'linestack1',
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#5470c6' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'line',
+                            stack: 'linestack1',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#91cc75' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'line',
+                            stack: 'linestack1',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 0,
+                            yAxisIndex: 0,
+                            itemStyle: { color: '#fac858' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        },
+                        // Reversed stacking order
+                        {
+                            name: 'Series 1',
+                            type: 'line',
+                            stack: 'linestack2',
+                            stackOrder: 'reverse',  // Reverse stacking order
+                            data: data.map(item => item.value1),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#5470c6' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        },
+                        {
+                            name: 'Series 2',
+                            type: 'line',
+                            stack: 'linestack2',
+                            data: data.map(item => item.value2),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#91cc75' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        },
+                        {
+                            name: 'Series 3',
+                            type: 'line',
+                            stack: 'linestack2',
+                            data: data.map(item => item.value3),
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: { color: '#fac858' },
+                            areaStyle: {},
+                            symbol: 'circle',
+                            symbolSize: 6
+                        }
+                    ]
+                };
+                stackedLineChart.setOption(stackedLineOption);
+                
+                // Responsive resize
+                window.addEventListener('resize', function() {
+                    verticalBarChart.resize();
+                    horizontalBarChart.resize();
+                    stackedLineChart.resize();
+                });
+            });
+        </script>
+    </body>
+</html> 

--- a/test/bar-stack-reverse.html
+++ b/test/bar-stack-reverse.html
@@ -124,7 +124,7 @@
                         { name: 'Series 2', type: 'bar', stack: 'stack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 3', type: 'bar', stack: 'stack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
                         // Reverse order
-                        { name: 'Series 1', type: 'bar', stack: 'stack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 1', type: 'bar', stack: 'stack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 2', type: 'bar', stack: 'stack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 3', type: 'bar', stack: 'stack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
                     ]
@@ -155,7 +155,7 @@
                         { name: 'Series 2', type: 'bar', stack: 'hstack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 3', type: 'bar', stack: 'hstack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } },
                         // Reverse order
-                        { name: 'Series 1', type: 'bar', stack: 'hstack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
+                        { name: 'Series 1', type: 'bar', stack: 'hstack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 2', type: 'bar', stack: 'hstack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, label: { show: true, position: 'inside' } },
                         { name: 'Series 3', type: 'bar', stack: 'hstack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, label: { show: true, position: 'inside' } }
                     ]
@@ -186,7 +186,7 @@
                         { name: 'Series 2', type: 'line', stack: 'linestack1', data: data.map(item => item.value2), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
                         { name: 'Series 3', type: 'line', stack: 'linestack1', data: data.map(item => item.value3), xAxisIndex: 0, yAxisIndex: 0, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
                         // Reverse order
-                        { name: 'Series 1', type: 'line', stack: 'linestack2', stackOrder: 'reverse', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
+                        { name: 'Series 1', type: 'line', stack: 'linestack2', stackOrder: 'seriesDesc', data: data.map(item => item.value1), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#5470c6' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
                         { name: 'Series 2', type: 'line', stack: 'linestack2', data: data.map(item => item.value2), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#91cc75' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 },
                         { name: 'Series 3', type: 'line', stack: 'linestack2', data: data.map(item => item.value3), xAxisIndex: 1, yAxisIndex: 1, itemStyle: { color: '#fac858' }, areaStyle: {}, symbol: 'circle', symbolSize: 6 }
                     ]
@@ -237,7 +237,7 @@
                     option.series = seriesData.map((series, index) => {
                         const newSeries = JSON.parse(JSON.stringify(series));
                         if (index === 0 && currentStackOrder === 'reverse') {
-                            newSeries.stackOrder = 'reverse';
+                            newSeries.stackOrder = 'seriesDesc';
                         }
                         return newSeries;
                     });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add support for reversing stack order in stacked charts through a new `stackOrder` option.



### Fixed issues

<!--
- #xxxx: ...
-->

https://github.com/apache/echarts/issues/20983


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

Previously, stacked charts (bar, line, area) only supported the default stacking order where series are stacked in the order they are defined. 
Users had no way to reverse the visual stacking order without manually reordering their series data, which could be inconvenient.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Now users can set `stackOrder: 'seriesDesc'` on any series in a stack group to reverse the visual stacking order. The feature works by:

1. Adding a new `stackOrder` option to `SeriesStackOptionMixin` with values `'seriesAsc'` (default) or `'seriesDesc'`
2. Modifying the data stack processor to check for the `stackOrder` setting and reverse the stack info list when needed
3. Properly updating the `stackedOnSeries` calculation to maintain correct stacking relationships

The feature supports all chart types that use stacking (bar, line, area charts).
Note that polar coordinate systems are not yet supported, and documentation will be updated accordingly.
Future enhancements may include value-based ascending/descending stack ordering.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/bar-stack-reverse.html` - Comprehensive test cases demonstrating the new `stackOrder` functionality with vertical bars, horizontal bars, and stacked line charts

<img width="443" alt="截屏2025-05-27 16 18 52" src="https://github.com/user-attachments/assets/38a97f75-db85-4656-8d9d-4f9edbbd6fd7" />


## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

**Limitations:**
- Polar coordinate systems are not yet supported
- Currently only supports 'seriesAsc' and 'seriesDesc' order (value-based sorting may be added in future versions)

**Future Enhancements:**
- Support for polar coordinate systems
- Potential support for value-based ascending/descending stack ordering
