### PR TITLE
feat(radar): add clockwise options support

### DIFF
--- a/src/coord/radar/Radar.ts
+++ b/src/coord/radar/Radar.ts
@@ -126,6 +126,7 @@ class Radar implements CoordinateSystem, CoordinateSystemMaster {
         const refContainer = createBoxLayoutReference(radarModel, api).refContainer;
 
         const center = radarModel.get('center');
+        const clockwise = radarModel.get('clockwise') || false;
         const viewSize = Math.min(refContainer.width, refContainer.height) / 2;
         this.cx = numberUtil.parsePercent(center[0], refContainer.width) + refContainer.x;
         this.cy = numberUtil.parsePercent(center[1], refContainer.height) + refContainer.y;
@@ -140,9 +141,11 @@ class Radar implements CoordinateSystem, CoordinateSystemMaster {
         this.r0 = numberUtil.parsePercent(radius[0], viewSize);
         this.r = numberUtil.parsePercent(radius[1], viewSize);
 
+        const sign = clockwise ? -1 : 1;
+
         each(this._indicatorAxes, function (indicatorAxis, idx) {
             indicatorAxis.setExtent(this.r0, this.r);
-            let angle = (this.startAngle + idx * Math.PI * 2 / this._indicatorAxes.length);
+            let angle = (this.startAngle + sign * idx * Math.PI * 2 / this._indicatorAxes.length);
             // Normalize to [-PI, PI]
             angle = Math.atan2(Math.sin(angle), Math.cos(angle));
             indicatorAxis.angle = angle;

--- a/src/coord/radar/RadarModel.ts
+++ b/src/coord/radar/RadarModel.ts
@@ -60,6 +60,8 @@ export interface RadarOption extends ComponentOption, CircleLayoutOptionMixin {
 
     startAngle?: number
 
+    clockwise?: boolean
+
     shape?: 'polygon' | 'circle'
 
     // TODO. axisType seems to have issue.
@@ -106,6 +108,7 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
     optionUpdated() {
         const boundaryGap = this.get('boundaryGap');
         const splitNumber = this.get('splitNumber');
+        const clockwise = this.get('clockwise');
         const scale = this.get('scale');
         const axisLine = this.get('axisLine');
         const axisTick = this.get('axisTick');
@@ -135,6 +138,7 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
             const innerIndicatorOpt: InnerIndicatorAxisOption = zrUtil.merge(zrUtil.clone(indicatorOpt), {
                 boundaryGap: boundaryGap,
                 splitNumber: splitNumber,
+                clockwise: clockwise,
                 scale: scale,
                 axisLine: axisLine,
                 axisTick: axisTick,
@@ -186,6 +190,8 @@ class RadarModel extends ComponentModel<RadarOption> implements CoordinateSystem
         radius: '50%',
 
         startAngle: 90,
+
+        clockwise: false,
 
         axisName: {
             show: true,

--- a/test/radar-clockwise-interactive.html
+++ b/test/radar-clockwise-interactive.html
@@ -1,0 +1,330 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+</head>
+
+<body>
+    <style>
+        html,
+        body,
+        #main {
+            width: 100%;
+            height: 100%;
+        }
+
+        #switchBtn {
+            position: fixed;
+            top: 20px;
+            left: 20px;
+        }
+
+        #startAngle {
+            position: fixed;
+            top: 60px;
+            left: 20px;
+        }
+
+        #startAngleLabel {
+            position: fixed;
+            top: 40px;
+            left: 20px;
+        }
+    </style>
+    <div id="main"></div>
+    <button id="switchBtn">Switch to clockwise</button>
+    <input id="startAngle" type="range" min="0" max="360" value="90" />
+    <label for="startAngle" id="startAngleLabel">Start Angle: 90</label>
+    <script>
+
+        require([
+            'echarts'
+        ], function (echarts) {
+            var currentDirection = 'anti-clockwise';
+            var startAngle = 90;
+            var switchBtn = document.getElementById('switchBtn');
+            var startAngleInput = document.getElementById('startAngle');
+            var startAngleLabel = document.getElementById('startAngleLabel');
+
+            var chart = echarts.init(document.getElementById('main'));
+
+            chart.setOption({
+                tooltip: {
+                    trigger: 'item'
+                },
+                legend: {
+                    x: 'left',
+                    data: ['图一', '图二', '图三']
+                },
+                radar: [
+                    {
+                        id: 'radar1',
+                        indicator: [
+                            { text: '指标一' },
+                            { text: '指标二' },
+                            { text: '指标三' },
+                            { text: '指标四' },
+                            { text: '指标五' }
+                        ],
+                        center: ['25%', 210],
+                        radius: 150,
+                        startAngle: 90,
+                        splitNumber: 8,
+                        name: {
+                            formatter: '【{value}】',
+                            textStyle: { color: 'red' }
+                        },
+                        scale: true
+                    },
+                    {
+                        id: 'radar2',
+                        indicator: [
+                            {
+                                text: '语文', max: 150, nameTextStyle: {
+                                    color: '#000000', fontSize: 5
+                                }
+                            },
+                            {
+                                text: '数学', max: 150, axisLine: {
+                                    lineStyle: {
+                                        color: 'red'
+                                    }
+                                }
+                            },
+                            {
+                                text: '英语', max: 150, axisLine: {
+                                    lineStyle: {
+                                        color: 'red'
+                                    }
+                                }
+                            },
+                            {
+                                text: '物理', max: 120, axisLine: {
+                                    lineStyle: {
+                                        color: 'red'
+                                    }
+                                }
+                            },
+                            {
+                                text: '化学', max: 108, axisLine: {
+                                    lineStyle: {
+                                        color: 'red'
+                                    }
+                                }
+                            },
+                            {
+                                text: '生物', max: 72, axisLine: {
+                                    lineStyle: {
+                                        color: 'red'
+                                    }
+                                }
+                            }
+                        ],
+                        center: ['75%', 210],
+                        radius: 150
+                    },
+                    {
+                        id: 'radar3',
+                        indicator: [{
+                            name: 'a',
+                            max: 13
+                        },
+                        {
+                            name: 'b',
+                            max: 1,
+                            min: 0
+                        },
+                        {
+                            name: 'c',
+                            max: 16000
+                        },
+                        {
+                            name: 'd',
+                            max: 30000
+                        },
+                        {
+                            name: 'e',
+                            max: 38000
+                        },
+                        {
+                            name: 'f',
+                            max: 52000
+                        },
+                        {
+                            name: 'g',
+                            max: 25000
+                        }],
+                        radius: 150
+                    }
+                ],
+                series: [
+                    {
+                        name: '雷达图',
+                        type: 'radar',
+                        itemStyle: {
+                            emphasis: {
+                                // color: 各异,
+                                lineStyle: {
+                                    width: 4
+                                }
+                            }
+                        },
+                        data: [
+                            {
+                                value: [100, 8, 0.40, -80, 2000],
+                                name: '图一',
+                                symbol: 'diamond',
+                                symbolSize: 20,
+                                itemStyle: {
+                                    normal: {
+                                        lineStyle: {
+                                            type: 'dashed'
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                value: [10, 3, 0.20, -100, 1000],
+                                name: '图二',
+                                itemStyle: {
+                                    normal: {
+                                        areaStyle: {
+                                            type: 'default'
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                value: [20, 3, 0.3, -13.5, 3000],
+                                name: '图三',
+                                symbol: 'none',         // 拐点图形类型，非标准参数
+                                itemStyle: {
+                                    normal: {
+                                        lineStyle: {
+                                            type: 'dotted'
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        name: '成绩单',
+                        type: 'radar',
+                        polarIndex: 1,
+                        itemStyle: {
+                            normal: {
+                                areaStyle: {
+                                    type: 'default'
+                                }
+                            }
+                        },
+                        data: [
+                            {
+                                value: [120, 118, 130, 100, 99, 70],
+                                name: '张三',
+                                itemStyle: {
+                                    normal: {
+                                        label: {
+                                            show: true,
+                                            formatter: function (params) {
+                                                return params.value;
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                value: [90, 113, 140, 30, 70, 60],
+                                name: '李四',
+                                itemStyle: {
+                                    normal: {
+                                        lineStyle: {
+                                            type: 'dashed'
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        name: 'join',
+                        polarIndex: 2,
+                        type: 'radar',
+                        data: [{
+                            value: [
+                                3,
+                                1,
+                                1,
+                                53,
+                                66,
+                                18,
+                                0.0121
+                            ]
+                        }]
+                    }
+                ]
+            });
+
+            switchBtn.addEventListener('click', function () {
+                switchBtn.textContent = 'Switch to ' + currentDirection;
+                currentDirection = currentDirection === 'clockwise' ? 'anti-clockwise' : 'clockwise';
+                chart.setOption({
+                    radar: [{
+                        id: 'radar1',
+                        clockwise: currentDirection === 'clockwise'
+                    }, {
+                        id: 'radar2',
+                        clockwise: currentDirection === 'clockwise'
+                    }, {
+                        id: 'radar3',
+                        clockwise: currentDirection === 'clockwise'
+                    }]
+                });
+            });
+
+            startAngleInput.addEventListener('input', function () {
+                startAngle = parseInt(startAngleInput.value);
+                startAngleLabel.textContent = 'Start Angle: ' + startAngle;
+                chart.setOption({
+                    radar: [{
+                        id: 'radar1',
+                        startAngle: startAngle
+                    }, {
+                        id: 'radar2',
+                        startAngle: startAngle
+                    }, {
+                        id: 'radar3',
+                        startAngle: startAngle
+                    }]
+                }, {
+                    slient: true
+                });
+            });
+        });
+
+    </script>
+</body>
+
+</html>

--- a/test/radar-clockwise.html
+++ b/test/radar-clockwise.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <!-- <script src="ut/lib/canteen.js"></script> -->
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <style>
+    </style>
+
+    <div id="main0"></div>
+    <div id="main1"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            var option, radarComponent;
+
+            radarComponent = {
+                name: {
+                    textStyle: {
+                        color: '#fff',
+                        backgroundColor: '#999',
+                        borderRadius: 3,
+                        padding: [3, 5]
+                    }
+                },
+                indicator: [
+                    { name: '销售（sales）' },
+                    { name: '管理（Administration）' },
+                    { name: '信息技术（Information Techology）' },
+                    { name: '客服（Customer Support）' },
+                    { name: '研发（Development）' },
+                    { name: '市场（Marketing）' }
+                ],
+                axisLabel: {
+                    show: true,
+                    textStyle: {
+                        color: 'red'
+                    }
+                },
+            }
+
+            option = {
+                title: {
+                    text: '基础雷达图'
+                },
+                tooltip: {},
+                legend: {
+                    data: ['预算分配（Allocated Budget）', '实际开销（Actual Spending）']
+                },
+                radar: radarComponent,
+                series: [{
+                    name: '预算 vs 开销（Budget vs spending）',
+                    type: 'radar',
+                    // areaStyle: {normal: {}},
+                    data: [
+                        {
+                            value: [4300, 10000, 28000, 35000, 50000, 19000],
+                            name: '预算分配（Allocated Budget）'
+                        },
+                        {
+                            value: [5000, 14000, 28000, 31000, 42000, 21000],
+                            name: '实际开销（Actual Spending）'
+                        }
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    'Leave the `clockwise` option empty',
+                    'The direction of radar chart is anti-clockwise by default.'
+                ],
+                option: option
+            });
+
+            var chart2 = testHelper.create(echarts, 'main1', {
+                title: [
+                    'Set `clockwise` to true',
+                    'The indicator axes of radar chart should be rendered clockwise.'
+                ],
+                option: {
+                    ...option,
+                    radar: {
+                        ...radarComponent,
+                        clockwise: true
+                    }
+                }
+            });
+        });
+    </script>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

This pull request introduces support for configuring the direction of radar charts by adding a `clockwise` option.

### Fixed issues

closes #5190

## Details

### Before: What was the problem?

The radar chart indicator axis can only be arranged anti-clockwise; the original data must be modified to change it to clockwise.

### After: How does it behave after the fixing?

We can make the radar chart render in a clockwise direction using `options.radar.clockwise` (boolean).

<img width="731" height="979" alt="image" src="https://github.com/user-attachments/assets/7f3bbc38-43e2-4271-9b6b-71bd26eee3f6" />

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- test/radar-clockwise.html
- test/radar-clockwise-interactive.html

## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
