### PR TITLE
Fix: Respect encode.value in visualMap for multi-column datasets

### DIFF
--- a/src/component/visualMap/VisualMapModel.ts
+++ b/src/component/visualMap/VisualMapModel.ts
@@ -462,6 +462,16 @@ class VisualMapModel<Opts extends VisualMapOption = VisualMapOption> extends Com
             return data.getDimensionIndex(optDim);
         }
 
+        // First, try to use the dimension encoded as 'value' if it exists
+        // This respects the series' encode configuration
+        const valueDimName = data.mapDimension('value');
+        if (valueDimName != null && valueDimName !== '') {
+            const dimIndex = data.getDimensionIndex(valueDimName);
+            if (dimIndex >= 0) {
+                return dimIndex;
+            }
+        }
+
         const dimNames = data.dimensions;
         for (let i = dimNames.length - 1; i >= 0; i--) {
             const dimName = dimNames[i];

--- a/test/heatmap-encode-value-fix.html
+++ b/test/heatmap-encode-value-fix.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Heatmap Encode Value Bug Fix Test</title>
+    <script src="../dist/echarts.js"></script>
+</head>
+<body>
+    <div id="main" style="width: 800px;height:600px;"></div>
+    <script type="text/javascript">
+        // Dataset with multiple value columns
+        var dataset = {
+            source: [
+                ['x', 'y', 'value1', 'value2', 'value3'],
+                ['A', 'X', 0.1, 0.5, 0.9],
+                ['A', 'Y', 0.2, 0.6, 0.8],
+                ['B', 'X', 0.3, 0.7, 0.7],
+                ['B', 'Y', 0.4, 0.8, 0.6]
+            ]
+        };
+
+        var xData = [
+            { value: 'Group1', children: [{ value: 'A' }, { value: 'B' }] }
+        ];
+
+        var yData = [
+            { value: 'Group1', children: [{ value: 'X' }, { value: 'Y' }] }
+        ];
+
+        var myChart = echarts.init(document.getElementById('main'));
+        
+        var option = {
+            dataset: dataset,
+            matrix: {
+                top: 80,
+                bottom: 80,
+                left: 120,
+                right: 30,
+                x: {
+                    data: xData,
+                    levels: [{ levelSize: 20 }, { levelSize: 50 }]
+                },
+                y: {
+                    data: yData,
+                    levels: [{ levelSize: 20 }, { levelSize: 50 }]
+                }
+            },
+            series: [{
+                type: 'heatmap',
+                coordinateSystem: 'matrix',
+                encode: {
+                    x: 'x',
+                    y: 'y',
+                    value: 'value1'
+                },
+                datasetIndex: 0
+            }],
+            visualMap: {
+                type: 'continuous',
+                min: 0,
+                max: 1,
+                calculable: true,
+                orient: 'vertical',
+                left: 10,
+                top: 80,
+                inRange: {
+                    color: ['#ffffff', '#006400']
+                }
+            },
+            tooltip: {
+                show: true,
+                formatter: function (params) {
+                    var d = params.data;
+                    return 'x: ' + d[0] + '<br>y: ' + d[1] + '<br>' +
+                           'value1: ' + d[2] + '<br>' +
+                           'value2: ' + d[3] + '<br>' +
+                           'value3: ' + d[4];
+                }
+            }
+        };
+
+        myChart.setOption(option);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fixes visualMap to respect the series encode.value configuration when determining which dimension to use for visual mapping.

### Fixed issues

- Resolves issue where heatmap with multiple value columns ignores encode.value and uses the last column instead

## Details

### Before: What was the problem?

When a series (e.g., heatmap with matrix coordinate system) has multiple value columns in the dataset and uses encode to specify which dimension should be mapped as 'value', the visualMap component was ignoring this configuration. Instead, it used a backward search algorithm that always picked the last non-coordinate dimension.

Example:

dataset: {
  source: [
    ['x', 'y', 'value1', 'value2', 'value3'],
    ['A', 'X', 0.1, 0.5, 0.9],
    ['A', 'Y', 0.2, 0.6, 0.8],
    ['B', 'X', 0.3, 0.7, 0.7],
    ['B', 'Y', 0.4, 0.8, 0.6]
  ]
},
series: [{
  type: 'heatmap',
  coordinateSystem: 'matrix',
  encode: {
    x: 'x',
    y: 'y',
    value: 'value1'
  }
}]

The visualMap would incorrectly use 'value3' (last column) instead of 'value1' for color mapping, producing an inverted gradient.

### After: How does it behave after the fixing?

Modified getDataDimensionIndex() in src/component/visualMap/VisualMapModel.ts to:

1. First check for explicit dimension option (existing behavior)
2. Respect the series encode configuration by using data.mapDimension('value')
3. Fall back to backward search only if no encoded 'value' dimension exists

Now when encode: { value: 'value1' } is specified, the visualMap correctly uses 'value1' for color mapping, producing the expected visual gradient.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Test file: test/heatmap-encode-value-fix.html demonstrates the fix with a heatmap using matrix coordinate system and multiple value columns.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Files modified:
- src/component/visualMap/VisualMapModel.ts - Modified getDataDimensionIndex() to respect encode configuration
- test/heatmap-encode-value-fix.html - Added test/verification file