### PR TITLE
fix(candlestick): fix candlestick render error with `series.encode`

### DIFF
--- a/src/chart/boxplot/BoxplotView.ts
+++ b/src/chart/boxplot/BoxplotView.ts
@@ -46,7 +46,7 @@ class BoxplotView extends ChartView {
             group.removeAll();
         }
 
-        const constDim = seriesModel.get('layout') === 'horizontal' ? 1 : 0;
+        const constDim = seriesModel.getWhiskerBoxesLayout() === 'horizontal' ? 1 : 0;
 
         data.diff(oldData)
             .add(function (newIdx) {

--- a/src/chart/boxplot/boxplotLayout.ts
+++ b/src/chart/boxplot/boxplotLayout.ts
@@ -144,7 +144,7 @@ function layoutSingleSeries(seriesModel: BoxplotSeriesModel, offset: number, box
     const coordSys = seriesModel.coordinateSystem;
     const data = seriesModel.getData();
     const halfWidth = boxWidth / 2;
-    const cDimIdx = seriesModel.get('layout') === 'horizontal' ? 0 : 1;
+    const cDimIdx = seriesModel.getWhiskerBoxesLayout() === 'horizontal' ? 0 : 1;
     const vDimIdx = 1 - cDimIdx;
     const coordDims = ['x', 'y'];
     const cDim = data.mapDimension(coordDims[cDimIdx]);

--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -37,6 +37,7 @@ import SeriesData from '../../data/SeriesData';
 import Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import { BrushCommonSelectorsForSeries } from '../../component/brush/selector';
 import { mixin } from 'zrender/src/core/util';
+import type Axis2D from '../../coord/cartesian/Axis2D';
 
 type CandlestickDataValue = OptionDataValue[];
 
@@ -158,6 +159,9 @@ class CandlestickSeriesModel extends SeriesModel<CandlestickSeriesOption> {
     }
 }
 
+interface CandlestickSeriesModel extends WhiskerBoxCommonMixin<CandlestickSeriesOption> {
+    getBaseAxis(): Axis2D
+}
 mixin(CandlestickSeriesModel, WhiskerBoxCommonMixin, true);
 
 export default CandlestickSeriesModel;

--- a/src/chart/candlestick/candlestickLayout.ts
+++ b/src/chart/candlestick/candlestickLayout.ts
@@ -51,8 +51,7 @@ const candlestickLayout: StageHandler = {
         const coordSys = seriesModel.coordinateSystem;
         const data = seriesModel.getData();
         const candleWidth = calculateCandleWidth(seriesModel, data);
-        const layout = seriesModel.get('layout');
-        const cDimIdx = layout === 'horizontal' ? 0 : 1;
+        const cDimIdx = seriesModel.getWhiskerBoxesLayout() === 'horizontal' ? 0 : 1;
         const vDimIdx = 1 - cDimIdx;
         const coordDims = ['x', 'y'];
         const cDimI = data.getDimensionIndex(data.mapDimension(coordDims[cDimIdx]));

--- a/src/chart/helper/whiskerBoxCommon.ts
+++ b/src/chart/helper/whiskerBoxCommon.ts
@@ -30,6 +30,9 @@ import type Axis2D from '../../coord/cartesian/Axis2D';
 import { CoordDimensionDefinition } from '../../data/helper/createDimensions';
 
 interface CommonOption extends SeriesOption, SeriesOnCartesianOptionMixin {
+    // - 'horizontal': Multiple whisker boxes (each drawn vertically)
+    //      are arranged side by side horizontally.
+    // - 'vertical': The opposite.
     layout?: LayoutOrient
 
     // data?: (DataItemOption | number[])[]
@@ -44,13 +47,14 @@ interface DataItemOption {
 interface WhiskerBoxCommonMixin<Opts extends CommonOption> extends SeriesModel<Opts>{}
 class WhiskerBoxCommonMixin<Opts extends CommonOption> {
 
-    /**
-     * @private
-     * @type {string}
-     */
-    _baseAxisDim: string;
+    private _baseAxisDim: string;
 
     defaultValueDimensions: CoordDimensionDefinition['dimsDef'];
+
+    /**
+     * Computed layout.
+     */
+    private _layout: CommonOption['layout'];
 
     /**
      * @private
@@ -76,28 +80,33 @@ class WhiskerBoxCommonMixin<Opts extends CommonOption> {
         const yAxisType = yAxisModel.get('type');
         let addOrdinal;
 
+        // Theoretically, if `encode` and/or `layout` are not specified, they can be derived from
+        // the specified one (also according to axis types). However, only the logic for deriving
+        // `encode` from `layout` is implemented; the reverse direction is not implemented yet,
+        // due to its complexity and low priority.
+        let layout = option.layout;
+        // 'category' axis has historically been enforcing `layout` regardless of its presence.
+        // This behavior is preserved until it causes problems.
         if (xAxisType === 'category') {
-            option.layout = 'horizontal';
+            layout = 'horizontal';
             ordinalMeta = xAxisModel.getOrdinalMeta();
             addOrdinal = !this._hasEncodeRule('x');
         }
         else if (yAxisType === 'category') {
-            option.layout = 'vertical';
+            layout = 'vertical';
             ordinalMeta = yAxisModel.getOrdinalMeta();
             addOrdinal = !this._hasEncodeRule('y');
         }
-        else if (xAxisType === 'time') {
-            option.layout = 'horizontal';
+        if (!layout) {
+            layout = yAxisType === 'time' ? 'vertical' : 'horizontal';
+            // It is theoretically possible for an axis with type "time" to serve as the "value axis".
+            // `layout` can be explicitly specified for that case.
         }
-        else if (yAxisType === 'time') {
-            option.layout = 'vertical';
-        }
-        else {
-            option.layout = option.layout || 'horizontal';
-        }
+        // Do not assign the computed `layout` to `option.layout`, otherwise the idempotent may be broken.
+        this._layout = layout;
 
         const coordDims = ['x', 'y'];
-        const baseAxisDimIndex = option.layout === 'horizontal' ? 0 : 1;
+        const baseAxisDimIndex = layout === 'horizontal' ? 0 : 1;
         const baseAxisDim = this._baseAxisDim = coordDims[baseAxisDimIndex];
         const otherAxisDim = coordDims[1 - baseAxisDimIndex];
         const axisModels = [xAxisModel, yAxisModel];
@@ -167,6 +176,10 @@ class WhiskerBoxCommonMixin<Opts extends CommonOption> {
         return (this.ecModel.getComponent(
             dim + 'Axis', this.get(dim + 'AxisIndex' as 'xAxisIndex' | 'yAxisIndex')
         ) as CartesianAxisModel).axis;
+    }
+
+    getWhiskerBoxesLayout() {
+        return this._layout;
     }
 
 };

--- a/test/candlestick-horizontal.html
+++ b/test/candlestick-horizontal.html
@@ -41,6 +41,7 @@ under the License.
         <div id="main6"></div>
         <div id="main7"></div>
         <div id="main8"></div>
+        <div id="main9"></div>
 
         <script>
             require(["echarts"], function (echarts) {
@@ -69,7 +70,8 @@ under the License.
                     xAxisType,
                     yAxisType,
                     encode,
-                    data
+                    data,
+                    layout,
                 ) {
                     var itemStyle =
                         chartType === "candlestick"
@@ -101,6 +103,7 @@ under the License.
                                 type: chartType,
                                 encode: encode,
                                 data: data,
+                                layout: layout,
                                 itemStyle: itemStyle,
                             },
                         ],
@@ -219,6 +222,24 @@ under the License.
                             "time",
                             { x: [0, 1, 2, 3, 4], y: 5 },
                             reversedaray
+                        ),
+                    },
+                    {
+                        id: "main9",
+                        title: "boxplot with dual time axes",
+                        option: createChartOption(
+                            "boxplot",
+                            "time",
+                            "time",
+                            { y: [0, 1, 2, 3, 4], x: 5 },
+                            reversedaray.map(item => {
+                                const newItem = item.slice();
+                                for (let i = 0; i < 5; i++) {
+                                    newItem[i] = new Date(newItem[i] + 1761804046510).toISOString();
+                                }
+                                return newItem;
+                            }),
+                            'horizontal'
                         ),
                     },
                 ];


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes TypeError: Cannot read properties of undefined (reading 'sign') and displays horizontal candlesticks properly


### Fixed issues

- Fix #21322


## Details

### Before: What was the problem?

<img width="580" height="400" alt="Screenshot_20-Oct_19-45-20_18405" src="https://github.com/user-attachments/assets/0ddd62ea-f79f-4484-8110-04710b772fc3" />



### After: How does it behave after the fixing?

<img width="1392" height="1384" alt="Screenshot_20-Oct_19-43-42_30857" src="https://github.com/user-attachments/assets/769de5f4-8143-4b25-8697-902f61fa79b1" />



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
