### PR TITLE
fix(marker): overwrite value only if type is not defined

### DIFF
--- a/src/component/marker/markerHelper.ts
+++ b/src/component/marker/markerHelper.ts
@@ -154,7 +154,7 @@ export function dataTransform(
     if (item.coord == null || !isArray(dims)) {
         item.coord = [];
         const baseAxis = seriesModel.getBaseAxis();
-        if (baseAxis) {
+        if (baseAxis && item.type && markerTypeCalculator[item.type]) {
             const otherAxis = coordSys.getOtherAxis(baseAxis);
             if (otherAxis) {
                 item.value = numCalculate(data, data.mapDimension(otherAxis.dim), item.type);

--- a/test/markPoint-stock.html
+++ b/test/markPoint-stock.html
@@ -99,6 +99,7 @@ under the License.
                     data,
                     showSymbol: false,
                     markPoint: {
+                        silent: true,
                         symbol: 'circle',
                         symbolSize: 0,
                         label: {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

#20166 adds `value` to marker information, which may break the case where user-provided `name` should be displayed instead. This PR fixes this case by only adding `value` when `type` is provided and valid.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

```js
[
    {name: 'ABC', x: 50, y: 60},
    {x: 70, y: 90}
]
```

renders `655`, while it should be `ABC` instead.

### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

`ABC` is displayed.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
