### PR TITLE
feat(gauge): progress.color supports 'auto'

### DIFF
--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -564,6 +564,11 @@ class GaugeView extends ChartView {
                     const progress = progressList[idx];
                     progress.useStyle(data.getItemVisual(idx, 'style'));
                     progress.setStyle(itemModel.getModel(['progress', 'itemStyle']).getItemStyle());
+                    if (progress.style.fill === 'auto') {
+                        progress.setStyle('fill', getColor(
+                            linearMap(data.get(valueDim, idx) as number, valueExtent, [0, 1], true)
+                        ));
+                    }
                     (progress as ECElement).z2EmphasisLift = 0;
                     setStatesStylesFromModel(progress, itemModel);
                     toggleHoverEmphasis(progress, focus, blurScope, emphasisDisabled);

--- a/src/chart/gauge/GaugeView.ts
+++ b/src/chart/gauge/GaugeView.ts
@@ -529,6 +529,7 @@ class GaugeView extends ChartView {
                 const focus = emphasisModel.get('focus');
                 const blurScope = emphasisModel.get('blurScope');
                 const emphasisDisabled = emphasisModel.get('disabled');
+                const autoColor = getColor(linearMap(data.get(valueDim, idx) as number, valueExtent, [0, 1], true));
                 if (showPointer) {
                     const pointer = data.getItemGraphicEl(idx) as ECSymbol;
                     const symbolStyle = data.getItemVisual(idx, 'style');
@@ -550,9 +551,7 @@ class GaugeView extends ChartView {
 
 
                     if (pointer.style.fill === 'auto') {
-                        pointer.setStyle('fill', getColor(
-                            linearMap(data.get(valueDim, idx) as number, valueExtent, [0, 1], true)
-                        ));
+                        pointer.setStyle('fill', autoColor);
                     }
 
                     (pointer as ECElement).z2EmphasisLift = 0;
@@ -565,9 +564,7 @@ class GaugeView extends ChartView {
                     progress.useStyle(data.getItemVisual(idx, 'style'));
                     progress.setStyle(itemModel.getModel(['progress', 'itemStyle']).getItemStyle());
                     if (progress.style.fill === 'auto') {
-                        progress.setStyle('fill', getColor(
-                            linearMap(data.get(valueDim, idx) as number, valueExtent, [0, 1], true)
-                        ));
+                        progress.setStyle('fill', autoColor);
                     }
                     (progress as ECElement).z2EmphasisLift = 0;
                     setStatesStylesFromModel(progress, itemModel);

--- a/test/gauge-progress.html
+++ b/test/gauge-progress.html
@@ -346,6 +346,58 @@ under the License.
                     chart5.setOption(option5, true);
                 }}]
             });
+            var option6 = {
+                tooltip: {
+                    formatter: '{a} <br/>{b} : {c}%'
+                },
+                toolbox: {
+                    feature: {
+                        restore: {},
+                        saveAsImage: {}
+                    }
+                },
+                series: [
+                    {
+                        name: '业务指标',
+                        type: 'gauge',
+                        axisLine: {
+                            lineStyle: {
+                                width: 5,
+                                color: [
+                                    [0.3, '#67e0e3'],
+                                    [0.7, '#37a2da'],
+                                    [1, '#fd666d']
+                                ]
+                            }
+                        },
+                        progress:{
+                            show:true,
+                            overlap:true,
+                            width:-10,
+                            itemStyle: {
+                                color: 'auto'
+                            }
+                        },
+                        pointer: {
+                            show: false,
+                        },
+                        data: [
+                            {value: 50, name: '本月跑步'}
+                        ],
+                    }
+                ]
+            };
+            var chart6 = testHelper.create(echarts, 'main6', {
+                title: [
+                    'progress.itemStyle.color: \'auto\''
+                ],
+                renderer: 'svg',
+                option: option6
+            });
+            setInterval(function () {
+                option6.series[0].data[0].value = (Math.random() * 100).toFixed(2) - 0;
+                chart6.setOption(option6, true);
+            }, 2000);
 
         });
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Apply correct color to gauge chart progress when set to 'auto' in svg renderer.



### Fixed issues

- fixes #19884


## Details

### Before: What was the problem?

See the issue for more details.

<img width="979" height="919" alt="image" src="https://github.com/user-attachments/assets/6e047ecf-6fbd-4c67-94b1-cfe3ffbe188c" />

### After: How does it behave after the fixing?

<img width="892" height="833" alt="image" src="https://github.com/user-attachments/assets/425b27b1-c57c-4a2b-b298-89c30f7eca18" />

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
