### PR TITLE
feat(canvas): update `devicePixelRatio` to prevent chart being blurry after resizing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Lint
         run: npx eslint $(cat ~/tmp/changed_files)
 
+      - name: Build generated types
+        run: npm run build:lib
+
       - name: Check types
         run: npm run checktype
 

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -312,6 +312,7 @@ export interface SetOptionOpts {
 export interface ResizeOpts {
     width?: number | 'auto', // Can be 'auto' (the same as null/undefined)
     height?: number | 'auto', // Can be 'auto' (the same as null/undefined)
+    devicePixelRatio?: number,
     animation?: AnimationOption
     silent?: boolean // by default false.
 };
@@ -1458,7 +1459,14 @@ class ECharts extends Eventful<ECEventDefinition> {
             return;
         }
 
-        this._zr.resize(opts);
+        // Default to use window.devicePixelRatio to handle browser zoom changes.
+        const zrResizeOpts = opts ? extend({}, opts) : {};
+        if (zrResizeOpts.devicePixelRatio == null && env.hasGlobalWindow) {
+            /* eslint-disable-next-line */
+            zrResizeOpts.devicePixelRatio = window.devicePixelRatio;
+        }
+
+        this._zr.resize(zrResizeOpts);
 
         const ecModel = this._model;
 

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1459,14 +1459,7 @@ class ECharts extends Eventful<ECEventDefinition> {
             return;
         }
 
-        // Default to use window.devicePixelRatio to handle browser zoom changes.
-        const zrResizeOpts = opts ? extend({}, opts) : {};
-        if (zrResizeOpts.devicePixelRatio == null && env.hasGlobalWindow) {
-            /* eslint-disable-next-line */
-            zrResizeOpts.devicePixelRatio = window.devicePixelRatio;
-        }
-
-        this._zr.resize(zrResizeOpts);
+        this._zr.resize(opts);
 
         const ecModel = this._model;
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Auto update `devicePixelRatio` on `resize()` to fix blurry chart after browser zoom.
Zoom in to 500% and call `resize()`.
Before:
<img width="149" height="91" alt="截屏2026-01-22 17 15 14" src="https://github.com/user-attachments/assets/af23e9c0-a000-47b8-8822-1cc4010b0342" />
After:
<img width="145" height="110" alt="截屏2026-01-22 17 13 53" src="https://github.com/user-attachments/assets/ab4201a7-63c3-442f-8881-7e1ec4de8670" />

### Fixed issues

- #21386

## Details

### Before: What was the problem?

When browser zoom changes, calling `chart.resize()` does not update `devicePixelRatio`, resulting in blurry charts.

### After: How does it behave after the fixing?

`resize()` now defaults to use `window.devicePixelRatio`, so charts automatically become crisp after browser zoom.

## Document Info

- [x] The document changes have been made in apache/echarts-doc#514

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [x] This PR depends on ZRender changes (https://github.com/ecomfe/zrender/pull/1149).

### Related test cases or examples to use the new APIs

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This PR also includes a small CI workflow fix for the `lint` job. The job restores `node_modules` from cache and skips `npm ci` on cache hits, but `npm ci` is the step that normally runs `prepare -> build:lib` and generates `types/dist/echarts`. Without regenerating those type files, `npm run checktype` can fail with `Cannot find module './types/dist/echarts'`.

To make the PR check deterministic, the workflow now runs `npm run build:lib` explicitly before `npm run checktype`.
