### PR TITLE
fix(bar): prevent bar chart overflowing the graph when using dataZoom 'filterMode: none' with time axis

### DIFF
--- a/src/chart/bar/BarView.ts
+++ b/src/chart/bar/BarView.ts
@@ -92,14 +92,14 @@ type RealtimeSortConfig = {
 // Return a number, based on which the ordinal sorted.
 type OrderMapping = (dataIndex: number) => number;
 
-function getClipArea(coord: CoordSysOfBar, data: SeriesData) {
+function getClipArea(coord: CoordSysOfBar, data: SeriesData, strictClip?: boolean) {
     const coordSysClipArea = coord.getArea && coord.getArea();
     if (isCoordinateSystemType<Cartesian2D>(coord, 'cartesian2d')) {
         const baseAxis = coord.getBaseAxis();
         // When boundaryGap is false or using time axis. bar may exceed the grid.
         // We should not clip this part.
         // See test/bar2.html
-        if (baseAxis.type !== 'category' || !baseAxis.onBand) {
+        if (!strictClip && (baseAxis.type !== 'category' || !baseAxis.onBand)) {
             const expandWidth = data.getLayout('bandWidth');
             if (baseAxis.isHorizontal()) {
                 (coordSysClipArea as CartesianCoordArea).x -= expandWidth;
@@ -220,7 +220,8 @@ class BarView extends ChartView {
         }
 
         const needsClip = seriesModel.get('clip', true) || realtimeSortCfg;
-        const coordSysClipArea = getClipArea(coord, data);
+        const strictClip = seriesModel.get('clip', true);
+        const coordSysClipArea = getClipArea(coord, data, strictClip);
         // If there is clipPath created in large mode. Remove it.
         group.removeClipPath();
         // We don't use clipPath in normal mode because we needs a perfect animation

--- a/test/bar-datazoom-filtermode-none-time-axis.html
+++ b/test/bar-datazoom-filtermode-none-time-axis.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+    <title>Issue #19972: Bar + Time Axis + DataZoom filterMode: none</title>
+    <style>
+        .description {
+            padding: 15px 20px;
+            background: #fffbe6;
+            border: 1px solid #ffe58f;
+            margin: 10px 20px;
+            border-radius: 5px;
+        }
+        .description h2 {
+            margin: 0 0 10px 0;
+            color: #ad6800;
+        }
+        .description code {
+            background: #f5f5f5;
+            padding: 2px 6px;
+            border-radius: 3px;
+        }
+        .test-case {
+            margin: 20px;
+            padding: 15px;
+            border: 1px solid #d9d9d9;
+            border-radius: 5px;
+        }
+        .test-case h3 {
+            margin: 0 0 10px 0;
+        }
+        .pass { border-color: #52c41a; background: #f6ffed; }
+        .fail { border-color: #ff4d4f; background: #fff1f0; }
+    </style>
+</head>
+<body>
+    <div class="description">
+        <h2>Issue #19972: Bar Chart bars overflow out of the coordinate system</h2>
+        <p><strong>Scenario:</strong> <code>filterMode: 'none'</code> + <code>series type: bar</code> + <code>x-axis type: time</code></p>
+        <p><strong>Problem:</strong> On zooming in too much, the bars would go outside of the graph (beyond axis)</p>
+        <p><strong>Expected:</strong> Bars should be clipped at the coordinate system boundary when <code>clip: true</code></p>
+        <p><strong>Test:</strong> Use the slider or mouse wheel to zoom in. Bars at the edges should be clipped, not overflow.</p>
+    </div>
+
+    <!-- Main Test Case: Exact scenario from issue -->
+    <div class="chart" id="main-test"></div>
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            // Generate sample time-series data
+            var data = [];
+            var baseTime = +new Date(2024, 0, 1);
+            for (var i = 0; i < 90; i++) {
+                data.push([
+                    baseTime + i * 24 * 3600 * 1000,  // time
+                    Math.round(Math.random() * 200 + 50)  // value
+                ]);
+            }
+
+            var option = {
+                title: {
+                    text: 'MAIN TEST: filterMode: none + bar + time axis',
+                    subtext: 'Zoom in using slider or mouse wheel - bars should NOT overflow',
+                    left: 'center'
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: {
+                        type: 'shadow'
+                    }
+                },
+                grid: {
+                    left: 60,
+                    right: 60,
+                    top: 80,
+                    bottom: 100,
+                    borderColor: '#f00',
+                    borderWidth: 2,
+                    show: true
+                },
+                dataZoom: [
+                    {
+                        type: 'slider',
+                        xAxisIndex: 0,
+                        filterMode: 'none',  // KEY: filterMode is 'none'
+                        start: 30,
+                        end: 70
+                    },
+                    {
+                        type: 'inside',
+                        xAxisIndex: 0,
+                        filterMode: 'none'  // KEY: filterMode is 'none'
+                    }
+                ],
+                xAxis: {
+                    type: 'time',  // KEY: x-axis is time type
+                    axisLine: {
+                        lineStyle: {
+                            color: '#f00',
+                            width: 2
+                        }
+                    }
+                },
+                yAxis: {
+                    type: 'value',
+                    axisLine: {
+                        show: true,
+                        lineStyle: {
+                            color: '#f00',
+                            width: 2
+                        }
+                    }
+                },
+                series: [{
+                    name: 'Sales',
+                    type: 'bar',  // KEY: series type is bar
+                    data: data,
+                    clip: true,  // Should clip bars at boundaries
+                    itemStyle: {
+                        color: '#5470c6'
+                    }
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main-test', {
+                title: 'MAIN TEST: filterMode: none + bar + time axis (Issue #19972)',
+                option: option,
+                height: 500,
+                buttons: [
+                    {
+                        text: 'Zoom In (10%-30%)',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 10,
+                                end: 30
+                            });
+                        }
+                    },
+                    {
+                        text: 'Zoom In More (15%-25%)',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 15,
+                                end: 25
+                            });
+                        }
+                    },
+                    {
+                        text: 'Zoom In Extreme (20%-22%)',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 20,
+                                end: 22
+                            });
+                        }
+                    },
+                    {
+                        text: 'Reset Zoom',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 0,
+                                end: 100
+                            });
+                        }
+                    },
+                    {
+                        text: 'Toggle clip: true/false',
+                        onclick: function () {
+                            var currentClip = chart.getOption().series[0].clip;
+                            chart.setOption({
+                                series: [{
+                                    clip: !currentClip
+                                }]
+                            });
+                            console.log('clip is now:', !currentClip);
+                        }
+                    }
+                ]
+            });
+        });
+    </script>
+
+    <!-- Comparison: clip: false (should overflow) -->
+    <div class="chart" id="test-clip-false"></div>
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var data = [];
+            var baseTime = +new Date(2024, 0, 1);
+            for (var i = 0; i < 90; i++) {
+                data.push([
+                    baseTime + i * 24 * 3600 * 1000,
+                    Math.round(Math.random() * 200 + 50)
+                ]);
+            }
+
+            var option = {
+                title: {
+                    text: 'COMPARISON: clip: false (bars SHOULD overflow)',
+                    subtext: 'With clip: false, bars are expected to overflow',
+                    left: 'center'
+                },
+                tooltip: {
+                    trigger: 'axis'
+                },
+                grid: {
+                    left: 60,
+                    right: 60,
+                    top: 80,
+                    bottom: 100,
+                    borderColor: '#f00',
+                    borderWidth: 2,
+                    show: true
+                },
+                dataZoom: [
+                    {
+                        type: 'slider',
+                        xAxisIndex: 0,
+                        filterMode: 'none',
+                        start: 30,
+                        end: 70
+                    },
+                    {
+                        type: 'inside',
+                        xAxisIndex: 0,
+                        filterMode: 'none'
+                    }
+                ],
+                xAxis: {
+                    type: 'time'
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [{
+                    name: 'Sales',
+                    type: 'bar',
+                    data: data,
+                    clip: false,  // Bars SHOULD overflow when false
+                    itemStyle: {
+                        color: '#91cc75'
+                    }
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'test-clip-false', {
+                title: 'COMPARISON: clip: false (bars should overflow - this is expected behavior)',
+                option: option,
+                height: 500,
+                buttons: [
+                    {
+                        text: 'Zoom In (10%-30%)',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 10,
+                                end: 30
+                            });
+                        }
+                    },
+                    {
+                        text: 'Reset Zoom',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 0,
+                                end: 100
+                            });
+                        }
+                    }
+                ]
+            });
+        });
+    </script>
+
+    <!-- Additional test: Stacked bars with time axis -->
+    <div class="chart" id="test-stacked"></div>
+    <script>
+        require([
+            'echarts'
+        ], function (echarts) {
+            var data1 = [];
+            var data2 = [];
+            var data3 = [];
+            var baseTime = +new Date(2024, 0, 1);
+            for (var i = 0; i < 60; i++) {
+                var time = baseTime + i * 24 * 3600 * 1000;
+                data1.push([time, Math.round(Math.random() * 100 + 30)]);
+                data2.push([time, Math.round(Math.random() * 80 + 20)]);
+                data3.push([time, Math.round(Math.random() * 60 + 10)]);
+            }
+
+            var option = {
+                title: {
+                    text: 'Stacked Bars + Time Axis + filterMode: none',
+                    left: 'center'
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    axisPointer: { type: 'shadow' }
+                },
+                legend: {
+                    top: 30,
+                    data: ['Series A', 'Series B', 'Series C']
+                },
+                grid: {
+                    left: 60,
+                    right: 60,
+                    top: 80,
+                    bottom: 100,
+                    borderColor: '#f00',
+                    borderWidth: 2,
+                    show: true
+                },
+                dataZoom: [
+                    {
+                        type: 'slider',
+                        filterMode: 'none',
+                        start: 20,
+                        end: 80
+                    },
+                    {
+                        type: 'inside',
+                        filterMode: 'none'
+                    }
+                ],
+                xAxis: {
+                    type: 'time'
+                },
+                yAxis: {
+                    type: 'value'
+                },
+                series: [
+                    {
+                        name: 'Series A',
+                        type: 'bar',
+                        stack: 'total',
+                        data: data1,
+                        clip: true
+                    },
+                    {
+                        name: 'Series B',
+                        type: 'bar',
+                        stack: 'total',
+                        data: data2,
+                        clip: true
+                    },
+                    {
+                        name: 'Series C',
+                        type: 'bar',
+                        stack: 'total',
+                        data: data3,
+                        clip: true
+                    }
+                ]
+            };
+
+            var chart = testHelper.create(echarts, 'test-stacked', {
+                title: 'Stacked Bars with Time Axis + filterMode: none',
+                option: option,
+                height: 500,
+                buttons: [
+                    {
+                        text: 'Zoom In',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 40,
+                                end: 60
+                            });
+                        }
+                    },
+                    {
+                        text: 'Reset Zoom',
+                        onclick: function () {
+                            chart.dispatchAction({
+                                type: 'dataZoom',
+                                start: 0,
+                                end: 100
+                            });
+                        }
+                    }
+                ]
+            });
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
… filterMode none with time axis. close #19972

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->



### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
