### PR TITLE
fix(jitter): fix overlap when there is enough space to avoid

### DIFF
--- a/test/runTest/marks/scatter-jitter.json
+++ b/test/runTest/marks/scatter-jitter.json
@@ -1,5 +1,13 @@
 [
   {
+    "link": "https://github.com/apache/echarts/pull/21067",
+    "comment": "fix(jitter): fix overlap when there is enough space to avoid",
+    "type": "Bug Fixing",
+    "markedBy": "Ovilia",
+    "lastVersion": "6.0.0-beta.1",
+    "markTime": 1750938868718
+  },
+  {
     "link": "https://github.com/apache/echarts/pull/19941",
     "comment": "jittering",
     "type": "New Feature",


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

The jittering implementation of 6.0.0-beta.1 has a bug that sometimes even when there is enough space to avoid overlap, it still overlaps. 

This was because I used a double linked list to improve overlapping checking speed. When using a double linked list, I only need to check from the last scatter to see if it overlaps. But this is not correct because the previous scatters may also overlap. So instead of a link, this PR proposes to use an ordinary array and the logic is even easier to follow.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
