### PR TITLE
feat(tooltip): add status to CallbackDataParams on trigger 'axis'

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -57,6 +57,7 @@ import { normalizeTooltipFormatResult } from '../../model/mixin/dataFormat';
 import { createTooltipMarkup, buildTooltipMarkup, TooltipMarkupStyleCreator } from './tooltipMarkup';
 import { findEventDispatcher } from '../../util/event';
 import { clear, createOrUpdate } from '../../util/throttle';
+import { getElementState } from '../../util/states';
 
 const proxyRect = new Rect({
     shape: { x: -1, y: -1, width: 2, height: 2 }
@@ -582,6 +583,11 @@ class TooltipView extends ComponentView {
                         axisModel.axis, { value: axisValue as number }
                     );
                     cbParams.axisValueLabel = axisValueLabel;
+                    const data = series.getData();
+                    const el = data.getItemGraphicEl(dataIndex);
+                    if (el) {
+                        cbParams.status = getElementState(el);
+                    }
                     // Pre-create marker style for makers. Users can assemble richText
                     // text in `formatter` callback and use those markers style.
                     cbParams.marker = markupStyleCreator.makeTooltipMarker(

--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -180,6 +180,19 @@ export function setStatesFlag(el: ECElement, stateName: DisplayState) {
     }
 }
 
+export function getElementState(el: ECElement): DisplayState {
+    if (el.selected) {
+        return 'select';
+    }
+    else if (el.hoverState === 1) {
+        return 'blur';
+    }
+    else if (el.hoverState === 2) {
+        return 'emphasis';
+    }
+    return 'normal';
+}
+
 /**
  * If we reuse elements when rerender.
  * DON'T forget to clearStates before we update the style and shape.

--- a/test/tooltip.html
+++ b/test/tooltip.html
@@ -52,6 +52,8 @@ under the License.
         <div class="chart" id="cross-item"></div>
         <h1>cross compatible | tooltip.trigger: 'axis' | xAxisPointer label not show</h1>
         <div class="chart" id="cross-axis"></div>
+        <h1>tooltip.trigger: 'axis' | callback params status ('normal' | 'emphasis' | 'blur' | 'select' | undefined)</h1>
+        <div class="chart" id="tooltip-axis-status"></div>
         <h1>tooltip.axisPointer.axis is 'y' | auto snap | auto animation when snap</h1>
         <div class="chart" id="tooltip.axisPointer.axis"></div>
         <h1>showDelay: 50 | enterable | dynamic callback</h1>
@@ -227,6 +229,44 @@ under the License.
         </script>
 
 
+
+
+
+        <script>
+
+            require(['echarts'], function (echarts) {
+
+                var option = {
+                    tooltip: {
+                        trigger: 'axis',
+                        formatter: function (params) {
+                            var result = params[0].name + '<br/>';
+                            for (var i = 0; i < params.length; i++) {
+                                var param = params[i];
+                                var statusText = param.status !== undefined ? ' (' + param.status + ')' : '';
+                                result += param.marker + param.seriesName + statusText + ': ' + param.value + '<br/>';
+                            }
+                            return result;
+                        }
+                    }
+                };
+                var baseTop = 90;
+                var height = 150;
+                var gap = 50;
+                makeCategoryGrid(option, {
+                    grid: {top: baseTop, height: height}
+                });
+                baseTop += height + gap;
+
+                var dom = document.getElementById('tooltip-axis-status');
+                if (dom) {
+                    dom.style.height = baseTop + 'px';
+                    var chart = echarts.init(dom);
+                    chart.setOption(option);
+                }
+            })
+
+        </script>
 
 
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Add status (`DisplayState`) to tooltip's formatter `CallbackDataParams` when using trigger `axis`. 


### Fixed issues
- https://github.com/apache/echarts/issues/11749
- https://github.com/apache/echarts/issues/14774

## Details

### Before: What was the problem?

When using `trigger: "axis"` tooltip, it's currently not possible to show which series are being focused/emphasized on the tooltip.

### After: How does it behave after the fixing?

`CallbackDataParams` now include `status` property 


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
