### PR TITLE
fix(line): correctly stack not-synced time series data. close #15742

### DIFF
--- a/src/data/SeriesData.ts
+++ b/src/data/SeriesData.ts
@@ -1391,7 +1391,7 @@ class SeriesData<
             const invertedIndicesMap = data._invertedIndicesMap;
             zrUtil.each(invertedIndicesMap, function (invertedIndices, dim) {
                 const dimInfo = data._dimInfos[dim];
-                // Currently, only dimensions that has ordinalMeta can create inverted indices.
+                // Currently, only dimensions that have ordinalMeta or are of type time can create inverted indices.
                 const ordinalMeta = dimInfo.ordinalMeta;
                 const store = data._store;
                 if (ordinalMeta) {
@@ -1403,6 +1403,13 @@ class SeriesData<
                     for (let i = 0; i < invertedIndices.length; i++) {
                         invertedIndices[i] = INDEX_NOT_FOUND;
                     }
+                    for (let i = 0; i < store.count(); i++) {
+                        // Only support the case that all values are distinct.
+                        invertedIndices[store.get(dimInfo.storeDimIndex, i) as number] = i;
+                    }
+                }
+                else if (dimInfo.type === 'time') {
+                    invertedIndices = invertedIndicesMap[dim] = { length: store.count() };
                     for (let i = 0; i < store.count(); i++) {
                         // Only support the case that all values are distinct.
                         invertedIndices[store.get(dimInfo.storeDimIndex, i) as number] = i;

--- a/src/data/helper/dataStackHelper.ts
+++ b/src/data/helper/dataStackHelper.ts
@@ -103,7 +103,7 @@ export function enableDataStack(
 
         if (mayStack && !dimensionInfo.isExtraCoord) {
             // Find the first ordinal dimension as the stackedByDimInfo.
-            if (!byIndex && !stackedByDimInfo && dimensionInfo.ordinalMeta) {
+            if (!byIndex && !stackedByDimInfo && (dimensionInfo.ordinalMeta || dimensionInfo.type === 'time')) {
                 stackedByDimInfo = dimensionInfo;
             }
             // Find the first stackable dimension as the stackedDimInfo.

--- a/test/line-stack-disjunct-timeseries.html
+++ b/test/line-stack-disjunct-timeseries.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            .test-title {
+                background: #146402;
+                color: #fff;
+            }
+        </style>
+
+        <div id="main0"></div>
+
+        <script>
+            var chart;
+            var myChart;
+            var option;
+
+            require(["echarts"], function (echarts) {
+                data1 = [
+                    ["2022-01-01T00:15:00.000Z", 750],
+                    ["2022-01-01T00:30:00.000Z", 250],
+                    ["2022-01-01T00:45:00.000Z", 1000],
+            ];
+                data2 = [
+                    ["2022-01-01T00:00:00.000Z", 1000],
+                    ["2022-01-01T00:15:00.000Z", 250],
+                    ["2022-01-01T00:30:00.000Z", 750],
+                ];
+                data3 = [
+                    ["2022-01-01T01:15:00.000Z", 800],
+                    ["2022-01-01T01:30:00.000Z", 600],
+                ];
+
+                var option = {
+                    tooltip: {
+                        trigger: "axis",
+                    },
+                    legend: {
+                        data: ["line1", "line2"],
+                    },
+                    xAxis: {
+                        type: "time",
+                    },
+                    yAxis: {
+                        type: "value",
+                    },
+                    series: [
+                        {
+                            name: "line1",
+                            type: "line",
+                            stack: "total",
+                            data: data1,
+                            areaStyle: {}
+                        },
+                        {
+                            name: "line2",
+                            type: "line",
+                            stack: "total",
+                            data: data2,
+                            areaStyle: {}
+                        },
+                        {
+                            name: "line3",
+                            type: "line",
+                            stack: "total",
+                            data: data3,
+                            areaStyle: {}
+                        },
+                        {
+                            name: "expected",
+                            type: "line",
+                            lineStyle: { color: '#00000000' },
+                            itemStyle: { color: 'red' },
+                            data: [
+                                ["2022-01-01T00:00:00.000Z", 1000],
+                                ["2022-01-01T00:15:00.000Z", 1000],
+                                ["2022-01-01T00:30:00.000Z", 1000],
+                                ["2022-01-01T00:45:00.000Z", 1000],
+                                ["2022-01-01T01:15:00.000Z", 800],
+                                ["2022-01-01T01:30:00.000Z", 600],
+                            ],
+                        }
+                    ],
+                };
+
+                chart = myChart = testHelper.create(echarts, "main0", {
+                    option: option,
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Create correct stacked area chart when it contains time series, regardless of them being disjunct.



### Fixed issues

- #15742

## Details

### Before: What was the problem?

When stacking time series, echarts decided to use stacking by index.
This causes it to place data in places where it is not: Index 0 for one time series is not necessarily the same point in time as index 0 for another time series.


### After: How does it behave after the fixing?

For time series, stacking is set to stacking by dimension and an inverted index is created, allowing stacking to use the time value instead of the index for stacking. It reuses the mechanism for ordinal stacking.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

I added a visual test `line-stack-disjunct-timeseries.html`.
Please advise whether this should be put in an existing test or can be left stand alone.

All existing visual tests that pass for 6.0.0-beta.1 pass for this PR, however some seem to be flaky. With several runs the flaky ones also pass.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

I have not tested the performance of this on a large dataset.