### PR TITLE
Adds support for changing the tick interval base

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -163,6 +163,12 @@ export interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {
      * Will be ignored if interval is set.
      */
     alignTicks?: boolean
+
+    /**
+     * Configures the base of the interval to be used, e.g. use 2 for binary-based nice intervals (1, 2, 4, 8 × 2^n)
+     * or 10 for decimal-based intervals (1, 2, 5 × 10^n) (default).
+     */
+    tickBase?: number;
 }
 
 export interface CategoryAxisBaseOption extends AxisBaseOptionCommon {

--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -178,7 +178,8 @@ export function niceScaleExtent(
         fixMin: extentInfo.fixMin,
         fixMax: extentInfo.fixMax,
         minInterval: isIntervalOrTime ? model.get('minInterval') : null,
-        maxInterval: isIntervalOrTime ? model.get('maxInterval') : null
+        maxInterval: isIntervalOrTime ? model.get('maxInterval') : null,
+        tickBase: isIntervalOrTime ? model.get('tickBase') : undefined
     });
 
     // If some one specified the min, max. And the default calculated interval

--- a/src/scale/Interval.ts
+++ b/src/scale/Interval.ts
@@ -285,7 +285,7 @@ class IntervalScale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> e
      *
      * @param splitNumber By default `5`.
      */
-    calcNiceTicks(splitNumber?: number, minInterval?: number, maxInterval?: number): void {
+    calcNiceTicks(splitNumber?: number, minInterval?: number, maxInterval?: number, tickBase?: number): void {
         splitNumber = splitNumber || 5;
         let extent = this._extent.slice() as [number, number];
         let span = this._getExtentSpanWithBreaks();
@@ -302,7 +302,7 @@ class IntervalScale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> e
         }
 
         const result = helper.intervalScaleNiceTicks(
-            extent, span, splitNumber, minInterval, maxInterval
+            extent, span, splitNumber, minInterval, maxInterval, tickBase,
         );
 
         this._intervalPrecision = result.intervalPrecision;
@@ -316,6 +316,7 @@ class IntervalScale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> e
         fixMax?: boolean,
         minInterval?: number,
         maxInterval?: number
+        tickBase?: number,
     }): void {
         let extent = this._extent.slice() as [number, number];
         // If extent start and end are same, expand them
@@ -350,7 +351,7 @@ class IntervalScale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> e
         this._innerSetExtent(extent[0], extent[1]);
         extent = this._extent.slice() as [number, number];
 
-        this.calcNiceTicks(opt.splitNumber, opt.minInterval, opt.maxInterval);
+        this.calcNiceTicks(opt.splitNumber, opt.minInterval, opt.maxInterval, opt.tickBase);
         const interval = this._interval;
         const intervalPrecition = this._intervalPrecision;
 

--- a/src/scale/Scale.ts
+++ b/src/scale/Scale.ts
@@ -250,6 +250,7 @@ abstract class Scale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> 
             fixMax?: boolean,
             minInterval?: number,
             maxInterval?: number
+            tickBase?: number,
         }
     ): void;
 

--- a/src/scale/helper.ts
+++ b/src/scale/helper.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {getPrecision, round, nice, quantityExponent} from '../util/number';
+import {getPrecision, round, nice, niceBinary, quantityExponent} from '../util/number';
 import IntervalScale from './Interval';
 import LogScale from './Log';
 import type Scale from './Scale';
@@ -53,12 +53,13 @@ export function intervalScaleNiceTicks(
     spanWithBreaks: number,
     splitNumber: number,
     minInterval?: number,
-    maxInterval?: number
+    maxInterval?: number,
+    tickBase?: number
 ): intervalScaleNiceTicksResult {
 
     const result = {} as intervalScaleNiceTicksResult;
 
-    let interval = result.interval = nice(spanWithBreaks / splitNumber, true);
+    let interval = result.interval = getNiceInterval(spanWithBreaks / splitNumber, true, tickBase);
     if (minInterval != null && interval < minInterval) {
         interval = result.interval = minInterval;
     }
@@ -172,4 +173,15 @@ export function logTransform(base: number, extent: number[], noClampNegative?: b
         Math.log(noClampNegative ? extent[0] : Math.max(0, extent[0])) / loggedBase,
         Math.log(noClampNegative ? extent[1] : Math.max(0, extent[1])) / loggedBase
     ];
+}
+
+function getNiceInterval(val: number, round?: boolean, base?: number): number {
+  if (base === 2) {
+    return niceBinary(val, round);
+  }
+ else if (base === 10) {
+    return nice(val, round);
+  }
+  // default to base 10
+  return nice(val, round);
 }

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -522,6 +522,52 @@ export function nice(val: number, round?: boolean): number {
 }
 
 /**
+ * Binary-based nice function for bytes, memory, etc.
+ * Produces intervals like 1, 2, 4, 8 × 2^n
+ */
+export function niceBinary(val: number, round?: boolean): number {
+    const exp2 = Math.pow(2, Math.floor(Math.log2(val)));
+    const f = val / exp2; // 1 <= f < 2
+
+    let nf: number;
+    if (round) {
+        if (f < 1.5) {
+            nf = 1;
+        }
+        else if (f < 2.5) {
+            nf = 2;
+        }
+        else if (f < 4) {
+            nf = 4;
+        }
+        else if (f < 7) {
+            nf = 8;
+        }
+        else {
+            nf = 16;
+        }
+    }
+    else {
+        if (f < 1) {
+            nf = 1;
+        }
+        else if (f < 2) {
+            nf = 2;
+        }
+        else if (f < 3) {
+            nf = 4;
+        }
+        else if (f < 5) {
+            nf = 8;
+        }
+        else {
+            nf = 16;
+        }
+    }
+    return nf * exp2;
+}
+
+/**
  * This code was copied from "d3.js"
  * <https://github.com/d3/d3/blob/9cc9a875e636a1dcf36cc1e07bdf77e1ad6e2c74/src/arrays/quantile.js>.
  * See the license statement at the head of this file.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

This PR adds the ability to change the base of the tick intervals to align on (1, 2, 3, 4,... * base^x).


### Fixed issues

https://github.com/apache/echarts/issues/21208


## Details

### Before: What was the problem?

When using KMB formatting for a unit that is non base 10 such as binary bytes, the tick intervals will align on a multiple of a base 10 number, so when the formatting occurs the number do not align nicely with the KMB formatting. Setting the interval manually can be difficult/expensive when you have a highly variable, dynamic dataset.

For example, where formatter code looks like so:
```
function (value) {
  if (value >= 1024 * 1024 * 1024) {
    return (value / (1024 * 1024 * 1024)).toFixed(2) + ' GiB';
  } else if (value >= 1024 * 1024) {
    return (value / (1024 * 1024)).toFixed(2) + ' MiB';
  } else if (value >= 1024) {
    return (value / 1024).toFixed(2) + ' KiB';
  } else {
    return value + ' B';
  }
}
```

<img width="1441" height="308" alt="Screenshot 2025-09-02 at 3 09 39 PM" src="https://github.com/user-attachments/assets/4b984398-1e71-4ea9-909c-1cea2c4745f7" />

### After: How does it behave after the fixing?

When using the same formatter but with tickBase = 2

<img width="1458" height="306" alt="Screenshot 2025-09-02 at 3 11 35 PM" src="https://github.com/user-attachments/assets/f937de15-73e1-4178-b7bb-fddf4816b123" />

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Let me know what you think! Thanks!
