### PR TITLE
fix(toolbox): fix dataView component does not fit dark mode

### DIFF
--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -106,7 +106,7 @@ const theme = {
         },
         feature: {
             dataView: {
-                backgroundColor: color.background,
+                backgroundColor: backgroundColor,
                 textColor: color.primary,
                 textareaColor: color.background,
                 textareaBorderColor: color.border,


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix the DataView component does not fit dark mode.


### Fixed issues

- Fix #21170


## Details

### Before: What was the problem?

Create an instance of the dark theme, but the style of the dataview is not dark

<img width="1697" height="1349" alt="image" src="https://github.com/user-attachments/assets/d9dd27d8-ce9c-44ef-986c-d5e87311e0e8" />


### After: How does it behave after the fixing?

The style of dataview follows the theme

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information