### PR TITLE
Fix/toolbox selection chart rerender

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -2317,6 +2317,12 @@ class ECharts extends Eventful<ECEventDefinition> {
 
             renderComponents(ecIns, ecModel, api, payload, updateParams);
 
+            // Skip series rendering for takeGlobalCursor to prevent unnecessary re-render
+            // when user clicks toolbox buttons (brush, dataZoom, etc.)
+            if (payload && payload.type === 'takeGlobalCursor') {
+                return;
+            }
+
             each(ecIns._chartsViews, function (chart: ChartView) {
                 chart.__alive = false;
             });

--- a/test/toolbox-brush-rerender-fix.html
+++ b/test/toolbox-brush-rerender-fix.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+    <title>Toolbox DataZoom Re-render Fix Test</title>
+</head>
+<body>
+    <style>
+        #main {
+            width: 800px;
+            height: 600px;
+        }
+        .info {
+            margin: 20px;
+            padding: 10px;
+            background: #f0f0f0;
+            border-radius: 5px;
+        }
+    </style>
+
+    <div class="info">
+        <h3>Test: Toolbox Box Select Re-render Fix</h3>
+        <p><strong>Issue:</strong> Clicking the "Box Select" (rect) button in the brush toolbox causes the entire chart to re-render with progressive animation.</p>
+        <p><strong>Expected:</strong> Clicking the toolbox button should NOT trigger a re-render; it should only change the cursor mode.</p>
+        <p><strong>Test:</strong> Click the "Box Select" (rect) icon in the toolbox. The chart should NOT animate/re-render.</p>
+    </div>
+
+    <div id="main"></div>
+
+    <script>
+    require([
+        'echarts'
+    ], function (echarts) {
+        var myChart = echarts.init(document.getElementById('main'));
+        var renderCount = 0;
+
+        var data1 = [];
+        for (var i = 0; i < 10000; i++) {
+            data1.push([+(Math.random()*10).toFixed(2), +(Math.random()*10).toFixed(2)]);
+        }
+
+        var option = {
+            xAxis: {},
+            yAxis: {},
+            brush: {
+                toolbox: ['rect', 'keep', 'clear']
+            },
+            series: [
+                {
+                    symbolSize: 1,
+                    data: data1,
+                    type: 'scatter'
+                }
+            ]
+        };
+
+        myChart.setOption(option);
+
+        console.log('Test initialized. Click the Box Select (rect) icon in the toolbox.');
+        console.log('If the fix works, the chart should NOT re-render with progressive animation.');
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Prevents unnecessary chart re-rendering when clicking toolbox buttons (brush, dataZoom selection tools) by skipping series rendering for `takeGlobalCursor` actions.

### Fixed issues

- Fixes performance issue where clicking toolbox selection buttons caused entire chart to re-render with progressive animation, especially problematic with large datasets (10,000+ points)

## Details

### Before: What was the problem?

When users clicked toolbox buttons like "Box Select" (brush rect) or dataZoom selection tools, the entire chart would re-render including all series data points. This triggered:
- Progressive rendering animation replaying from scratch
- Significant performance degradation with large datasets
- Poor user experience as the chart appeared to "reload" just to change cursor mode

**Root Cause:** The `takeGlobalCursor` action was registered with `update: 'update'`, which triggered the full update pipeline including `render()` → `renderSeries()`, causing all chart series to re-render even though only UI state (toolbox icons, brush controller) needed updating.

**Investigation Journey:**
1. Initially tried changing `update: 'update'` to `update: 'none'` and manually calling component updates in a custom action handler
2. This worked but required complex manual orchestration of brush model updates and view updates
3. Then attempted `update: 'toolbox:updateView'` and other targeted update strategies
4. Realized the issue: we needed components to update (toolbox, brush) but NOT series to render

### After: How does it behave after the fixing?

Clicking toolbox buttons now:
- ✅ Instantly activates the tool (brush/dataZoom selection) without any re-rendering
- ✅ Updates toolbox icon states correctly (emphasis/normal)
- ✅ Enables/disables brush controllers properly
- ✅ No progressive animation or performance impact
- ✅ Works seamlessly with large datasets

**The Fix:** Added a simple early return in the `render()` function to skip series rendering when the payload type is `takeGlobalCursor`:

```typescript
if (payload && payload.type === 'takeGlobalCursor') {
    return;
}
```

i am attaching a video of the fix

https://github.com/user-attachments/assets/81e51d28-7509-481c-9355-da283356b119

