### PR TITLE
[Bugfix] Chord chart zero value edge covers full circle in clockwise orientation

### DIFF
--- a/src/chart/chord/ChordEdge.ts
+++ b/src/chart/chord/ChordEdge.ts
@@ -47,6 +47,7 @@ export class ChordPathShape {
     cy: number = 0;
     // series.r0 of ChordSeries
     r: number = 0;
+    value: number = 0;
 
     clockwise: boolean = true;
 }
@@ -70,6 +71,9 @@ export class ChordEdge extends graphic.Path<ChordEdgePathProps> {
     }
 
     buildPath(ctx: PathProxy | CanvasRenderingContext2D, shape: ChordPathShape): void {
+        if (shape.value <= 0) {
+            return;
+        }
         // Start from n11
         ctx.moveTo(shape.s1[0], shape.s1[1]);
 


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?
- Fix the rendering of chord edge when edge value is 0 in clockwise orientation


### Fixed issues

N.A

## Details

### Before: What was the problem?
```
option = {
  series: [
    {
      type: 'chord',
      label: { show: false},
      data: [
        { name: 'A' },
        { name: 'B' },
        { name: 'C' },
        { name: 'D' }
      ],
      links: [
        { source: 'B', target: 'A', value: 100 },
        { source: 'C', target: 'B', value: 0 },
        { source: 'D', target: 'C', value:50 }
      ]
    }
  ]
};
```
with clockwise: false, its correct but without it, there is a shade on full circle
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/251a4e0c-27ae-487d-a2bd-f6e8cc65eab2" />


### After: How does it behave after the fixing?
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/f558031e-c341-4b27-9ad9-61f73ac99fd8" />


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

N.A.
