### PR TITLE
feat(tooltip): add series name as third parameter to valueFormatter (#21459)

### DIFF
--- a/src/component/tooltip/tooltipMarkup.ts
+++ b/src/component/tooltip/tooltipMarkup.ts
@@ -324,7 +324,7 @@ function buildNameValue(
     const noMarker = !fragment.markerType;
     const name = fragment.name;
     const useUTC = ctx.useUTC;
-    const valueFormatter = fragment.valueFormatter || ctx.valueFormatter || ((value) => {
+    const valueFormatter = fragment.valueFormatter || ctx.valueFormatter || ((value, dataIndex, name) => { // Added params here
         value = isArray(value) ? value : [value];
         return map(value as unknown[], (val, idx) => makeValueReadable(
             val, isArray(valueTypeOption) ? valueTypeOption[idx] : valueTypeOption, useUTC
@@ -347,8 +347,8 @@ function buildNameValue(
         : makeValueReadable(name, 'ordinal', useUTC);
     const valueTypeOption = fragment.valueType;
     const readableValueList = noValue
-        ? []
-        : valueFormatter(fragment.value as OptionDataValue, fragment.dataIndex);
+    ? []
+    : valueFormatter(fragment.value as OptionDataValue, fragment.dataIndex, fragment.name); // Added fragment.name
     const valueAlignRight = !noMarker || !noName;
     // It little weird if only value next to marker but far from marker.
     const valueCloseToMarker = !noMarker && noName;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1540,11 +1540,11 @@ export interface CommonTooltipOption<FormatterParams> {
     formatter?: string | TooltipFormatterCallback<FormatterParams>
 
     /**
-     * Formatter of value.
-     *
-     * Will be ignored if tooltip.formatter is specified.
-     */
-    valueFormatter?: (value: OptionDataValue | OptionDataValue[], dataIndex: number) => string
+ * Formatter of value.
+ *
+ * Will be ignored if tooltip.formatter is specified.
+ */
+valueFormatter?: (value: OptionDataValue | OptionDataValue[], dataIndex: number, name?: string) => string | string[]
     /**
      * Absolution pixel [x, y] array. Or relative percent string [x, y] array.
      * If trigger is 'item'. position can be set to 'inside' / 'top' / 'left' / 'right' / 'bottom',


### PR DESCRIPTION
This PR adds the series name as a third argument to the valueFormatter function in the tooltip component.

Currently, valueFormatter only receives value and dataIndex. Adding the name (series name) allows users to perform conditional formatting based on the series without having to write a full custom formatter HTML string.

Changes
src/component/tooltip/tooltipMarkup.ts: Updated buildNameValue to pass fragment.name into the valueFormatter call.

src/util/types.ts: Updated the CommonTooltipOption and TooltipValueFormatter types to include the optional name?: string parameter to ensure TypeScript compatibility.