### PR TITLE
fix(dataset): wrong area when dimension name is empty string

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -132,7 +132,7 @@ function getStackedOnPoints(
     data: SeriesData,
     dataCoordInfo: ReturnType<typeof prepareDataCoordInfo>
 ) {
-    if (!dataCoordInfo.valueDim) {
+    if (dataCoordInfo.valueDim == null) {
         return [];
     }
 

--- a/test/line-area-empty-dimension-name.html
+++ b/test/line-area-empty-dimension-name.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Line Area Empty Dimension Name Test</title>
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+</head>
+<body>
+    <style>
+        html, body, #main {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+    </style>
+    
+    <div id="main"></div>
+    
+    <script>
+        require(['echarts'], function (echarts) {
+            var chart = echarts.init(document.getElementById('main'));
+            
+            var option = {
+                title: {
+                    text: 'Line Area with Empty Dimension Name',
+                    left: 'center'
+                },
+                dataset: [{
+                    dimensions: [
+                        'x',
+                        {
+                            name: '', // Empty dimension name for area test
+                        }
+                    ],
+                    source: [
+                        [1, 20],
+                        [2, 10],
+                        [3, 25],
+                        [4, 15],
+                        [5, 18]
+                    ]
+                }],
+                xAxis: {
+                    type: 'category'
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [{
+                    type: 'line',
+                    areaStyle: {}
+                }]
+            };
+            
+            chart.setOption(option);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fix line area rendering issue when dataset dimension name is empty string.
<img width="958" height="373" alt="截屏2025-08-22 16 51 00" src="https://github.com/user-attachments/assets/f058dd4e-595f-47b0-9420-0533ef5d6cde" />

### Fixed issues

- #20756

## Details

### Before: What was the problem?

When `dataset.dimensions[].name` is set to an empty string `""`, the line chart with `areaStyle` renders incorrectly.

**Root cause:** In `getStackedOnPoints` function, empty string dimension name fails truthiness check:
```typescript
if (!dataCoordInfo.valueDim) {  // Empty string "" is falsy
    return [];
}
```

This causes the function to return empty `stackedOnPoints` array, breaking area rendering.

### After: How does it behave after the fixing?

Changed the check to only reject `null`/`undefined` values:
```typescript
if (dataCoordInfo.valueDim == null) {  // Only reject null/undefined
    return [];
}
```

Empty string dimension names are now treated as valid dimension names for area rendering.

## Document Info

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.
