### PR TITLE
fix(dataZoom): fix wrong position of the dataZoom when the series has only one data point

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -294,8 +294,11 @@ class SliderZoomView extends DataZoomView {
 
         // Position barGroup
         const rect = thisGroup.getBoundingRect([sliderGroup]);
-        thisGroup.x = location.x - rect.x;
-        thisGroup.y = location.y - rect.y;
+        const rectX = isNaN(rect.x) ? 0 : rect.x;
+        const rectY = isNaN(rect.y) ? 0 : rect.y;
+
+        thisGroup.x = location.x - rectX;
+        thisGroup.y = location.y - rectY;
         thisGroup.markRedraw();
     }
 

--- a/test/dataZoom-single-datapoint.html
+++ b/test/dataZoom-single-datapoint.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="lib/canteen.js"></script> -->
+        <!-- <script src="lib/draggable.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            html {
+                /* Fix the line-height to integer to avoid it varying across clients and
+                   causing visual test failures. Some clients may not support fractional px. */
+                line-height: 18px;
+            }
+            #main0 {
+                width: 800px;
+                margin: 0 auto;
+            }
+        </style>
+
+        <div id="main0"></div>
+
+        <script>
+            require(['echarts'], function (echarts /*, data */) {
+                var option = {
+                    animation: false,
+                    dataZoom: {},
+                    xAxis: {
+                        type: 'time'
+                    },
+                    yAxis: {
+                        show: false,
+                        type: 'value',
+                        min: 0,
+                        max: 100
+                    },
+                    series: [
+                        {
+                            animation: false,
+                            name: 'Test',
+                            type: 'bar',
+                            barWidth: 4,
+                            data: [
+                                {
+                                    timestamp: 1753548900000,
+                                    value: [1753548900000, 50, 0]
+                                },
+                            ],
+                            dimensions: ['timestamp', 'value'],
+                            encode: {
+                                x: 0,
+                                y: 1
+                            }
+                        }
+                    ]
+                };
+
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Position of dataZoom when there is only one data point',
+                    ],
+                    option: option,
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Fix position of the dataZoom control when the series has only one data point. Please refer to the linked issue for more details.


### Fixed issues


- #21195 

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

