### PR TITLE
feat(matrix): support matrix.x/y.length for conveniently creating a headless matrix without composing an array

### DIFF
--- a/src/coord/matrix/MatrixDim.ts
+++ b/src/coord/matrix/MatrixDim.ts
@@ -149,6 +149,7 @@ export class MatrixDim {
         this._uniqueValueGen = createUniqueValueGenerator(dim);
 
         let dimModelData = dimModel.get('data', true);
+        const length = dimModel.get('length', true);
         if (dimModelData != null && !isArray(dimModelData)) {
             if (__DEV__) {
                 error(`Illegal echarts option - matrix.${this.dim}.data must be an array if specified.`);
@@ -156,6 +157,13 @@ export class MatrixDim {
             dimModelData = [];
         }
         if (dimModelData) {
+            this._initByDimModelData(dimModelData);
+        }
+        else if (length != null) {
+            dimModelData = Array(length);
+            for (let i = 0; i < length; i++) {
+                dimModelData[i] = null;
+            }
             this._initByDimModelData(dimModelData);
         }
         else {

--- a/src/coord/matrix/MatrixModel.ts
+++ b/src/coord/matrix/MatrixModel.ts
@@ -158,6 +158,9 @@ interface MatrixDimensionOption extends MatrixCellStyleOption, MatrixDimensionLe
     type?: 'category'; // For internal usage; force be 'category'.
     show?: boolean;
     data?: MatrixDimensionCellLooseOption[];
+    // A simple way to provide column/row count if no need to compose a `data`.
+    // Note: `length` is ignored if `data` is specified.
+    length?: number;
     // `levels[0]`: the topmost (for x dimension) or leftmost (for y dimension) level.
     // If not specified, use null/undefined, such as `levels: [null, null, {levelSize: 10}]`
     levels?: (MatrixDimensionLevelOption | NullUndefined)[];

--- a/test/matrix.html
+++ b/test/matrix.html
@@ -46,6 +46,7 @@ under the License.
         <div id="main4"></div>
         <div id="main_collect"></div>
         <div id="main_series_data_use_ordinal_number"></div>
+        <div id="main_x_y_length"></div>
 
 
 
@@ -661,6 +662,49 @@ under the License.
                 });
             });
         </script>
+
+
+
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+
+                var option = {
+                    matrix: {
+                        x: {length: 4},
+                        y: {length: 3},
+                    },
+                    series: {
+                        type: 'scatter',
+                        coordinateSystem: 'matrix',
+                        label: {show: true},
+                        encode: {label: 2},
+                        symbolSize: 20,
+                        data: [
+                            [0, 0, 1223],
+                            [1, 0, 323],
+                            [2, 0, 142],
+                            [0, 1, 63],
+                            [1, 1, 91],
+                            [2, 1, 45],
+                            [0, 2, 55],
+                            [1, 2, 15],
+                            [2, 2, 53],
+                        ]
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main_x_y_length', {
+                    title: [
+                        'matrx.x/y.length'
+                    ],
+                    option: option
+                });
+            });
+        </script>
+
 
 
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

A tiny update:

Support matrix.x/y.length for conveniently create matrix without composing an array when header is not needed.

Before:
```js
matrix: {
    x: {data: Array(5).fill(null)},
    y: {data: Array(3).fill(null)},
}
```
After:
```js
// Support this way, more straightforward.
matrix: {
    x: {length: 5},
    y: {length: 3},
}
```


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

**TODO** Doc: Need to clarify that:
If neither `matrix.x.data` nor `matrix.x.length` exists, it collect values from `series.data` or `dataset.source`.

