### PR TITLE
fix(matrix): fix matrix label formatter does not work

### DIFF
--- a/src/component/matrix/MatrixView.ts
+++ b/src/component/matrix/MatrixView.ts
@@ -303,17 +303,17 @@ function createMatrixCell(
                 componentIndex: matrixModel.componentIndex,
                 name: text,
                 value: textValue as unknown,
-                xyLocator: xyLocator.slice() as MatrixXYLocator[],
-                $vars: ['name', 'value', 'xyLocator'] as const
+                coord: xyLocator.slice() as MatrixXYLocator[],
+                $vars: ['name', 'value', 'coord'] as const
             };
-            if (isFunction(formatter)) {
+            if (isString(formatter)) {
+                text = formatTplSimple(formatter, params);
+            }
+            else if (isFunction(formatter)) {
                 const formattedText = formatter(params);
                 if (formattedText != null) {
                     text = formattedText + '';
                 }
-            }
-            else if (isString(formatter)) {
-                text = formatTplSimple(formatter, params);
             }
         }
 

--- a/src/coord/matrix/MatrixModel.ts
+++ b/src/coord/matrix/MatrixModel.ts
@@ -204,8 +204,8 @@ export interface MatrixLabelFormatterParams {
     componentIndex: number;
     name: string;
     value: unknown;
-    xyLocator: MatrixXYLocator[];
-    $vars: readonly ['name', 'value', 'xyLocator'];
+    coord: MatrixXYLocator[];
+    $vars: readonly ['name', 'value', 'coord'];
 }
 
 /**

--- a/test/matrix-label-formatter.html
+++ b/test/matrix-label-formatter.html
@@ -76,7 +76,7 @@ under the License.
                 },
             };
 
-            var chart = testHelper.create(echarts, 'main0', {
+            testHelper.create(echarts, 'main0', {
                 title: [
                     'Test: Function formatter on x and y labels',
                     'x labels should have "📊" prefix',
@@ -130,7 +130,7 @@ under the License.
                 }
             };
 
-            var chart = testHelper.create(echarts, 'main1', {
+            testHelper.create(echarts, 'main1', {
                 title: [
                     'Test: String template formatter on x and y labels',
                     'x labels should show "Col: A", "Col: B", "Col: C"',
@@ -192,7 +192,7 @@ under the License.
                 }
             };
 
-            var chart = testHelper.create(echarts, 'main2', {
+            testHelper.create(echarts, 'main2', {
                 title: [
                     'Test: Formatter with nested structure',
                     'x labels should be wrapped in brackets: [Group 1], [A1], etc.',


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fix matrix label formatter not working.
<img width="867" height="190" alt="截屏2025-12-04 18 06 10" src="https://github.com/user-attachments/assets/eb950da2-7642-4d2b-838e-100c1ba9699c" />
[demo](https://echarts.apache.org/examples/zh/editor.html?c=matrix-correlation-heatmap&code=tZG9bsIwFIV3nuJsbtWoCLoFdQi8QdeKwWBHipTY0cVpqVDGdugICxvvxhPwCDhxEiJ-JJBgsc9wz7G_c3VqIq3wjkUHSLihaO6XGmgEILjhPj7ZSMdZohAwD7UetvSIjb3KEfOJjA8BQKjJxhtJPsJMTctXn1JOPJk9t8aAbheBEEhJhtEcRmPqwhVP5Kw1R9JkpMB2m9U_GF7gwl6LuUEzl1fK3bn73s8p2Yf-Rq9AKUS_Fm8PASKbfIlm-7e8EWaixSlPY1nY-jSJ4-U53LGHLx5n0gcLeqwOPG8r9-zKadmGfWurXHeoqmlh_Xt1C_bMO_lgDw&enc=deflate)

### Fixed issues

- #21403

## Details

### Before: What was the problem?

`matrix.x.label.formatter` and `matrix.y.label.formatter` were ignored.

### After: How does it behave after the fixing?

Label formatter now works correctly for matrix axes.

## Document Info

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/matrix-label-formatter.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
