### PR TITLE
fix: change the calculation of precision in round method

### DIFF
--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -157,7 +157,8 @@ export function round(x: number | string, precision: number, returnStr: false): 
 export function round(x: number | string, precision: number, returnStr: true): string;
 export function round(x: number | string, precision?: number, returnStr?: boolean): string | number {
     if (precision == null) {
-        precision = 10;
+        const expStr = (x + '').split('e')[1];
+        precision = expStr ? -expStr + 1 : 10;
     }
     // Avoid range error
     precision = Math.min(Math.max(0, precision), ROUND_SUPPORTED_PRECISION_MAX);

--- a/test/logScale.html
+++ b/test/logScale.html
@@ -38,6 +38,7 @@ under the License.
         <div id='main1'></div>
         <div id='main2_negative'></div>
         <div id='main_small_values'></div>
+        <div id='main3'></div>
 
 
         <script>
@@ -360,8 +361,35 @@ under the License.
 
         </script>
 
+        <script>
 
+            require([
+                'echarts',
+            ], function (echarts) {
 
+                option = {
+                    xAxis: {
+                        data: ['2017-10-24', '2017-10-25', '2017-10-26', '2017-10-27']
+                    },
+                    yAxis: {},
+                    series: [
+                        {
+                        type: 'candlestick',
+                        data: [
+                            ['0.000000000012', '0.000000000034', '0.000000000010', '0.000000000038']
+                        ]
+                        }
+                    ]
+                    };
+
+                var chart = testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Test Case Description of main0'
+                    ],
+                    option: option,
+                });
+            });
+        </script>
 
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
Revise the calculation of precision in round function based on [PR #16286](https://github.com/apache/echarts/pull/16286) .


### Fixed issues

<!--
- #xxxx: ...
-->
#16266 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
The dataset ['0.000000000012', '0.000000000034', '0.000000000010', '0.000000000038'] was round to 0 as data are too small.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
The dataset can be displayed normally after changing the precision based on the review suggestions in [PR #16286](https://github.com/apache/echarts/pull/16286). The testing examples is added to /test/logScale.html .

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
