### PR TITLE
fix(axis): Reverse default splitArea color order

### DIFF
--- a/src/coord/axisDefault.ts
+++ b/src/coord/axisDefault.ts
@@ -115,8 +115,8 @@ const defaultOption: AxisBaseOption = {
         show: false,
         areaStyle: {
             color: [
-                tokens.color.backgroundTint,
-                tokens.color.backgroundTransparent
+                tokens.color.backgroundTransparent,
+                tokens.color.backgroundTint
             ]
         }
     },


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Reverses the default color order of `axis.splitArea` to fix a rendering bug on heatmaps with empty data.This fix works for both the Canvas and SVG renderers.



### Fixed issues

- #21290


## Details

### Before: What was the problem?

The color of the top-left block is inconsistent with the rest of its column.

<img width="1062" height="571" alt="Image" src="https://github.com/user-attachments/assets/a0648937-0088-407d-a393-a0e8f3cedc6a" />



### After: How does it behave after the fixing?

The color is now consistent for both SVG and Canvas renderers.

<img width="1275" height="519" alt="Image" src="https://github.com/user-attachments/assets/80b7a581-6cb0-4786-8522-84878cf015c9" />



## Document Info

One of the following should be checked.

- [X] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
