### PR TITLE
fix(custom): restore emphasis for large datasets (#21442)

### DIFF
--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -983,10 +983,10 @@ el && data.setItemGraphicEl(dataIndex, el);
 
 //  FIX START
 if (
-    el &&
-    el.states &&
-    el.states.emphasis &&
-    !elOption.emphasisDisabled
+    el
+    && el.states
+    && el.states.emphasis
+    && !elOption.emphasisDisabled
 ) {
     el.silent = false;
     el.ignore = false;


### PR DESCRIPTION
### Problem
Custom series elements with large datasets (~3000+ points) were being marked as `silent` / `ignore` 
by ECharts for performance reasons. As a result, **hover and emphasis (highlighting) did not work** 
even when `emphasis` was explicitly defined in `renderItem`. This is tracked in issue #21442.

### Solution
This PR ensures that any **custom element with an `emphasis` state** is not marked as silent or ignored.  
The fix is applied in `src/chart/custom/CustomView.ts` just before `toggleHoverEmphasis` is called.

- Only elements with `emphasis` are affected
- `emphasisDisabled` is respected
- Large dataset performance remains unaffected

### How to Test
1. Open the custom series example (CodeSandbox or `http://localhost:9001`)  
2. Set `dataCount` to ~3000-4000  
3. Hover over the rectangles  
4. Observe that emphasis (highlight) works correctly


### Related Issue
Closes #21442

