### PR TITLE
Fix (Saving Images): Fixed a window proxy issue when saving images in the micro-frontend framework.

### DIFF
--- a/src/component/toolbox/feature/SaveAsImage.ts
+++ b/src/component/toolbox/feature/SaveAsImage.ts
@@ -42,10 +42,14 @@ export interface ToolboxSaveAsImageFeatureOption extends ToolboxFeatureOption {
     lang?: string[]
 }
 
+interface ProxyWindow extends Window {
+    rawWindow?: Window
+}
+
 function pickEventView(): Window {
   try {
-    void new MouseEvent("click", { view: window?.rawWindow || window });
-    return window?.rawWindow || window;
+    void new MouseEvent("click", { view: (window as ProxyWindow)?.rawWindow || window });
+    return (window as ProxyWindow)?.rawWindow || window;
   } catch {
     if (document.defaultView) {
       try {


### PR DESCRIPTION
Fix (Saving Images)
  
Added the `pickEventView` function to handle the window proxy issue in the micro-frontend framework, ensuring that the save image event is triggered correctly in different environments.  
  
<!-- Please fill in the following information to help us review your PR more efficiently. -->  
  
## Brief Information  
  
This pull request is in the type of:  
  
- [ ] bug fixing  
- [ ] new feature  
- [x] others  
  
### What does this PR do?  
  
This PR fixes an issue where the save image functionality failed in micro-frontend environments due to window proxy interference. The introduced `pickEventView` function correctly identifies the appropriate view context for event handling, ensuring consistent behavior across different sandboxed or proxy-ed window environments.

### Fixed issues  

## Details  
  
### Before: What was the problem?  
  
In micro-frontend architectures (e.g., using Module Federation or iframe-based isolation), the `window` object is often proxied or sandboxed. When triggering the save image event, the original `window` reference was used directly, leading to failures in event dispatching or incorrect DOM context resolution. This caused the save image feature to be non-functional or inconsistent across environments.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->  
  
### After: How does it behave after the fixing?  
  
With the addition of the `pickEventView` utility function, the system now dynamically resolves the correct view context (e.g., the actual `window` or `document` from the current execution context) before triggering the save image event. This ensures the event is properly dispatched and handled regardless of the micro-frontend sandboxing mechanism. The save image functionality now works reliably in all supported environments, including isolated or proxied frames.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->  
  
## Document Info  
  
One of the following should be checked.  
  
- [x] This PR doesn't relate to document changes  
- [ ] The document should be updated later  
- [ ] The document changes have been made in apache/echarts-doc#xxx  
  
### Other information

This fix is particularly important for users adopting ECharts in micro-frontend setups using tools like Webpack Module Federation, Single-SPA, Micro-App, or custom sandboxing solutions. The `pickEventView` function is designed to be lightweight and reusable across similar contexts.