### PR TITLE
[Feature] Disable triggering tooltip for items disabled by visualMap

### DIFF
--- a/src/component/marker/MarkerModel.ts
+++ b/src/component/marker/MarkerModel.ts
@@ -90,7 +90,7 @@ export interface MarkerOption extends ComponentOption, AnimationOptionMixin {
     data?: unknown[]
 
     tooltip?: CommonTooltipOption<unknown> & {
-        trigger?: 'item' | 'axis' | boolean | 'none'
+        trigger?: 'item' | 'activeItem' | 'axis' | boolean | 'none'
     }
 }
 

--- a/src/component/tooltip/TooltipModel.ts
+++ b/src/component/tooltip/TooltipModel.ts
@@ -49,7 +49,7 @@ export interface TooltipOption extends CommonTooltipOption<TopLevelFormatterPara
     /**
      * Trigger only works on coordinate system.
      */
-    trigger?: 'item' | 'axis' | 'none'
+    trigger?: 'item' | 'activeItem' | 'axis' | 'none'
 
     /**
      * 'auto': use html by default, and use non-html if `document` is not defined
@@ -96,7 +96,7 @@ class TooltipModel extends ComponentModel<TooltipOption> {
         showContent: true,
 
         // 'trigger' only works on coordinate system.
-        // 'item' | 'axis' | 'none'
+        // 'item' | 'activeItem' | 'axis' | 'none'
         trigger: 'item',
 
         // 'click' | 'mousemove' | 'none'

--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -669,12 +669,39 @@ class TooltipView extends ComponentView {
             positionDefault ? { position: positionDefault } : null
         );
 
-        const tooltipTrigger = tooltipModel.get('trigger');
-        if (tooltipTrigger != null && tooltipTrigger !== 'item') {
+         const tooltipTrigger = tooltipModel.get('trigger');
+        if (tooltipTrigger === 'none' || tooltipTrigger === 'axis') {
             return;
         }
 
         const params = dataModel.getDataParams(dataIndex, dataType);
+        let hide: boolean = false;
+        const visualMap: any = ecModel.option.visualMap;
+            if (visualMap) {
+                visualMap.forEach((model: any) => {
+                    let value: any;
+                    switch (typeof model.dimension) {
+                        case 'string':
+                            value = data.getValues(dataIndex)[Array.prototype.indexOf(model.dimension)];
+                            break;
+                        case 'number':
+                            value = data.getValues(dataIndex)[model.dimension];
+                            break;
+                        default:
+                        return;
+                    }
+                    if (
+                        tooltipTrigger === 'activeItem'
+                        && (value < model.range[0] || value > model.range[1])
+                    ) {
+                        hide = true;
+                        return;
+                    }
+                });
+            }
+        if (hide) {
+            return;
+        }
         const markupStyleCreator = new TooltipMarkupStyleCreator();
         // Pre-create marker style for makers. Users can assemble richText
         // text in `formatter` callback and use those markers style.

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1368,7 +1368,7 @@ export type ComponentItemTooltipLabelFormatterParams = {
  * Tooltip option configured on each series
  */
 export type SeriesTooltipOption = CommonTooltipOption<CallbackDataParams> & {
-    trigger?: 'item' | 'axis' | boolean | 'none'
+    trigger?: 'item' | 'activeItem' | 'axis' | boolean | 'none'
 };
 
 

--- a/test/visualMap-continuous.html
+++ b/test/visualMap-continuous.html
@@ -258,7 +258,7 @@ under the License.
                             top: 'top'
                         },
                         tooltip: {
-                            trigger: 'item',
+                            trigger: 'activeItem',
                             formatter: function (params) {
                                 const list = (params.value + '').split('.');
                                 const value = list[0].replace(/(\d{1,3})(?=(?:\d{3})+(?!\d))/g, '$1,')
@@ -287,7 +287,8 @@ under the License.
                             text: ['High', 'Low'],
                             // realtime: false,
                             calculable: true,
-                            color: ['orangered', 'yellow', 'lightskyblue']
+                            color: ['orangered', 'yellow', 'lightskyblue'],
+                            dimension: 0
                         },
                         series: [
                             {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Adds tooltip.trigger option for active items:
`tooltip.trigger = 'activeItem'`
It enables showing tooltip only for items that are active (not modified by visualMap) when visualMap is present. At the same time it doesn't modify current logic implemented for `tooltip.trigger = 'item', which is a default option.

### Fixed issues

- [[Feature] Disable triggering tooltip for items disabled by visualMap #21053](https://github.com/apache/echarts/issues/21053)

## Details

### Before: What was the problem?

If item is disabled by visualMap, tooltip is still being shown, even if there is no node.

![Image](https://github.com/user-attachments/assets/45f50754-ad24-4b62-b67b-6370df2842fb)

### After: How does it behave after the fixing?

If user sets tooltip.trigger = 'activeItem', if item is disabled by visualMap, it won't trigger tooltip.

![Screenshot 2025-06-23 at 15 28 01](https://github.com/user-attachments/assets/3f98058a-0d08-47e3-b39a-676f0329b082)
![Screenshot 2025-06-23 at 15 28 21](https://github.com/user-attachments/assets/966948d6-f948-4b65-825f-a0c5940b7105)


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
