### PR TITLE
feat: the value axis range should be designed to accommodate marker

### DIFF
--- a/src/component/marker/checkMarkerInSeries.ts
+++ b/src/component/marker/checkMarkerInSeries.ts
@@ -20,7 +20,7 @@
 import { isArray } from 'zrender/src/core/util';
 import { SeriesOption } from '../../util/types';
 
-type MarkerTypes = 'markPoint' | 'markLine' | 'markArea';
+export type MarkerTypes = 'markPoint' | 'markLine' | 'markArea';
 
 type SeriesWithMarkerOption = SeriesOption & Partial<Record<MarkerTypes, unknown>>;
 

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -129,9 +129,6 @@ export interface AxisBaseOptionCommon extends ComponentOption,
     breakLabelLayout?: {
         moveOverlap?: 'auto' | boolean;
     }
-
-    // Whether to include marker data (markPoint, markLine, markArea) in axis extent calculation
-    includeMarkerInExtent?: boolean;
 }
 
 export interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {

--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -129,6 +129,9 @@ export interface AxisBaseOptionCommon extends ComponentOption,
     breakLabelLayout?: {
         moveOverlap?: 'auto' | boolean;
     }
+
+    // Whether to include marker data (markPoint, markLine, markArea) in axis extent calculation
+    includeMarkerInExtent?: boolean;
 }
 
 export interface NumericAxisBaseOptionCommon extends AxisBaseOptionCommon {

--- a/src/coord/cartesian/AxisModel.ts
+++ b/src/coord/cartesian/AxisModel.ts
@@ -37,6 +37,8 @@ export type CartesianAxisOption = AxisBaseOption & {
     // Offset is for multiple axis on the same position.
     offset?: number;
     categorySortInfo?: OrdinalSortInfo;
+    // Whether to include marker data (markPoint, markLine, markArea) in axis extent calculation
+    includeMarkerInExtent?: boolean;
 };
 
 export type XAXisOption = CartesianAxisOption & {

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -569,7 +569,7 @@ class Grid implements CoordinateSystemMaster {
         ): void {
             const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? false;
             const isValidNumber = typeof value === 'number' && !isNaN(value);
-            if (includeMarkerInExtent && isValidNumber && axisType !== 'category') {
+            if (includeMarkerInExtent && (isValidNumber || typeof value === 'string') && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {
                     axis.scale.unionExtentByValue(val);

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -572,7 +572,10 @@ class Grid implements CoordinateSystemMaster {
             if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {
-                    axis.scale._innerUnionExtent([val, val]);
+                    // Construct the parameter and use unionExtentFromData to avoid using the private method _innerUnionExtent
+                    axis.scale.unionExtentFromData({
+                        getApproximateExtent: () => [val, val]
+                    } as any, 0);
                 }
             }
         }

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -587,9 +587,8 @@ class Grid implements CoordinateSystemMaster {
                 if (!item) {
                     return;
                 }
-                const items = isObject(item) && !item.coord && !item.xAxis && !item.yAxis
-                    ? (Array.isArray(item) ? item : [item])
-                    : [item];
+                const items = isObject(item) && !item.coord && !item.xAxis && !item.yAxis && Array.isArray(item)
+                    ? item : [item];
 
                 each(items, function (markerItem) {
                     if (!markerItem) {

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -589,8 +589,7 @@ class Grid implements CoordinateSystemMaster {
                 if (!item) {
                     return;
                 }
-                const items = isObject(item) && !item.coord && !item.xAxis && !item.yAxis && Array.isArray(item)
-                    ? item : [item];
+                const items = Array.isArray(item) ? item : [item];
 
                 each(items, function (markerItem) {
                     if (!markerItem) {

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -568,7 +568,6 @@ class Grid implements CoordinateSystemMaster {
             axis: Axis2D,
             axisType: OptionAxisType,
         ): void {
-            // 检查该轴是否配置为包含 marker 数据
             const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? true;
             if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
                 const val = axis.scale.parse(value);

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -568,7 +568,8 @@ class Grid implements CoordinateSystemMaster {
             axisType: OptionAxisType,
         ): void {
             const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? false;
-            if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
+            const isValidNumber = typeof value === 'number' && !isNaN(value);
+            if (includeMarkerInExtent && isValidNumber && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {
                     axis.scale.unionExtentByValue(val);

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -53,7 +53,7 @@ import {
     updateCartesianAxisViewCommonPartBuilder,
     isCartesian2DInjectedAsDataCoordSys
 } from './cartesianAxisHelper';
-import { CategoryAxisBaseOption, NumericAxisBaseOptionCommon } from '../axisCommonTypes';
+import { CategoryAxisBaseOption, NumericAxisBaseOptionCommon, OptionAxisType } from '../axisCommonTypes';
 import { AxisBaseModel } from '../AxisBaseModel';
 import { isIntervalOrLogScale } from '../../scale/helper';
 import { alignScaleTicks } from '../axisAlignTicks';
@@ -566,9 +566,11 @@ class Grid implements CoordinateSystemMaster {
         function UnionExtentForAxisByValue(
             value: any,
             axis: Axis2D,
-            axisType: string,
+            axisType: OptionAxisType,
         ): void {
-            if (value != null && typeof value !== 'string' && axisType !== 'category') {
+            // 检查该轴是否配置为包含 marker 数据
+            const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? true;
+            if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {
                     axis.scale._innerUnionExtent([val, val]);

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -567,7 +567,7 @@ class Grid implements CoordinateSystemMaster {
             axis: Axis2D,
             axisType: OptionAxisType,
         ): void {
-            const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? true;
+            const includeMarkerInExtent = axis.model.get('includeMarkerInExtent') ?? false;
             if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {

--- a/src/coord/cartesian/Grid.ts
+++ b/src/coord/cartesian/Grid.ts
@@ -70,6 +70,7 @@ import { error, log } from '../../util/log';
 import { AxisTickLabelComputingKind } from '../axisTickLabelBuilder';
 import { injectCoordSysByOption } from '../../core/CoordinateSystem';
 import { mathMax, parsePositionSizeOption } from '../../util/number';
+import { MarkerTypes } from '../../component/marker/checkMarkerInSeries';
 
 type Cartesian2DDimensionName = 'x' | 'y';
 
@@ -80,8 +81,6 @@ type AxesMap = {
 };
 
 type ParsedOuterBoundsContain = 'all' | 'axisLabel';
-
-type MarkerTypes = 'markPoint' | 'markLine' | 'markArea';
 
 // margin is [top, right, bottom, left]
 const XY_TO_MARGIN_IDX = [
@@ -545,7 +544,7 @@ class Grid implements CoordinateSystemMaster {
                 unionExtent(data, xAxis);
                 unionExtent(data, yAxis);
 
-                // 处理 markPoint、markLine、markArea
+                // Handle markPoint, markLine, markArea
                 const markerTypes: MarkerTypes[] = ['markPoint', 'markLine', 'markArea'];
 
                 markerTypes.forEach(markerType => {
@@ -563,7 +562,7 @@ class Grid implements CoordinateSystemMaster {
             });
         }
 
-        function UnionExtentForAxisByValue(
+        function unionExtentForAxisByValue(
             value: any,
             axis: Axis2D,
             axisType: OptionAxisType,
@@ -572,10 +571,7 @@ class Grid implements CoordinateSystemMaster {
             if (includeMarkerInExtent && value != null && typeof value !== 'string' && axisType !== 'category') {
                 const val = axis.scale.parse(value);
                 if (!isNaN(val)) {
-                    // Construct the parameter and use unionExtentFromData to avoid using the private method _innerUnionExtent
-                    axis.scale.unionExtentFromData({
-                        getApproximateExtent: () => [val, val]
-                    } as any, 0);
+                    axis.scale.unionExtentByValue(val);
                 }
             }
         }
@@ -596,12 +592,12 @@ class Grid implements CoordinateSystemMaster {
                         return;
                     }
 
-                    UnionExtentForAxisByValue(markerItem.xAxis, xAxis, xAxis.type);
-                    UnionExtentForAxisByValue(markerItem.yAxis, yAxis, yAxis.type);
+                    unionExtentForAxisByValue(markerItem.xAxis, xAxis, xAxis.type);
+                    unionExtentForAxisByValue(markerItem.yAxis, yAxis, yAxis.type);
 
                     if (markerItem.coord && Array.isArray(markerItem.coord)) {
-                        UnionExtentForAxisByValue(markerItem.coord[0], xAxis, xAxis.type);
-                        UnionExtentForAxisByValue(markerItem.coord[1], yAxis, yAxis.type);
+                        unionExtentForAxisByValue(markerItem.coord[0], xAxis, xAxis.type);
+                        unionExtentForAxisByValue(markerItem.coord[1], yAxis, yAxis.type);
                     }
                 });
             });

--- a/src/scale/Log.ts
+++ b/src/scale/Log.ts
@@ -134,6 +134,12 @@ class LogScale extends IntervalScale {
         this._innerUnionExtent(loggedOther);
     }
 
+    unionExtentByValue(value: number): void {
+        this._originalScale.unionExtentByValue(value);
+        const loggedValue = logTransform(this.base, [value, value], true);
+        this._innerUnionExtent(loggedValue);
+    }
+
     /**
      * Update interval and extent of intervals for nice ticks
      * @param approxTickNum default 10 Given approx tick number

--- a/src/scale/Scale.ts
+++ b/src/scale/Scale.ts
@@ -134,6 +134,18 @@ abstract class Scale<SETTING extends ScaleSettingDefault = ScaleSettingDefault> 
     }
 
     /**
+     * Update extent by value
+     */
+    unionExtentByValue(value: number): void {
+        const extent = this._extent;
+        // Considered that number could be NaN and should not write into the extent.
+        this._innerSetExtent(
+            value < extent[0] ? value : extent[0],
+            value > extent[1] ? value : extent[1]
+        );
+    }
+
+    /**
      * Get a new slice of extent.
      * Extent is always in increase order.
      */

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -65,7 +65,7 @@ under the License.
         <div id="main-markline-negative-minmax" class="chart-container"></div>
     </div>
 
-    <div class="chart-title">仅有 markLine（includeMarkerInExtent: true）</div>
+    <div class="chart-title">仅有 markLine（includeMarkerInExtent未设置）</div>
     <div class="chart-row">
         <div id="main-markline-include-marker" class="chart-container"></div>
         <div id="main-markline-include-marker-minmax" class="chart-container"></div>
@@ -105,7 +105,8 @@ under the License.
                 data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
             },
             yAxis: {
-                type: 'value'
+                type: 'value',
+                includeMarkerInExtent: true,
             }
         };
 
@@ -227,13 +228,13 @@ under the License.
                 }]
             });
 
-            // 2.1 仅有 markLine（includeMarkerInExtent: true）用例
+            // 2.1 仅有 markLine（includeMarkerInExtent未设置）用例
             var chartMarklineIncludeMarker = echarts.init(document.getElementById('main-markline-include-marker'));
             chartMarklineIncludeMarker.setOption({
                 ...optionBase,
                 yAxis: {
                     ...optionBase.yAxis,
-                    includeMarkerInExtent: true
+                    includeMarkerInExtent: undefined
                 },
                 series: [{
                     data: [150, 230, 224, 218, 135, 147, 260],
@@ -257,7 +258,7 @@ under the License.
                     ...optionBase.yAxis,
                     min: -100,
                     max: 400,
-                    includeMarkerInExtent: true
+                    includeMarkerInExtent: undefined
                 },
                 series: [{
                     data: [150, 230, 224, 218, 135, 147, 260],
@@ -344,7 +345,8 @@ under the License.
             var barHorizOption = {
                 ...optionBase,
                 xAxis: {
-                    type: 'value' // 水平条形图 x 轴为 value
+                    type: 'value', // 水平条形图 x 轴为 value
+                    includeMarkerInExtent: true,
                 },
                 yAxis: {
                     type: 'category',
@@ -374,7 +376,8 @@ under the License.
                 xAxis: {
                     type: 'value',
                     min: -100,
-                    max: 400
+                    max: 400,
+                    includeMarkerInExtent: true,
                 },
                 yAxis: {
                     type: 'category',

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -1,0 +1,228 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+    <style>
+        .chart-row {
+            width: 100%;
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            margin-bottom: 10px;
+        }
+        .chart-container {
+            width: 48%;
+            display: inline-block;
+            vertical-align: top;
+            margin: 1%;
+            height: 360px;
+        }
+        .chart-title {
+            text-align: center;
+            margin: 12px 0 3px 0;
+            font-weight: bold;
+            font-size: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="chart-title">无标记（基础折线图）</div>
+    <div class="chart-row">
+        <div id="main-none" class="chart-container"></div>
+        <div id="main-none-minmax" class="chart-container"></div>
+    </div>
+
+    <div class="chart-title">仅有 markLine</div>
+    <div class="chart-row">
+        <div id="main-markline" class="chart-container"></div>
+        <div id="main-markline-minmax" class="chart-container"></div>
+    </div>
+
+    <div class="chart-title">仅有 markPoint</div>
+    <div class="chart-row">
+        <div id="main-markpoint" class="chart-container"></div>
+        <div id="main-markpoint-minmax" class="chart-container"></div>
+    </div>
+
+    <div class="chart-title">仅有 markArea</div>
+    <div class="chart-row">
+        <div id="main-markarea" class="chart-container"></div>
+        <div id="main-markarea-minmax" class="chart-container"></div>
+    </div>
+
+    <script>
+        var optionBase = {
+            title: {
+                text: '主标题',
+                subtext: '副标题',
+                left: 'center',
+                top: 'top',
+                textAlign: 'center',
+                textVerticalAlign: 'top'
+            },
+            xAxis: {
+                type: 'category',
+                data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+            },
+            yAxis: {
+                type: 'value'
+            }
+        };
+
+        // 用于yAxis增加min/max配置的option
+        function getOptionWithYAxisMinMax(baseOption) {
+            return {
+                ...baseOption,
+                yAxis: {
+                    ...baseOption.yAxis,
+                    min: -100,
+                    max: 400
+                }
+            };
+        }
+
+        require(['echarts'], function (echarts) {
+            // 1. 无任何标记
+            var chartNone = echarts.init(document.getElementById('main-none'));
+            chartNone.setOption({
+                ...optionBase,
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line'
+                }]
+            });
+
+            var chartNoneMinMax = echarts.init(document.getElementById('main-none-minmax'));
+            chartNoneMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line'
+                }]
+            });
+
+            // 2. 仅 markLine
+            var chartMarkline = echarts.init(document.getElementById('main-markline'));
+            chartMarkline.setOption({
+                ...optionBase,
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '两个屏幕坐标之间的标线',
+                                yAxis: 467,
+                                lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarklineMinMax = echarts.init(document.getElementById('main-markline-minmax'));
+            chartMarklineMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '两个屏幕坐标之间的标线',
+                                yAxis: 467,
+                                lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            // 3. 仅 markPoint
+            var chartMarkpoint = echarts.init(document.getElementById('main-markpoint'));
+            chartMarkpoint.setOption({
+                ...optionBase,
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markPoint: {
+                        data: [
+                            { coord: [2, 432], value: 432, itemStyle: {color: 'blue'}, name: '自定义点' }
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarkpointMinMax = echarts.init(document.getElementById('main-markpoint-minmax'));
+            chartMarkpointMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markPoint: {
+                        data: [
+                            { coord: [2, 432], value: 432, itemStyle: {color: 'blue'}, name: '自定义点' }
+                        ]
+                    }
+                }]
+            });
+
+            // 4. 仅 markArea
+            var chartMarkarea = echarts.init(document.getElementById('main-markarea'));
+            chartMarkarea.setOption({
+                ...optionBase,
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markArea: {
+                        data: [
+                            [
+                                { yAxis: 987, itemStyle: {color: 'rgba(255,0,0,0.15)'} },
+                                { yAxis: 1100 }
+                            ]
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarkareaMinMax = echarts.init(document.getElementById('main-markarea-minmax'));
+            chartMarkareaMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markArea: {
+                        data: [
+                            [
+                                { yAxis: 987, itemStyle: {color: 'rgba(255,0,0,0.15)'} },
+                                { yAxis: 1100 }
+                            ]
+                        ]
+                    }
+                }]
+            });
+        });
+    </script>
+</body>
+</html>

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -83,6 +83,13 @@ under the License.
         <div id="main-markarea-minmax" class="chart-container"></div>
     </div>
 
+    <!-- 新增水平条形图 markLine 用例 -->
+    <div class="chart-title">Bar Chart（水平）基于 markLine 用例</div>
+    <div class="chart-row">
+        <div id="main-bar-horiz-markline" class="chart-container"></div>
+        <div id="main-bar-horiz-markline-minmax" class="chart-container"></div>
+    </div>
+
     <script>
         var optionBase = {
             title: {
@@ -330,6 +337,67 @@ under the License.
                     }
                 }]
             });
+
+            // 5. 水平 Bar Chart + markLine 用例
+            var barHorizData = [320, 432, 301, 334, 390, 330, 220];
+            // 构建水平条形图的 option
+            var barHorizOption = {
+                ...optionBase,
+                xAxis: {
+                    type: 'value' // 水平条形图 x 轴为 value
+                },
+                yAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                series: [{
+                    data: barHorizData,
+                    type: 'bar',
+                    markLine: {
+                        data: [
+                            {
+                                name: '警戒线',
+                                xAxis: 650, // 水平条形图 markLine 在 xAxis 放置
+                                lineStyle: { color: 'purple' },
+                                label: { formatter: '警戒线: 650' }
+                            }
+                        ]
+                    }
+                }]
+            };
+            var chartBarHorizMarkline = echarts.init(document.getElementById('main-bar-horiz-markline'));
+            chartBarHorizMarkline.setOption(barHorizOption);
+
+            // 含 min/max 水平条形图
+            var barHorizOptionMinMax = {
+                ...optionBase,
+                xAxis: {
+                    type: 'value',
+                    min: -100,
+                    max: 400
+                },
+                yAxis: {
+                    type: 'category',
+                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+                },
+                series: [{
+                    data: barHorizData,
+                    type: 'bar',
+                    markLine: {
+                        data: [
+                            {
+                                name: '警戒线',
+                                xAxis: 650,
+                                lineStyle: { color: 'purple' },
+                                label: { formatter: '警戒线: 300' }
+                            }
+                        ]
+                    }
+                }]
+            };
+            var chartBarHorizMarklineMinMax = echarts.init(document.getElementById('main-bar-horiz-markline-minmax'));
+            chartBarHorizMarklineMinMax.setOption(barHorizOptionMinMax);
+
         });
     </script>
 </body>

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -90,6 +90,18 @@ under the License.
         <div id="main-bar-horiz-markline-minmax" class="chart-container"></div>
     </div>
 
+    <!-- 新增 x 轴 time 类型和 y 轴 log 类型用例 -->
+    <div class="chart-title">x轴为 time 类型</div>
+    <div class="chart-row">
+        <div id="main-time-xaxis" class="chart-container"></div>
+        <div id="main-time-xaxis-minmax" class="chart-container"></div>
+    </div>
+    <div class="chart-title">y轴为 log 类型</div>
+    <div class="chart-row">
+        <div id="main-log-yaxis" class="chart-container"></div>
+        <div id="main-log-yaxis-minmax" class="chart-container"></div>
+    </div>
+
     <script>
         var optionBase = {
             title: {
@@ -400,6 +412,133 @@ under the License.
             };
             var chartBarHorizMarklineMinMax = echarts.init(document.getElementById('main-bar-horiz-markline-minmax'));
             chartBarHorizMarklineMinMax.setOption(barHorizOptionMinMax);
+
+            // ==== 新增x轴为time类型的用例 ====
+            var timeData = [
+                ['2023-01-01', 120],
+                ['2023-01-02', 132],
+                ['2023-01-03', 101],
+                ['2023-01-04', 134],
+                ['2023-01-05', 90],
+                ['2023-01-06', 230],
+                ['2023-01-07', 210]
+            ];
+            var chartTimeXaxis = echarts.init(document.getElementById('main-time-xaxis'));
+            chartTimeXaxis.setOption({
+                title: { text: 'x 轴为 time 类型', left: 'center' },
+                tooltip: { trigger: 'axis' },
+                xAxis: {
+                    type: 'time',
+                    name: '日期',
+                    splitLine: { show: false },
+                    includeMarkerInExtent: true
+                },
+                yAxis: {
+                    type: 'value',
+                    includeMarkerInExtent: true
+                },
+                series: [{
+                    type: 'line',
+                    data: timeData,
+                    markLine: {
+                        data: [
+                            {
+                                name: '时间警戒线',
+                                xAxis: '2023-01-10',
+                                lineStyle: { color: 'orange' },
+                                label: { formatter: '时间警戒线@01-05' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartTimeXaxisMinMax = echarts.init(document.getElementById('main-time-xaxis-minmax'));
+            chartTimeXaxisMinMax.setOption({
+                title: { text: 'x 轴为 time 类型 + min/max', left: 'center' },
+                tooltip: { trigger: 'axis' },
+                xAxis: {
+                    type: 'time',
+                    name: '日期',
+                    min: '2022-12-31',
+                    max: '2023-01-08',
+                    splitLine: { show: false },
+                    includeMarkerInExtent: true
+                },
+                yAxis: {
+                    type: 'value',
+                    min: 80,
+                    max: 260,
+                    includeMarkerInExtent: true
+                },
+                series: [{
+                    type: 'line',
+                    data: timeData,
+                    markLine: {
+                        data: [
+                            {
+                                name: '时间警戒线',
+                                xAxis: '2023-01-10',
+                                lineStyle: { color: 'orange' },
+                                label: { formatter: '时间警戒线@01-05' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            // ==== 新增y轴为log类型的用例 ====
+            var logData = [
+                [1, 100],
+                [2, 400],
+                [3, 1000],
+                [4, 4000],
+                [5, 9000],
+                [6, 16000]
+            ];
+            var chartLogYaxis = echarts.init(document.getElementById('main-log-yaxis'));
+            chartLogYaxis.setOption({
+                title: { text: 'y 轴为 log 类型', left: 'center' },
+                tooltip: { trigger: 'axis' },
+                xAxis: { type: 'value', includeMarkerInExtent: true },
+                yAxis: { type: 'log', includeMarkerInExtent: true },
+                series: [{
+                    type: 'line',
+                    data: logData,
+                    markLine: {
+                        data: [
+                            {
+                                name: '对数警戒线',
+                                yAxis: 1000000,
+                                lineStyle: { color: 'brown' },
+                                label: { formatter: '对数警戒线: 10000' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartLogYaxisMinMax = echarts.init(document.getElementById('main-log-yaxis-minmax'));
+            chartLogYaxisMinMax.setOption({
+                title: { text: 'y 轴为 log 类型 + min/max', left: 'center' },
+                tooltip: { trigger: 'axis' },
+                xAxis: { type: 'value', min: 0, max: 8, includeMarkerInExtent: true },
+                yAxis: { type: 'log', min: 10, max: 20000, includeMarkerInExtent: true },
+                series: [{
+                    type: 'line',
+                    data: logData,
+                    markLine: {
+                        data: [
+                            {
+                                name: '对数警戒线',
+                                yAxis: 1000000,
+                                lineStyle: { color: 'brown' },
+                                label: { formatter: '对数警戒线: 10000' }
+                            }
+                        ]
+                    }
+                }]
+            });
 
         });
     </script>

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -59,6 +59,12 @@ under the License.
         <div id="main-markline-minmax" class="chart-container"></div>
     </div>
 
+    <div class="chart-title">markLine为负值用例</div>
+    <div class="chart-row">
+        <div id="main-markline-negative" class="chart-container"></div>
+        <div id="main-markline-negative-minmax" class="chart-container"></div>
+    </div>
+
     <div class="chart-title">仅有 markLine（includeMarkerInExtent: true）</div>
     <div class="chart-row">
         <div id="main-markline-include-marker" class="chart-container"></div>
@@ -172,6 +178,42 @@ under the License.
                                 name: '两个屏幕坐标之间的标线',
                                 yAxis: 467,
                                 lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarklineNegative = echarts.init(document.getElementById('main-markline-negative'));
+            chartMarklineNegative.setOption({
+                ...optionBase,
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '负值标线',
+                                yAxis: -80,
+                                lineStyle: { color: 'green' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarklineNegativeMinMax = echarts.init(document.getElementById('main-markline-negative-minmax'));
+            chartMarklineNegativeMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '负值标线',
+                                yAxis: -80,
+                                lineStyle: { color: 'green' }
                             }
                         ]
                     }

--- a/test/axis-marker-extent.html
+++ b/test/axis-marker-extent.html
@@ -47,7 +47,7 @@ under the License.
     </style>
 </head>
 <body>
-    <div class="chart-title">无标记（基础折线图）</div>
+    <div class="chart-title">仅有 markLine（includeMarkerInExtent: false）</div>
     <div class="chart-row">
         <div id="main-none" class="chart-container"></div>
         <div id="main-none-minmax" class="chart-container"></div>
@@ -57,6 +57,12 @@ under the License.
     <div class="chart-row">
         <div id="main-markline" class="chart-container"></div>
         <div id="main-markline-minmax" class="chart-container"></div>
+    </div>
+
+    <div class="chart-title">仅有 markLine（includeMarkerInExtent: true）</div>
+    <div class="chart-row">
+        <div id="main-markline-include-marker" class="chart-container"></div>
+        <div id="main-markline-include-marker-minmax" class="chart-container"></div>
     </div>
 
     <div class="chart-title">仅有 markPoint</div>
@@ -107,9 +113,22 @@ under the License.
             var chartNone = echarts.init(document.getElementById('main-none'));
             chartNone.setOption({
                 ...optionBase,
+                yAxis: {
+                    ...optionBase.yAxis,
+                    includeMarkerInExtent: false
+                },
                 series: [{
                     data: [150, 230, 224, 218, 135, 147, 260],
-                    type: 'line'
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '两个屏幕坐标之间的标线',
+                                yAxis: 467,
+                                lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
                 }]
             });
 
@@ -144,6 +163,53 @@ under the License.
             var chartMarklineMinMax = echarts.init(document.getElementById('main-markline-minmax'));
             chartMarklineMinMax.setOption({
                 ...getOptionWithYAxisMinMax(optionBase),
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '两个屏幕坐标之间的标线',
+                                yAxis: 467,
+                                lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            // 2.1 仅有 markLine（includeMarkerInExtent: true）用例
+            var chartMarklineIncludeMarker = echarts.init(document.getElementById('main-markline-include-marker'));
+            chartMarklineIncludeMarker.setOption({
+                ...optionBase,
+                yAxis: {
+                    ...optionBase.yAxis,
+                    includeMarkerInExtent: true
+                },
+                series: [{
+                    data: [150, 230, 224, 218, 135, 147, 260],
+                    type: 'line',
+                    markLine: {
+                        data: [
+                            {
+                                name: '两个屏幕坐标之间的标线',
+                                yAxis: 467,
+                                lineStyle: { color: 'red' }
+                            }
+                        ]
+                    }
+                }]
+            });
+
+            var chartMarklineIncludeMarkerMinMax = echarts.init(document.getElementById('main-markline-include-marker-minmax'));
+            chartMarklineIncludeMarkerMinMax.setOption({
+                ...getOptionWithYAxisMinMax(optionBase),
+                yAxis: {
+                    ...optionBase.yAxis,
+                    min: -100,
+                    max: 400,
+                    includeMarkerInExtent: true
+                },
                 series: [{
                     data: [150, 230, 224, 218, 135, 147, 260],
                     type: 'line',


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

## fix issue
Fixes #21203 

### What does this PR do?

When markers such as marker line, marker pointer, and marker area exceed the default axis range, they will be discarded directly. When the user set the includeMarkerInExtent of the axis to true, the default axis range will take into account the marker value


## Details

### Before: What was the problem?

```
{
             title: {
                text: '主标题',
                subtext: '副标题',
                left: 'center',
                top: 'top',
                textAlign: 'center',
                textVerticalAlign: 'top'
            },
            xAxis: {
                type: 'category',
                data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
            },
            yAxis: {
                type: 'value'
            },
             series: [{
                    data: [150, 230, 224, 218, 135, 147, 260],
                    type: 'line',
                    markLine: {
                        data: [
                            {
                                name: '两个屏幕坐标之间的标线',
                                yAxis: 467,
                                lineStyle: { color: 'red' }
                            }
                        ]
                    }
            }]
}
```

When markers such as marker line, marker pointer, and marker area exceed the default axis range, they will be discarded directly.

<img width="1290" height="572" alt="image" src="https://github.com/user-attachments/assets/283d4107-1377-4a0e-a541-9d79c44e95b7" />



### After: How does it behave after the fixing?

When the user set the includeMarkerInExtent of the axis to true, the axis range will take into account the marker value

<img width="1208" height="716" alt="image" src="https://github.com/user-attachments/assets/d3473649-fa21-4586-a748-d17b07fc81bf" />



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in [apache/echarts-doc#481](https://github.com/apache/echarts-doc/pull/481)



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
