### PR TITLE
fix(toolbox): fix emphasis color to be different with default color

### DIFF
--- a/src/component/toolbox/ToolboxModel.ts
+++ b/src/component/toolbox/ToolboxModel.ts
@@ -147,7 +147,7 @@ class ToolboxModel extends ComponentModel<ToolboxOption> {
         },
         emphasis: {
             iconStyle: {
-                borderColor: tokens.color.accent50
+                borderColor: tokens.color.accent70
             }
         },
         // textStyle: {},


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Toolbox icon color was not changing when hovering on. This is because `emphasis.iconStyle.borderColor` was set to be the same with `iconStyle.borderColor`. This PR uses a darker color for emphasis.


### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->
<img width="180" height="50" alt="image" src="https://github.com/user-attachments/assets/f5d4df79-a81e-4e33-9883-5a1c1ab1512b" />


### After: How does it behave after the fixing?

<img width="179" height="63" alt="image" src="https://github.com/user-attachments/assets/48c97235-7d29-4d40-aa51-cf3df6d7092b" />



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
