### PR TITLE
fix(dataZoom): fix the case when first value is NaN, relates to #16978

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -430,8 +430,10 @@ class SliderZoomView extends DataZoomView {
                     linePoints.push([thisCoord, 0]);
                 }
 
-                areaPoints.push([thisCoord, otherCoord]);
-                linePoints.push([thisCoord, otherCoord]);
+                if (!isEmpty) {
+                    areaPoints.push([thisCoord, otherCoord]);
+                    linePoints.push([thisCoord, otherCoord]);
+                }
 
                 lastIsEmpty = isEmpty;
             });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

#16978 breaks the case of `test/tooltip-axisPointer.html`, where the first `otherCoord` is NaN.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

DataZoom is displayed at the wrong position.

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/3ffce14f-3bca-42ee-8575-16f928f34916" />


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/57b3f12d-edb2-4acd-85a7-0770acac3f32" />


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
