### PR TITLE
feat: Introducing "mixed" valued Pie Chart

### DIFF
--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -115,7 +115,7 @@ export interface PieSeriesOption extends
 
     type?: 'pie'
 
-    roseType?: 'radius' | 'area'
+    roseType?: 'radius' | 'area' | 'mixed'
 
     clockwise?: boolean
     startAngle?: number

--- a/test/pie-mixed-rose-type.html
+++ b/test/pie-mixed-rose-type.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>ECharts Mixed Rose Type Test</title>
+    <script src="../dist/echarts.js"></script>
+</head>
+<body>
+    <div id="main" style="width: 600px; height: 400px;"></div>
+    <div>
+        <button onclick="setRoseType('radius')">Radius</button>
+        <button onclick="setRoseType('area')">Area</button>
+        <button onclick="setRoseType('mixed')">Mixed</button>
+        <button onclick="setRoseType(false)">None</button>
+    </div>
+    <script>
+        var chart = echarts.init(document.getElementById('main'));
+
+        var option = {
+            title: {
+                text: 'Rose Type Test',
+                left: 'center'
+            },
+            tooltip: {
+                trigger: 'item',
+                formatter: function(params) {
+                    if (Array.isArray(params.value) && params.value.length >= 2) {
+                        return params.seriesName + '<br/>' +
+                               params.name + ': Radius=' + params.value[0] + ', Angle=' + params.value[1] + ' (' + params.percent + '%)';
+                    } else {
+                        return params.seriesName + '<br/>' +
+                               params.name + ': ' + params.value + ' (' + params.percent + '%)';
+                    }
+                }
+            },
+            series: [
+                {
+                    name: 'Rose Type',
+                    type: 'pie',
+                    radius: ['30%', '70%'],
+                    center: ['50%', '50%'],
+                    roseType: 'mixed', // Default to mixed
+                    data: [
+                        { value: [10, 15], name: 'A' },
+                        { value: [20, 25], name: 'B' },
+                        { value: [30, 35], name: 'C' },
+                        { value: [40, 45], name: 'D' },
+                        { value: [50, 55], name: 'E' }
+                    ],
+                    label: {
+                        show: true,
+                        formatter: function(params) {
+                            if (Array.isArray(params.value) && params.value.length >= 2) {
+                                return params.name + ': R=' + params.value[0] + ', A=' + params.value[1];
+                            } else {
+                                return params.name + ': ' + params.value;
+                            }
+                        }
+                    }
+                }
+            ]
+        };
+
+        chart.setOption(option);
+
+        function setRoseType(type) {
+            option.series[0].roseType = type;
+
+            // Convert data format based on roseType
+            if (type === 'mixed') {
+                // Ensure data is in array format for mixed type
+                option.series[0].data = [
+                    { value: [10, 15], name: 'A' },
+                    { value: [20, 25], name: 'B' },
+                    { value: [30, 35], name: 'C' },
+                    { value: [40, 45], name: 'D' },
+                    { value: [50, 55], name: 'E' }
+                ];
+            } else {
+                // Convert to single values for other types
+                // For non-mixed types, use the average of the two values
+                option.series[0].data = [
+                    { value: 12.5, name: 'A' }, // Average of [10, 15]
+                    { value: 22.5, name: 'B' }, // Average of [20, 25]
+                    { value: 32.5, name: 'C' }, // Average of [30, 35]
+                    { value: 42.5, name: 'D' }, // Average of [40, 45]
+                    { value: 52.5, name: 'E' }  // Average of [50, 55]
+                ];
+            }
+
+            chart.setOption(option);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Adding "mixed" type of the pie chart that will allow generate roses of variable radius + variable arc lengths



### Fixed issues

N/A

## Details

### Before: What was the problem?

Previously you could either specify "area" or "radius" for the `roseType` which reduced the number of possible dimensions of quantitative data to apply


<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

Now you could specify "mixed" `roseType` for the pie chart and supply two elements to the array of values:

- first element is responsible for the radius
- second element is responsible for the arc length

Example of the newly supported `roseType`:

```js
        const option = {
            title: {
                text: 'Rose Type Test',
                left: 'center'
            },
            tooltip: {
                trigger: 'item',
                formatter: function(params) {
                    if (Array.isArray(params.value) && params.value.length >= 2) {
                        return params.seriesName + '<br/>' +
                               params.name + ': Radius=' + params.value[0] + ', Angle=' + params.value[1] + ' (' + params.percent + '%)';
                    } else {
                        return params.seriesName + '<br/>' +
                               params.name + ': ' + params.value + ' (' + params.percent + '%)';
                    }
                }
            },
            series: [
                {
                    name: 'Rose Type',
                    type: 'pie',
                    radius: ['30%', '70%'],
                    center: ['50%', '50%'],
                    roseType: 'mixed',
                    data: [
                        { value: [10, 15], name: 'A' },
                        { value: [20, 25], name: 'B' },
                        { value: [30, 35], name: 'C' },
                        { value: [40, 45], name: 'D' },
                        { value: [50, 55], name: 'E' }
                    ],
                    label: {
                        show: true,
                        formatter: function(params) {
                            if (Array.isArray(params.value) && params.value.length >= 2) {
                                return params.name + ': R=' + params.value[0] + ', A=' + params.value[1];
                            } else {
                                return params.name + ': ' + params.value;
                            }
                        }
                    }
                }
            ]
        };
```

the full interactive example is added to:

`test/pie-mixed-rose-type.html`

## Document Info

One of the following should be checked.

- [] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
