### PR TITLE
feat: support timezone on time scale charts

### DIFF
--- a/build/pre-publish.js
+++ b/build/pre-publish.js
@@ -312,8 +312,8 @@ function singleTransformImport(code, replacement) {
     return transformImport(
         code.replace(/([\"\'])zrender\/src\//g, `$1zrender/${replacement}/`),
         (moduleName) => {
-            // Ignore 'tslib' and 'echarts' in the extensions.
-            if (moduleName === 'tslib' || moduleName === 'echarts') {
+            // Ignore 'tslib', '@date-fns/tz' and 'echarts' in the extensions.
+            if (moduleName === 'tslib' || moduleName === 'echarts' || moduleName === "@date-fns/tz") {
                 return moduleName;
             }
             else if (moduleName === 'zrender/lib/export') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "tslib": "2.3.0",
         "zrender": "6.0.0"
       },
@@ -696,6 +697,11 @@
       "engines": {
         "node": ">=0.1.95"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="
     },
     "node_modules/@definitelytyped/header-parser": {
       "version": "0.2.16",
@@ -12281,6 +12287,11 @@
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
       }
+    },
+    "@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="
     },
     "@definitelytyped/header-parser": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lint:dist": "echo 'It might take a while. Please wait ...' && npx jshint --config .jshintrc-dist dist/echarts.js"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "tslib": "2.3.0",
     "zrender": "6.0.0"
   },

--- a/src/component/timeline/SliderTimelineView.ts
+++ b/src/component/timeline/SliderTimelineView.ts
@@ -743,7 +743,8 @@ function createScaleByModel(model: SliderTimelineModel, axisType?: string): Scal
             case 'time':
                 return new TimeScale({
                     locale: model.ecModel.getLocaleModel(),
-                    useUTC: model.ecModel.get('useUTC')
+                    useUTC: model.ecModel.get('useUTC'),
+                    timezone: model.ecModel.get('timezone'),
                 });
             default:
                 // default to be value

--- a/src/coord/axisHelper.ts
+++ b/src/coord/axisHelper.ts
@@ -210,6 +210,7 @@ export function createScaleByModel(model: AxisBaseModel, axisType?: string): Sca
                 return new TimeScale({
                     locale: model.ecModel.getLocaleModel(),
                     useUTC: model.ecModel.get('useUTC'),
+                    timezone: model.ecModel.get('timezone'),
                 });
             default:
                 // case 'value'/'interval', 'log', or others.

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -26,6 +26,7 @@
 * </licenses/LICENSE-d3>).
 */
 
+import { TZDate } from '@date-fns/tz';
 import * as zrUtil from 'zrender/src/core/util';
 
 const RADIAN_EPSILON = 1e-4;
@@ -369,7 +370,7 @@ const TIME_REG = /^(?:(\d{4})(?:[-\/](\d{1,2})(?:[-\/](\d{1,2})(?:[T ](\d{1,2})(
  *   + a timestamp, which represent a time in UTC.
  * @return date Never be null/undefined. If invalid, return `new Date(NaN)`.
  */
-export function parseDate(value: unknown): Date {
+export function parseDate(value: unknown, timeZone?: string): Date {
     if (value instanceof Date) {
         return value;
     }
@@ -390,14 +391,14 @@ export function parseDate(value: unknown): Date {
         if (!match[8]) {
             // match[n] can only be string or undefined.
             // But take care of '12' + 1 => '121'.
-            return new Date(
+            return new TZDate(
                 +match[1],
                 +(match[2] || 1) - 1,
                 +match[3] || 1,
                 +match[4] || 0,
                 +(match[5] || 0),
                 +match[6] || 0,
-                match[7] ? +match[7].substring(0, 3) : 0
+                match[7] ? +match[7].substring(0, 3) : 0, timeZone
             );
         }
         // Timezoneoffset of Javascript Date has considered DST (Daylight Saving Time,
@@ -412,7 +413,7 @@ export function parseDate(value: unknown): Date {
             if (match[8].toUpperCase() !== 'Z') {
                 hour -= +match[8].slice(0, 3);
             }
-            return new Date(Date.UTC(
+            return new TZDate(Date.UTC(
                 +match[1],
                 +(match[2] || 1) - 1,
                 +match[3] || 1,
@@ -420,14 +421,14 @@ export function parseDate(value: unknown): Date {
                 +(match[5] || 0),
                 +match[6] || 0,
                 match[7] ? +match[7].substring(0, 3) : 0
-            ));
+            ), timeZone);
         }
     }
     else if (value == null) {
         return new Date(NaN);
     }
 
-    return new Date(Math.round(value as number));
+    return new TZDate(Math.round(value as number), timeZone);
 }
 
 /**

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -32,6 +32,7 @@ import {NullUndefined, ScaleTick} from './types';
 import { getDefaultLocaleModel, getLocaleModel, SYSTEM_LANG, LocaleOption } from '../core/locale';
 import Model from '../model/Model';
 import { getScaleBreakHelper } from '../scale/break';
+import { TZDate } from '@date-fns/tz';
 
 export const ONE_SECOND = 1000;
 export const ONE_MINUTE = ONE_SECOND * 60;
@@ -277,9 +278,9 @@ export function getDefaultFormatPrecisionOfInterval(timeUnit: PrimaryTimeUnit): 
 export function format(
     // Note: The result based on `isUTC` are totally different, which can not be just simply
     // substituted by the result without `isUTC`. So we make the param `isUTC` mandatory.
-    time: unknown, template: string, isUTC: boolean, lang?: string | Model<LocaleOption>
+    time: unknown, template: string, isUTC: boolean, lang?: string | Model<LocaleOption>, timeZone?: string
 ): string {
-    const date = numberUtil.parseDate(time);
+    const date = numberUtil.parseDate(time, timeZone);
     const y = date[fullYearGetterName(isUTC)]();
     const M = date[monthGetterName(isUTC)]() + 1;
     const q = Math.floor((M - 1) / 3) + 1;
@@ -333,7 +334,8 @@ export function leveledFormat(
     idx: number,
     formatter: TimeAxisLabelFormatterParsed,
     lang: string | Model<LocaleOption>,
-    isUTC: boolean
+    isUTC: boolean,
+    timeZone?: string
 ) {
     let template = null;
     if (zrUtil.isString(formatter)) {
@@ -359,19 +361,20 @@ export function leveledFormat(
         }
         else {
             // tick may be from customTicks or timeline therefore no tick.time.
-            const unit = getUnitFromValue(tick.value, isUTC);
+            const unit = getUnitFromValue(tick.value, isUTC, timeZone);
             template = formatter[unit][unit][0];
         }
     }
 
-    return format(new Date(tick.value), template, isUTC, lang);
+    return format(new TZDate(tick.value, timeZone), template, isUTC, lang);
 }
 
 export function getUnitFromValue(
     value: number | string | Date,
-    isUTC: boolean
+    isUTC: boolean,
+    timeZone?: string
 ): PrimaryTimeUnit {
-    const date = numberUtil.parseDate(value);
+    const date = numberUtil.parseDate(value, timeZone);
     const M = (date as any)[monthGetterName(isUTC)]() + 1;
     const d = (date as any)[dateGetterName(isUTC)]();
     const h = (date as any)[hoursGetterName(isUTC)]();

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -705,6 +705,7 @@ export type ECUnitOption = {
     darkMode?: boolean | 'auto'
     textStyle?: GlobalTextStyleOption
     useUTC?: boolean
+    timezone?: string;
     hoverLayerThreshold?: number
 
     legacyViewCoordSysCenterBase?: boolean

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "target": "ES3",
-
+        
+        "skipLibCheck": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictBindCallApply": true,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Supports formatting time axis with specific timezone. Very likely that this PR won't be merged since we are adding a new lib `@date-fns/tz` however, I believe the authors should consider. Provided here incase others want to use :)

### Fixed issues

- #14453 


## Details

### Before: What was the problem?

Timezone on the time scale charts were only possible to set with `UTC` or device local time. It wasn't possible to change this format outside the library because the axis tick intervals were lost. Doing this within the lib is very simple and the change is non breaking (unless you count the new lib as breaking)


### After: How does it behave after the fixing?

<img width="1422" height="894" alt="image" src="https://github.com/user-attachments/assets/cfa3e95b-04cd-41c0-9f8a-00e7f4a272b2" />
Axis ticks work as expected when zooming in (even over DST changes)
<img width="1422" height="894" alt="image" src="https://github.com/user-attachments/assets/57d477ac-d2df-4983-a32c-e8d84d3be4c7" />

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
