### PR TITLE
fix: Markline causes type error when used with series.encode

### DIFF
--- a/src/component/marker/MarkAreaView.ts
+++ b/src/component/marker/MarkAreaView.ts
@@ -412,9 +412,11 @@ function createList(
             const data = seriesModel.getData();
             const info = data.getDimensionInfo(
                 data.mapDimension(coordDim)
-            ) || {};
+            );
             // In map series data don't have lng and lat dimension. Fallback to same with coordSys
-            return extend(extend({}, info), {
+            // When using dataset with encode, dimension info might be incomplete/undefined
+            const baseInfo = info ? extend({}, info) : new SeriesDimensionDefine({ name: coordDim, type: 'float' });
+            return extend(baseInfo, {
                 name: coordDim,
                 // DON'T use ordinalMeta to parse and collect ordinal.
                 ordinalMeta: null

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -445,9 +445,11 @@ function createList(coordSys: CoordinateSystem, seriesModel: SeriesModel, mlMode
         coordDimsInfos = map(coordSys && coordSys.dimensions, function (coordDim) {
             const info = seriesModel.getData().getDimensionInfo(
                 seriesModel.getData().mapDimension(coordDim)
-            ) || {};
+            );
             // In map series data don't have lng and lat dimension. Fallback to same with coordSys
-            return extend(extend({}, info), {
+            // When using dataset with encode, dimension info might be incomplete/undefined
+            const baseInfo = info ? extend({}, info) : new SeriesDimensionDefine({ name: coordDim, type: 'float' });
+            return extend(baseInfo, {
                 name: coordDim,
                 // DON'T use ordinalMeta to parse and collect ordinal.
                 ordinalMeta: null

--- a/src/component/marker/MarkPointView.ts
+++ b/src/component/marker/MarkPointView.ts
@@ -205,9 +205,11 @@ function createData(
         coordDimsInfos = map(coordSys && coordSys.dimensions, function (coordDim) {
             const info = seriesModel.getData().getDimensionInfo(
                 seriesModel.getData().mapDimension(coordDim)
-            ) || {};
+            );
             // In map series data don't have lng and lat dimension. Fallback to same with coordSys
-            return extend(extend({}, info), {
+            // When using dataset with encode, dimension info might be incomplete/undefined
+            const baseInfo = info ? extend({}, info) : new SeriesDimensionDefine({ name: coordDim, type: 'float' });
+            return extend(baseInfo, {
                 name: coordDim,
                 // DON'T use ordinalMeta to parse and collect ordinal.
                 ordinalMeta: null

--- a/test/markLine-dataset-encode-fix.html
+++ b/test/markLine-dataset-encode-fix.html
@@ -1,0 +1,223 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>MarkLine with Dataset and Encode - Bug Fix Test</title>
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body {
+                margin: 0;
+                padding: 0;
+                font-family: Arial, sans-serif;
+            }
+            #info {
+                padding: 20px;
+                background: #f0f0f0;
+                border-bottom: 1px solid #ccc;
+            }
+            #main {
+                width: 100%;
+                height: 600px;
+            }
+        </style>
+        <div id="info">
+            <h2>MarkLine with Dataset + Encode Test</h2>
+            <p>This test reproduces the issue where markLine fails with "Cannot read properties of undefined (reading 'ordinalMeta')"
+               when using dataset with encode on a candlestick chart.</p>
+            <p><strong>Expected:</strong> Chart renders without errors and displays the markLine.</p>
+        </div>
+        <div id="main"></div>
+        <script>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+
+                var chart = echarts.init(document.getElementById('main'));
+
+                // Generate sample candlestick data
+                var dataCount = 50;
+                var data = [];
+                var baseTime = new Date('2011-01-01T00:00:00Z').getTime();
+                var basePrice = 4800;
+
+                for (var i = 0; i < dataCount; i++) {
+                    var time = new Date(baseTime + i * 30 * 60 * 1000).toISOString();
+                    var open = basePrice + Math.random() * 200 - 100;
+                    var close = open + Math.random() * 150 - 75;
+                    var low = Math.min(open, close) - Math.random() * 50;
+                    var high = Math.max(open, close) + Math.random() * 50;
+                    var volume = Math.floor(Math.random() * 1000) + 500;
+
+                    data.push([time, open, high, low, close, volume]);
+                    basePrice = close;
+                }
+
+                var option = {
+                    dataset: {
+                        source: data
+                    },
+                    title: {
+                        text: 'MarkLine with Dataset + Encode (Data Count: ' + dataCount + ')'
+                    },
+                    grid: [
+                        {
+                            left: '10%',
+                            right: '10%',
+                            bottom: 200
+                        },
+                        {
+                            left: '10%',
+                            right: '10%',
+                            height: 80,
+                            bottom: 80
+                        }
+                    ],
+                    xAxis: [
+                        {
+                            type: 'time',
+                            boundaryGap: false,
+                            axisLine: { onZero: false },
+                            splitLine: { show: false },
+                            min: 'dataMin',
+                            max: 'dataMax'
+                        },
+                        {
+                            type: 'category',
+                            gridIndex: 1,
+                            boundaryGap: false,
+                            axisLine: { onZero: false },
+                            axisTick: { show: false },
+                            splitLine: { show: false },
+                            axisLabel: { show: false },
+                            min: 'dataMin',
+                            max: 'dataMax'
+                        }
+                    ],
+                    yAxis: [
+                        {
+                            scale: true,
+                            splitArea: {
+                                show: true
+                            }
+                        },
+                        {
+                            scale: true,
+                            gridIndex: 1,
+                            splitNumber: 2,
+                            axisLabel: { show: false },
+                            axisLine: { show: false },
+                            axisTick: { show: false },
+                            splitLine: { show: false }
+                        }
+                    ],
+                    dataZoom: [
+                        {
+                            type: 'inside',
+                            xAxisIndex: [0, 1],
+                            start: 0,
+                            end: 100
+                        },
+                        {
+                            show: true,
+                            xAxisIndex: [0, 1],
+                            type: 'slider',
+                            bottom: 10,
+                            start: 0,
+                            end: 100
+                        }
+                    ],
+                    series: [
+                        {
+                            name: "Candles",
+                            type: 'candlestick',
+                            encode: {
+                                x: 0,
+                                y: [1, 4, 3, 2]
+                            },
+                            markLine: {
+                                symbol: ['none', 'none'],
+                                data: [
+                                    [
+                                        {
+                                            name: 'Test Line 1',
+                                            xAxis: data[10][0],
+                                            yAxis: 4800
+                                        },
+                                        {
+                                            xAxis: data[40][0],
+                                            yAxis: 4850
+                                        }
+                                    ],
+                                    {
+                                        name: 'Average',
+                                        type: 'average'
+                                    },
+                                    {
+                                        name: 'Max',
+                                        type: 'max',
+                                        label: {
+                                            formatter: 'Max: {c}'
+                                        }
+                                    }
+                                ],
+                                lineStyle: {
+                                    color: '#ff0000',
+                                    type: 'solid'
+                                },
+                                label: {
+                                    show: true
+                                }
+                            }
+                        },
+                        {
+                            name: 'Volume',
+                            type: 'bar',
+                            xAxisIndex: 1,
+                            yAxisIndex: 1,
+                            itemStyle: {
+                                color: '#7fbe9e'
+                            },
+                            large: true,
+                            encode: {
+                                x: 0,
+                                y: 5
+                            }
+                        }
+                    ]
+                };
+
+                try {
+                    chart.setOption(option);
+                } catch (error) {
+                    console.error('Chart failed to render:', error);
+                    document.getElementById('info').innerHTML += '<p style="color: red; font-weight: bold;">ERROR: ' + error.message + '</p>';
+                }
+
+            });
+
+        </script>
+    </body>
+</html>

--- a/test/ut/spec/component/marker.test.ts
+++ b/test/ut/spec/component/marker.test.ts
@@ -1,0 +1,224 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart } from '../../core/utHelper';
+
+describe('marker_components', function () {
+
+    let chart: EChartsType;
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('markLine_with_dataset_encode', function () {
+        // Test case for issue where markLine fails with dataset + encode
+        // due to undefined ordinalMeta when dimension info is incomplete
+        const data = [
+            ['2011-01-01T10:00:00Z', 4800, 4850, 4790, 4820, 1000],
+            ['2011-01-01T10:30:00Z', 4820, 4900, 4800, 4880, 1200],
+            ['2011-01-01T11:00:00Z', 4880, 4920, 4850, 4900, 1500],
+            ['2011-01-01T11:30:00Z', 4900, 4950, 4870, 4920, 1300],
+            ['2011-01-01T12:00:00Z', 4920, 5000, 4900, 4980, 1800]
+        ];
+
+        expect(() => {
+            chart.setOption({
+                dataset: {
+                    source: data
+                },
+                xAxis: {
+                    type: 'time'
+                },
+                yAxis: {
+                    scale: true
+                },
+                series: [
+                    {
+                        name: 'Candles',
+                        type: 'candlestick',
+                        encode: {
+                            x: 0,
+                            y: [1, 2, 3, 4]
+                        },
+                        markLine: {
+                            symbol: ['none', 'none'],
+                            data: [
+                                [
+                                    {
+                                        name: 'test line',
+                                        xAxis: '2011-01-01T10:50:00Z',
+                                        yAxis: 4800
+                                    },
+                                    {
+                                        xAxis: '2011-01-01T11:55:00Z',
+                                        yAxis: 4850
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            });
+        }).not.toThrow();
+
+        // Verify the chart rendered successfully
+        expect(chart.getOption()).toBeTruthy();
+    });
+
+    it('markPoint_with_dataset_encode', function () {
+        const data = [
+            ['2011-01-01', 100],
+            ['2011-01-02', 200],
+            ['2011-01-03', 150]
+        ];
+
+        expect(() => {
+            chart.setOption({
+                dataset: {
+                    source: data
+                },
+                xAxis: {
+                    type: 'category'
+                },
+                yAxis: {},
+                series: [
+                    {
+                        type: 'line',
+                        encode: {
+                            x: 0,
+                            y: 1
+                        },
+                        markPoint: {
+                            data: [
+                                {
+                                    name: 'Max',
+                                    type: 'max'
+                                }
+                            ]
+                        }
+                    }
+                ]
+            });
+        }).not.toThrow();
+
+        expect(chart.getOption()).toBeTruthy();
+    });
+
+    it('markArea_with_dataset_encode', function () {
+        const data = [
+            ['2011-01-01', 100],
+            ['2011-01-02', 200],
+            ['2011-01-03', 150],
+            ['2011-01-04', 300]
+        ];
+
+        expect(() => {
+            chart.setOption({
+                dataset: {
+                    source: data
+                },
+                xAxis: {
+                    type: 'category'
+                },
+                yAxis: {},
+                series: [
+                    {
+                        type: 'line',
+                        encode: {
+                            x: 0,
+                            y: 1
+                        },
+                        markArea: {
+                            data: [
+                                [
+                                    {
+                                        name: 'Area',
+                                        xAxis: '2011-01-01'
+                                    },
+                                    {
+                                        xAxis: '2011-01-03'
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            });
+        }).not.toThrow();
+
+        expect(chart.getOption()).toBeTruthy();
+    });
+
+    it('markLine_with_category_axis_dataset', function () {
+        // Test with category axis to ensure ordinalMeta is properly handled
+        const data = [
+            ['Mon', 120],
+            ['Tue', 200],
+            ['Wed', 150],
+            ['Thu', 80],
+            ['Fri', 70]
+        ];
+
+        expect(() => {
+            chart.setOption({
+                dataset: {
+                    source: data
+                },
+                xAxis: {
+                    type: 'category'
+                },
+                yAxis: {},
+                series: [
+                    {
+                        type: 'bar',
+                        encode: {
+                            x: 0,
+                            y: 1
+                        },
+                        markLine: {
+                            data: [
+                                {
+                                    type: 'average',
+                                    name: 'Average'
+                                },
+                                [
+                                    {
+                                        xAxis: 'Mon',
+                                        yAxis: 50
+                                    },
+                                    {
+                                        xAxis: 'Fri',
+                                        yAxis: 100
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            });
+        }).not.toThrow();
+
+        expect(chart.getOption()).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes a type error that causes `ordinalMeta` to be undefined when used on encoded axes with `series.encode`.


### Fixed issues

<!--
- #21300 : https://github.com/apache/echarts/issues/21300
-->


## Details

### Before: What was the problem?

When defining a markline within a series that uses the `series.encode` option, a type error would be thrown that `ordinalMeta` is undefined. It seems like due to this axis encoding, the series can not figure out the correct dimension to use for a markline. I feel its the same for markarea too.



### After: How does it behave after the fixing?

In the initial case reported in issue #21300 I used the broken example as input and created a test html file to render the chart, and I noticed the marklines appearing again _without_ needing to use a workaround of an empty/invisible scatter series.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [x] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/markLine-dataset-encode-fix.html
test/ut/spec/component/marker.test.ts

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

If anything needs to be changed or updated, please let me know. This is a bug affecting my workplace too so I felt I'd follow the ffmpeg motto of "Talk is cheap, send patches".

Thanks.