### PR TITLE
fix(chart/graph): Correct type of nodeScaleRatio on graph

### DIFF
--- a/src/chart/graph/GraphSeries.ts
+++ b/src/chart/graph/GraphSeries.ts
@@ -173,7 +173,7 @@ export interface GraphSeriesOption
     /**
      * Symbol size scale ratio in roam
      */
-    nodeScaleRatio?: 0.6,
+    nodeScaleRatio?: number,
 
     draggable?: boolean
 


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information
Correct type of nodeScaleRatio on graph

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
update type of nodeScaleRatio from fixed value to number 
<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
