### PR TITLE
fix(core): mark echarts instance object as raw in Vue

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -437,6 +437,9 @@ class ECharts extends Eventful<ECEventDefinition> {
 
         opts = opts || {};
 
+        // mark the echarts instance as raw in Vue 3 to prevent the object being converted to be a proxy.
+        (this as any).__v_skip = true;
+
         this._dom = dom;
 
         let defaultRenderer = 'canvas';

--- a/test/echarts-in-vue.html
+++ b/test/echarts-in-vue.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="https://registry.npmmirror.com/vue/2.6.0/files/dist/vue.min.js"></script>
+        <script>
+            window.Vue2 = window.Vue;
+            window.Vue = null
+        </script>
+        <script src="https://registry.npmmirror.com/vue/3.5.22/files/dist/vue.global.prod.js"></script>
+        <script>
+            window.Vue3 = window.Vue;
+            window.Vue = null
+        </script>
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            html {
+                line-height: 18px;
+            }
+        </style>
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+        <div id="main3"></div>
+        <div id="main4"></div>
+        <div id="main5"></div>
+        <div id="main6"></div>
+
+        <script>
+            var option = {
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'shadow'
+                    }
+                },
+                xAxis:{
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'Direct',
+                        type: 'bar',
+                        data: [10, 52, 200, 334, 390, 330, 220]
+                    }
+                ]
+            };
+
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Wrap echarts instance using Vue3 **ref**',
+                        'Should **show** the tooltip'
+                    ],
+                    option
+                });
+                const { ref } = window.Vue3;
+                const chartInstance = ref(chart);
+                const isSame = chartInstance.value === chart;
+                chartInstance.value.setOption({
+                    title: {
+                        text: `is the same chart instance object: ${isSame}`,
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.value.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Wrap echarts instance using Vue3 **shallowRef**',
+                        'Should **show** the tooltip'
+                    ],
+                    option
+                });
+                const { shallowRef } = window.Vue3;
+                const chartInstance = shallowRef(chart);
+                const isSame = chartInstance.value === chart;
+                chartInstance.value.setOption({
+                    title: {
+                        text: `is the same chart instance object: ${isSame}`,
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.value.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Wrap echarts instance using Vue3 **reactive**',
+                        'Should **show** the tooltip'
+                    ],
+                    option
+                });
+                const { reactive } = window.Vue3;
+                const chartInstance = reactive(chart);
+                const isSame = chartInstance === chart;
+                chartInstance.setOption({
+                    title: {
+                        text: `is the same chart instance object: ${isSame}`,
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Wrap echarts instance using Vue3 **shallowReactive**',
+                        'Should **show** the tooltip'
+                    ],
+                    option
+                });
+                const { shallowReactive } = window.Vue3;
+                const chartInstance = shallowReactive(chart);
+                const isSame = chartInstance === chart;
+                chartInstance.setOption({
+                    title: {
+                        text: `is the same chart instance object: ${isSame}`,
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main4', {
+                    title: [
+                        'Wrap echarts instance using Vue3 **markRaw**',
+                        'Should **show** the tooltip'
+                    ],
+                    option
+                });
+                const { markRaw } = window.Vue3;
+                const chartInstance = markRaw(chart);
+                const isSame = chartInstance === chart;
+                chartInstance.setOption({
+                    title: {
+                        text: `is the same chart instance object: ${isSame}`,
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main5', {
+                    title: [
+                        'Mount echarts instance using Vue2 **data**',
+                        'Should **show** the tooltip'
+                    ]
+                });
+                chart.dispose();
+                new window.Vue2({
+                    el: '#main5 .test-chart',
+                    template: `<div class="test-chart" ref="chartDom"></div>`,
+                    data() {
+                        return {
+                            chartInstance: null
+                        }
+                    },
+                    mounted() {
+                        const chart = echarts.init(this.$refs.chartDom);
+                        this.chartInstance = chart;
+                        this.chartInstance.setOption(option);
+                        const isSame = this.chartInstance === chart;
+                        this.chartInstance.setOption({
+                            title: {
+                                text: [
+                                    `is the same chart instance object: ${isSame}`,
+                                    `is being deeply proxied: ${!!this.chartInstance._model.option.__ob__}`
+                                ].join('\n'),
+                                textStyle: {
+                                    color: isSame ? 'green' : 'red'
+                                }
+                            }
+                        });
+                        setTimeout(() => {
+                            this.chartInstance.dispatchAction({
+                                type: 'showTip',
+                                seriesIndex: 0,
+                                dataIndex: 2
+                            });
+                        });
+                    }
+                })
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+            ], function (echarts) {
+                const chart = testHelper.create(echarts, 'main6', {
+                    title: [
+                        'Wrap echarts instance using Vue2 **observable**',
+                        'Should **show** the tooltip'
+                    ],
+                   option
+                });
+                const { observable } = window.Vue2;
+                const chartInstance = observable(chart);
+                const isSame = chartInstance === chart;
+                chartInstance.setOption({
+                    title: {
+                        text: [
+                            `is the same chart instance object: ${isSame}`,
+                            `is being deeply proxied: ${!!chartInstance._model.option.__ob__}`
+                        ].join('\n'),
+                        textStyle: {
+                            color: isSame ? 'green' : 'red'
+                        }
+                    }
+                });
+                setTimeout(() => {
+                    chartInstance.dispatchAction({
+                        type: 'showTip',
+                        seriesIndex: 0,
+                        dataIndex: 2
+                    });
+                });
+            });
+        </script>
+
+    </body>
+</html>
+


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

