### PR TITLE
chore: use zrender#next and remove unused import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "github:ecomfe/zrender#v6"
+        "zrender": "github:ecomfe/zrender#next"
       },
       "devDependencies": {
         "@babel/code-frame": "7.10.4",
@@ -11800,7 +11800,7 @@
     },
     "node_modules/zrender": {
       "version": "5.6.1",
-      "resolved": "git+ssh://git@github.com/ecomfe/zrender.git#31a654f2c28580cf479ea7b8531c987b3cb63000",
+      "resolved": "git+ssh://git@github.com/ecomfe/zrender.git#490a7b3b6e3e14440af40d04685dd8c1c31df591",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
@@ -20568,8 +20568,8 @@
       }
     },
     "zrender": {
-      "version": "git+ssh://git@github.com/ecomfe/zrender.git#31a654f2c28580cf479ea7b8531c987b3cb63000",
-      "from": "zrender@github:ecomfe/zrender#v6",
+      "version": "git+ssh://git@github.com/ecomfe/zrender.git#490a7b3b6e3e14440af40d04685dd8c1c31df591",
+      "from": "zrender@github:ecomfe/zrender#next",
       "requires": {
         "tslib": "2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "tslib": "2.3.0",
-    "zrender": "github:ecomfe/zrender#v6"
+    "zrender": "github:ecomfe/zrender#next"
   },
   "devDependencies": {
     "@babel/code-frame": "7.10.4",

--- a/src/util/model.ts
+++ b/src/util/model.ts
@@ -54,7 +54,6 @@ import CartesianAxisModel from '../coord/cartesian/AxisModel';
 import GridModel from '../coord/cartesian/GridModel';
 import { isNumeric, getRandomIdBase, getPrecision, round } from './number';
 import { error, warn } from './log';
-import type Model from '../model/Model';
 
 function interpolateNumber(p0: number, p1: number, percent: number): number {
     return (p1 - p0) * percent + p0;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
