### PR TITLE
fix(custom): preserve cursor for renderItem elements on hover

### DIFF
--- a/src/chart/custom/CustomView.ts
+++ b/src/chart/custom/CustomView.ts
@@ -284,12 +284,19 @@ export default class CustomChartView extends ChartView {
         const progressiveEls: Element[] = this._progressiveEls = [];
 
         function setIncrementalAndHoverLayer(el: Displayable) {
-            if (!el.isGroup) {
-                el.incremental = true;
-                el.ensureState('emphasis').hoverLayer = true;
-            }
+    if (!el.isGroup) {
+        el.incremental = true;
+
+        const emphasisState = el.ensureState('emphasis');
+        emphasisState.hoverLayer = true;
+
+        if (el.cursor) {
+            emphasisState.cursor = el.cursor;
         }
-        for (let idx = params.start; idx < params.end; idx++) {
+    }
+}
+
+            for (let idx = params.start; idx < params.end; idx++) {
             const el = createOrUpdateItem(
                 null, null, idx, renderItem(idx, payload), customSeries, this.group, data
             );


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
description:
When using `renderItem` with `cursor` specified, the cursor is lost on hover because the emphasis state does not inherit cursor from the normal state. This PR copies the cursor value to the emphasis state during incremental rendering.


Closes #21498