### PR TITLE
fix(buildPath): revert checking buildPath

### DIFF
--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -369,9 +369,6 @@ function createEl(elOption: CustomElementOption): Element {
             }
             const Clz = graphicUtil.getShapeClass(path.type);
             if (!Clz) {
-                if (typeof path.buildPath === 'function') {
-                    return path;
-                }
                 let errMsg = '';
                 if (__DEV__) {
                     errMsg = 'graphic type "' + graphicType + '" can not be found.';


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Revert checking `buildPath` from https://github.com/apache/echarts/pull/20402/commits/d2c05a7656828a28d96e0e6ee28c94c9af0221ca.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

I forgot why I added this code, probably to fix the cause where `path` is a `Path` instance rather than a plain object, in the case of custom [stage chart](https://github.com/apache/echarts-custom-series/tree/main/custom-series/stage). I checked it's not depended by the stage chart and visual tests don't fail without this change so I decide to revert it.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Nothing is expected to be different.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
