### PR TITLE
feat(line): `triggerAreaEvent` option for more control over mouse event

### DIFF
--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -120,6 +120,8 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption<CallbackD
     data?: (LineDataValue | LineDataItemOption)[]
 
     triggerLineEvent?: boolean
+
+    triggerAreaEvent?: boolean
 }
 
 class LineSeriesModel extends SeriesModel<LineSeriesOption> {
@@ -213,7 +215,11 @@ class LineSeriesModel extends SeriesModel<LineSeriesOption> {
             divideShape: 'clone'
         },
 
-        triggerLineEvent: false
+        triggerLineEvent: false,
+
+        // When false, this option gives more control in case hovering on the shaded area should not trigger mouse events.
+        // Defaults to true for backwards compatibility and sense it only works when triggerLineEvent is true.
+        triggerAreaEvent: true
     };
 
     getLegendIcon(opt: LegendIconParams): ECSymbol | Group {

--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -922,7 +922,9 @@ class LineView extends ChartView {
 
         if (seriesModel.get('triggerLineEvent')) {
             this.packEventData(seriesModel, polyline);
-            polygon && this.packEventData(seriesModel, polygon);
+            if (seriesModel.get('triggerAreaEvent')) {
+                polygon && this.packEventData(seriesModel, polygon);
+            }
         }
     }
 

--- a/test/polyline-gon-event.html
+++ b/test/polyline-gon-event.html
@@ -74,6 +74,18 @@ under the License.
                                 return d * 2;
                             })
                         },
+                        {
+                            name: 'line2',
+                            type: 'line',
+                            stack: 'a',
+                            areaStyle: {},
+                            data: data.map(function (d) {
+                                return d * 0.5;
+                            }),
+                            triggerLineEvent: true,
+                            // Only trigger event when hovering over line, not area under curve.
+                            triggerAreaEvent: false
+                        },
                     ]
                 });
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Add `triggerAreaEvent` option to line series that can be used to ensure the mouse event only fires when actually hovering on the line, not the shaded area under curve (when areaStyle set). 

### Fixed issues

- #21000

## Details

### Before: What was the problem?

Mouse event fires when hovering on shaded region, not just on the actual line. That behavior makes sense in many cases, but when there are many series overlapping, it can be useful to only fire when actually hovering directly on the line (or else it might not actually be the series closest to your cursor)

https://github.com/user-attachments/assets/88fbd1ea-d019-45e6-9cac-10f17a35acae

### After: How does it behave after the fixing?

When `triggerAreaEvent: false` and `triggerLineEvent: true`, only hovering on the line triggers the mouse event

https://github.com/user-attachments/assets/5ce15f83-eb63-4d19-b1ce-405b8dd9ba7c

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
  - _I'm working on getting docs updated now_
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
