### PR TITLE
fix(chord): add missing export entry for chord chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "./lib/chart/bar": "./lib/chart/bar.js",
     "./lib/chart/boxplot": "./lib/chart/boxplot.js",
     "./lib/chart/candlestick": "./lib/chart/candlestick.js",
+    "./lib/chart/chord": "./lib/chart/chord.js",
     "./lib/chart/custom": "./lib/chart/custom.js",
     "./lib/chart/effectScatter": "./lib/chart/effectScatter.js",
     "./lib/chart/funnel": "./lib/chart/funnel.js",

--- a/src/chart/chord.ts
+++ b/src/chart/chord.ts
@@ -1,0 +1,24 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { use } from '../extension';
+import { install } from './chord/install';
+
+use(install);
+


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

The new chord chart introduced in #20522 is not added to export entries in the package.json, and the self-registered entry file `src/chart/chord.ts` is also missing.

<img width="1970" height="502" alt="image" src="https://github.com/user-attachments/assets/1d4b18a3-eaa2-49a4-92bb-9e472368238d" />


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
