### PR TITLE
fix(type): add missing nullable type for the axis `min` and `max` option

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -102,14 +102,14 @@ export interface AxisBaseOptionCommon extends ComponentOption,
      * + 'dataMin': use the min value in data.
      * + null/undefined: auto decide min value (consider pretty look and boundaryGap).
      */
-    min?: ScaleDataValue | 'dataMin' | ((extent: {min: number, max: number}) => ScaleDataValue);
+    min?: ScaleDataValue | 'dataMin' | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
     /**
      * Max value of the axis. can be:
      * + ScaleDataValue
      * + 'dataMax': use the max value in data.
      * + null/undefined: auto decide max value (consider pretty look and boundaryGap).
      */
-    max?: ScaleDataValue | 'dataMax' | ((extent: {min: number, max: number}) => ScaleDataValue);
+    max?: ScaleDataValue | 'dataMax' | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
     startValue?: number;
 
     jitter?: number;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Adding support for null/undefined as a return type for the function value min/max axis option. (As per [documentation](https://echarts.apache.org/en/option.html#yAxis.max) null/undefined return type is supported)



### Fixed issues
https://github.com/apache/echarts/issues/21312
<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

function for min/max in yAxis/xAxis did not accept null/undefined as a fallback value.
Typescript throws compile error 

> Types of property 'max' are incompatible.

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

Added support for null/undefined, typescript no longer throws an error.
<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
