### PR TITLE
fix(treemap): fix treemap can not be zoomed out after a zoom-in when `scaleLimit` is specified

### DIFF
--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -158,16 +158,13 @@ export interface TreemapSeriesOption
     ComponentOnCalendarOptionMixin,
     ComponentOnMatrixOptionMixin,
     BoxLayoutOptionMixin,
+    // NOTE: In treemap, option `"zoom"` has never been exposed.
+    //  If users explicitly specify it in `setOption`, the behavior would be unexpected in before v6.1.0,
+    //  and it is removed since v6.1.0.
     RoamOptionMixin,
     TreemapSeriesVisualOption {
 
     type?: 'treemap'
-
-    /**
-     * configuration in echarts2
-     * @deprecated
-     */
-    size?: (number | string)[]
 
     /**
      * If sort in desc order.


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix treeMap scaleLimit bug



### Fixed issues
- #21426 

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
