### PR TITLE
fix(toolbox): dataview style does not follow the theme

### DIFF
--- a/src/component/toolbox/feature/DataView.ts
+++ b/src/component/toolbox/feature/DataView.ts
@@ -455,6 +455,9 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
     }
 
     static getDefaultOption(ecModel: GlobalModel) {
+        const darkMode = ecModel.get('darkMode')
+	    const color = darkMode === true ? tokens.darkColor : tokens.color
+
         const defaultOption: ToolboxDataViewFeatureOption = {
             show: true,
             readOnly: false,
@@ -465,12 +468,12 @@ class DataView extends ToolboxFeature<ToolboxDataViewFeatureOption> {
             icon: 'M17.5,17.3H33 M17.5,17.3H33 M45.4,29.5h-28 M11.5,2v56H51V14.8L38.4,2H11.5z M38.4,2.2v12.7H51 M45.4,41.7h-28',
             title: ecModel.getLocaleModel().get(['toolbox', 'dataView', 'title']),
             lang: ecModel.getLocaleModel().get(['toolbox', 'dataView', 'lang']),
-            backgroundColor: tokens.color.background,
-            textColor: tokens.color.primary,
-            textareaColor: tokens.color.background,
-            textareaBorderColor: tokens.color.border,
-            buttonColor: tokens.color.accent50,
-            buttonTextColor: tokens.color.neutral00
+            backgroundColor: color.background,
+            textColor: color.primary,
+            textareaColor: color.background,
+            textareaBorderColor: color.border,
+            buttonColor: color.accent50,
+            buttonTextColor: color.neutral00
         };
 
         return defaultOption;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues
https://github.com/apache/echarts/issues/21170
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?
创建dark主题的实例，但是dataview的样式不是深色的
<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
<img width="1697" height="1349" alt="image" src="https://github.com/user-attachments/assets/d9dd27d8-ce9c-44ef-986c-d5e87311e0e8" />

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?
dataview的样式跟随主题
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.