### PR TITLE
fix: dataZoom incorrectly filters stacked data

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -31,6 +31,7 @@ import { unionAxisExtentFromData } from '../../coord/axisHelper';
 import { ensureScaleRawExtentInfo } from '../../coord/scaleRawExtentInfo';
 import { getAxisMainType, isCoordSupported, DataZoomAxisDimension } from './helper';
 import { SINGLE_REFERRING } from '../../util/model';
+import { getStackedDimension } from '../../data/helper/dataStackHelper';
 
 const each = zrUtil.each;
 const asc = numberUtil.asc;
@@ -302,6 +303,10 @@ class AxisProxy {
             if (!dataDims.length) {
                 return;
             }
+
+            zrUtil.each(dataDims, function (dim, index) {
+                dataDims[index] = getStackedDimension(seriesData, dim);
+            });
 
             if (filterMode === 'weakFilter') {
                 const store = seriesData.getStore();


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

fixes #21371 dataZoom + stacked series + scale causing missing datapoints.



### Fixed issues

#21371


## Details

### Before: What was the problem?

DataZoom calculated valueWindow from stacked extents but filtered using original (unstacked) dimension values, causing incorrect point removal.



### After: How does it behave after the fixing?

Transform dimensions to use stackResultDimension before filtering.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.