### PR TITLE
fix(symbol): add rotate argument to correct text positioning issues

### DIFF
--- a/src/chart/helper/Symbol.ts
+++ b/src/chart/helper/Symbol.ts
@@ -65,7 +65,8 @@ class Symbol extends graphic.Group {
         idx: number,
         symbolSize: number[],
         z2: number,
-        keepAspect: boolean
+        keepAspect: boolean,
+        rotate: number
     ) {
         // Remove paths created before
         this.removeAll();
@@ -77,7 +78,7 @@ class Symbol extends graphic.Group {
         // and macOS Sierra, a circle stroke become a rect, no matter what
         // the scale is set. So we set width/height as 2. See #4150.
         const symbolPath = createSymbol(
-            symbolType, -1, -1, 2, 2, null, keepAspect
+            symbolType, -1, -1, 2, 2, null, keepAspect, rotate
         );
 
         symbolPath.attr({
@@ -163,7 +164,8 @@ class Symbol extends graphic.Group {
 
         if (isInit) {
             const keepAspect = data.getItemVisual(idx, 'symbolKeepAspect');
-            this._createSymbol(symbolType as string, data, idx, symbolSize, z2, keepAspect);
+            const rotate = data.getItemVisual(idx, 'symbolRotate') || 0;
+            this._createSymbol(symbolType as string, data, idx, symbolSize, z2, keepAspect, rotate);
         }
         else {
             const symbolPath = this.childAt(0) as ECSymbol;

--- a/src/util/symbol.ts
+++ b/src/util/symbol.ts
@@ -277,14 +277,16 @@ const SymbolClz = graphic.Path.extend({
         x: 0,
         y: 0,
         width: 0,
-        height: 0
+        height: 0,
+        rotate: 0
     },
 
     calculateTextPosition(out, config, rect) {
         const res = calculateTextPosition(out, config, rect);
         const shape = this.shape;
         if (shape && shape.symbolType === 'pin' && config.position === 'inside') {
-            res.y = rect.y + rect.height * 0.4;
+            res.x = res.x - rect.width * 0.1 * Math.sin(Math.PI * shape.rotate / 180);
+            res.y = res.y - rect.height * 0.1 * Math.cos(Math.PI * shape.rotate / 180);
         }
         return res;
     },
@@ -337,7 +339,8 @@ export function createSymbol(
     h: number,
     color?: ZRColor,
     // whether to keep the ratio of w/h,
-    keepAspect?: boolean
+    keepAspect?: boolean,
+    rotate?: number
 ) {
     // TODO Support image object, DynamicImage.
 
@@ -369,7 +372,8 @@ export function createSymbol(
                 x: x,
                 y: y,
                 width: w,
-                height: h
+                height: h,
+                rotate: rotate
             }
         }) as unknown as ECSymbol;
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add rotate argument to createSymbol to correct text position issues


### Fixed issues

[14718](https://github.com/apache/echarts/issues/14718)

## Details

### Before: What was the problem?

Text position is not in right place when Pin Symbol rotates as shown in Issue 14718

### After: How does it behave after the fixing?

The texts is centred properly.


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
