### PR TITLE
fix(husky): remote checkheader from pre-commit temporarily

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,3 @@
 
 npm run lint
 npm run checktype
-npm run checkheader


### PR DESCRIPTION
…is not completely correct and prevent commit.

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

Remote checkheader from pre-commit temporarily, since it is not completely correct and prevent commit.


Note: if support check header in pre-commit, need to:
+ Only check staged files.
+ Distinguish files that not need or can not add headers, such as, 
    + `json`, 
    + `md`, 
    + `license files itself`, 
    + `.xxx` file., including `.xxxconfig`, `.xxxignore`, ...
    + ...

