### PR TITLE
fix(dataZoom): fix cases with dataset, relates to #16978

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -516,11 +516,12 @@ class SliderZoomView extends DataZoomView {
                 }
 
                 otherDim = seriesModel.getData().mapDimension(otherDim);
+                const thisDim = seriesModel.getData().mapDimension(axisDim);
 
                 result = {
                     thisAxis: thisAxis,
                     series: seriesModel,
-                    thisDim: axisDim,
+                    thisDim: thisDim,
                     otherDim: otherDim,
                     otherAxisInverse: otherAxisInverse
                 };


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

There are a lot of failed test cases since #16978 . These problems happen when using dataset with dataZoom.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="624" alt="image" src="https://github.com/user-attachments/assets/7ce2198a-0513-4da3-bed1-ebd8dd537fc9" />

Many cases fail because `const dimIndices = map(normalizeDimensions(dims), this._getStoreDimIndex, this);` returns -1 for passing `'x'` as a dim but in fact is a string defined in dataset.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

These problems are fixed and the chart can render correctly as the last version.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
