### PR TITLE
fix(visualMap): fix dark mode should not provide inRange

### DIFF
--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -153,9 +153,6 @@ const theme = {
         textStyle: {
             color: color.secondary
         },
-        inRange: {
-            color: [color.neutral10, color.theme[0]]
-        },
         handleStyle: {
             borderColor: color.neutral30
         }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

When `inRange.color` was defined in dark theme, it may break the case where color isn't intended to use visualMap.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

v6 dark theme breaks the example at https://echarts.apache.org/examples/zh/editor.html?c=scatter-aqi-color .

<img width="600" height="450" alt="scatter-aqi-color" src="https://github.com/user-attachments/assets/f5e6bc9f-4381-4114-a994-faf06c195d09" />


### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

<img width="747" height="395" alt="image" src="https://github.com/user-attachments/assets/672392ae-1112-4a1b-9920-7f9ba60a526f" />


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
