### PR TITLE
fix(marker): fix bug of #20166

### DIFF
--- a/src/component/marker/MarkPointView.ts
+++ b/src/component/marker/MarkPointView.ts
@@ -43,7 +43,7 @@ function updateMarkerLayout(
     const coordSys = seriesModel.coordinateSystem;
     const apiWidth = api.getWidth();
     const apiHeight = api.getHeight();
-    const coordRect = coordSys.getArea && coordSys.getArea();
+    const coordRect = coordSys && coordSys.getArea && coordSys.getArea();
     mpData.each(function (idx: number) {
         const itemModel = mpData.getItemModel<MarkPointDataItemOption>(idx);
         const isRelativeToCoordinate = itemModel.get('relativeTo') === 'coordinate';

--- a/src/component/marker/markerHelper.ts
+++ b/src/component/marker/markerHelper.ts
@@ -154,8 +154,12 @@ export function dataTransform(
     if (item.coord == null || !isArray(dims)) {
         item.coord = [];
         const baseAxis = seriesModel.getBaseAxis();
-        const otherAxis = coordSys.getOtherAxis(baseAxis);
-        item.value = numCalculate(data, data.mapDimension(otherAxis.dim), item.type);
+        if (baseAxis) {
+            const otherAxis = coordSys.getOtherAxis(baseAxis);
+            if (otherAxis) {
+                item.value = numCalculate(data, data.mapDimension(otherAxis.dim), item.type);
+            }
+        }
     }
     else {
         // Each coord support max, min, average

--- a/test/dataZoom-action.html
+++ b/test/dataZoom-action.html
@@ -25,8 +25,8 @@ under the License.
         <script src="lib/testHelper.js"></script>
         <script src="lib/facePrint.js"></script>
         <script src="lib/jquery.min.js"></script>
-        <script src="lib/config.js"></script>
         <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
         <link rel="stylesheet" href="lib/reset.css" />
     </head>
     <body>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

#20166 breaks the case of `marker-case.html`, where marker is used in pie series and has no coordinate.

Fix the order of importing files in `test/dataZoom-action.html`, which is not related to this issue but fixed together for convenience. It seems `lib/config.js` should be imported before `lib/simpleRequire.js`, otherwise, the local echarts file cannot be found:

<img width="559" alt="image" src="https://github.com/user-attachments/assets/de5148ce-3749-4043-b978-bee60fb64d5e" />


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="678" alt="image" src="https://github.com/user-attachments/assets/1bae820b-128c-4c42-a454-e87824f0edb6" />


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

No error message and chart is rendered as expected.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
