### PR TITLE
[BugFix] Rose chart (area roseType) angles not uniform when end angle is not `auto`

### DIFF
--- a/src/chart/pie/pieLayout.ts
+++ b/src/chart/pie/pieLayout.ts
@@ -165,7 +165,7 @@ export default function pieLayout(
 
         // Some sector is constrained by minAngle and padAngle
         // Rest sectors needs recalculate angle
-        if (restAngle < PI2 && validDataCount) {
+        if (restAngle < angleRange && validDataCount) {
             // Average the angle if rest angle is not enough after all angles is
             // Constrained by minAngle and padAngle
             if (restAngle <= 1e-3) {


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
- Fix the condition for recalculating angles due to minAngle & padAngles
- Condition is always true when angle span < 2*PI 
- So when span < 2*PI, i.e. endAngle is not `auto`, its unnecessarily recompute sector angles
- Fix: change 2*PI --> angleRange


### Fixed issues

N.A

## Details

### Before: What was the problem?
```
// This example requires ECharts v5.5.0 or later
option = {
  tooltip: {
    trigger: 'item'
  },
  legend: {
    top: '5%',
    left: 'center'
  },
  series: [
    {
      name: 'Access From',
      type: 'pie',
      roseType: 'area',
      radius: ['40%', '70%'],
      center: ['50%', '70%'],
      // adjust the start and end angle
      startAngle: 180,
      endAngle: 360,
      data: [
        { value: 1000, name: 'Search Engine' },
        { value: 500, name: 'Direct' },
        { value: 250, name: 'Email' },
      ]
    }
  ]
};
```

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/655385ed-5f7a-4a63-b13a-b2475adac5dc" />


### After: How does it behave after the fixing?
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/2d2ee398-a2b2-4ace-8783-e630596fd945" />



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

N.A.