For a long time, many Vue developers have used `ref` or `reactive` by default to wrap the echarts instance object, which makes ECharts' internal properties also converted into a `Proxy`. As a result, all judgment logic in the ECharts internal code that uses `===` to determine whether two objects are identical returns `false`, which causes some components, such as the tooltip under the axis, not to function properly. Example:

<img width="588" height="671" alt="image" src="https://github.com/user-attachments/assets/67f8bd52-e140-4719-bea3-9083ea41b277" />

In the above code snippet, axis is the original object, but `coordSys.getAxis(axis.dim)` returns a proxied object. The two are no longer identical, resulting in missing data collected by collectSeriesInfo and a non-functional axis tooltip. Similar code libraries may also contain similar situations.

Although I previously added relevant instructions at [FAQ](https://echarts.apache.org/faq.html#others) and included [usage warnings](https://vuejs.org/api/reactivity-advanced.html#markraw) from the official Vue documentation, and reiterated this in the GitHub issue: https://github.com/apache/echarts/issues/17723#issuecomment-1268311307, many developers still remain unaware and continue to file issues. Until I saw another issue today, I thought it is time to address this issue.

I've considered two solutions to this problem:

- **Prominently remind Vue users in the documentation or Handbook to use `shallowRef`, `shallowReactive`, or common variables to receive echarts instances, or to mark instances as non-proxied using `markRaw`.** - But this does not solve the root issue.

- **Add a line of Vue-specific code to the echarts constructor to mark echarts objects as non-proxied by default.** - This is what this PR does.

### Fixed issues

- Fix #21267
- Fix #21225
- Fix #17723
- Fix #17496
- Fix #16681
- Fix #16659
- Fix #16642
- Fix #16061
- Fix #15845
- Fix #15967
- Fix #15457
- Fix #14974
- Fix #14342
- Fix #14339
- Fix #15253
- Fix #13943
- Fix #13537
- More similar issues

## Details

### Before: What was the problem?

When wrapping the echarts instance object with `ref/reactive` in Vue, some components, like `tooltip`, can't work as expected.

### After: How does it behave after the fixing?

Mark the echarts instance as raw to prevent the object from being converted to a proxy.

<img width="1468" height="765" alt="image" src="https://github.com/user-attachments/assets/a5c7a794-3b60-4ffc-91f6-e5338515d4b4" />

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

See `test/echarts-in-vue.html`

## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
