### PR TITLE
fix(types): correct typo `Continous` → `Continuous` in type definitions and deprecate typo'd types

### DIFF
--- a/src/component/visualMap/ContinuousModel.ts
+++ b/src/component/visualMap/ContinuousModel.ts
@@ -34,6 +34,9 @@ type RangeWithAuto = {
 
 type VisualState = VisualMapModel['stateList'][number];
 
+/**
+ * @deprecated Use ContinuousVisualMapOption instead.
+ */
 export interface ContinousVisualMapOption extends VisualMapOption {
 
     align?: 'auto' | 'left' | 'right' | 'top' | 'bottom'
@@ -98,7 +101,9 @@ export interface ContinousVisualMapOption extends VisualMapOption {
     }
 }
 
-class ContinuousModel extends VisualMapModel<ContinousVisualMapOption> {
+export type ContinuousVisualMapOption = ContinousVisualMapOption
+
+class ContinuousModel extends VisualMapModel<ContinuousVisualMapOption> {
 
     static type = 'visualMap.continuous' as const;
     type = ContinuousModel.type;
@@ -106,7 +111,7 @@ class ContinuousModel extends VisualMapModel<ContinousVisualMapOption> {
     /**
      * @override
      */
-    optionUpdated(newOption: ContinousVisualMapOption, isInit: boolean) {
+    optionUpdated(newOption: ContinuousVisualMapOption, isInit: boolean) {
         super.optionUpdated.apply(this, arguments as any);
 
         this.resetExtent();
@@ -324,7 +329,7 @@ class ContinuousModel extends VisualMapModel<ContinousVisualMapOption> {
         //         shadowColor: tokens.color.shadow
         //     }
         // }
-    }) as ContinousVisualMapOption;
+    }) as ContinuousVisualMapOption;
 }
 
 

--- a/src/component/visualMap/ContinuousModel.ts
+++ b/src/component/visualMap/ContinuousModel.ts
@@ -34,10 +34,7 @@ type RangeWithAuto = {
 
 type VisualState = VisualMapModel['stateList'][number];
 
-/**
- * @deprecated Use ContinuousVisualMapOption instead.
- */
-export interface ContinousVisualMapOption extends VisualMapOption {
+export interface ContinuousVisualMapOption extends VisualMapOption {
 
     align?: 'auto' | 'left' | 'right' | 'top' | 'bottom'
 
@@ -101,7 +98,10 @@ export interface ContinousVisualMapOption extends VisualMapOption {
     }
 }
 
-export type ContinuousVisualMapOption = ContinousVisualMapOption
+/**
+ * @deprecated Use `ContinuousVisualMapOption` instead.
+ */
+export type ContinousVisualMapOption = ContinuousVisualMapOption;
 
 class ContinuousModel extends VisualMapModel<ContinuousVisualMapOption> {
 

--- a/src/component/visualMap/installCommon.ts
+++ b/src/component/visualMap/installCommon.ts
@@ -20,7 +20,7 @@
 import { EChartsExtensionInstallRegisters } from '../../extension';
 import { VisualMapOption } from './VisualMapModel';
 import { PiecewiseVisualMapOption } from './PiecewiseModel';
-import { ContinousVisualMapOption } from './ContinuousModel';
+import { ContinuousVisualMapOption } from './ContinuousModel';
 import { visualMapActionInfo, visualMapActionHander } from './visualMapAction';
 import { visualMapEncodingHandlers } from './visualEncoding';
 import { each } from 'zrender/src/core/util';
@@ -44,7 +44,7 @@ export default function installCommon(registers: EChartsExtensionInstallRegister
                             ? ((option as PiecewiseVisualMapOption)).pieces.length > 0
                             : ((option as PiecewiseVisualMapOption)).splitNumber > 0
                     )
-                    || (option as ContinousVisualMapOption).calculable
+                    || (option as ContinuousVisualMapOption).calculable
                 )
             )
             ? 'continuous' : 'piecewise';

--- a/src/component/visualMap/typeDefaulter.ts
+++ b/src/component/visualMap/typeDefaulter.ts
@@ -20,7 +20,7 @@
 import Component from '../../model/Component';
 import {VisualMapOption} from './VisualMapModel';
 import {PiecewiseVisualMapOption} from './PiecewiseModel';
-import {ContinousVisualMapOption} from './ContinuousModel';
+import {ContinuousVisualMapOption} from './ContinuousModel';
 
 Component.registerSubTypeDefaulter(
     'visualMap', function (option: VisualMapOption) {
@@ -33,7 +33,7 @@ Component.registerSubTypeDefaulter(
                         ? ((option as PiecewiseVisualMapOption)).pieces.length > 0
                         : ((option as PiecewiseVisualMapOption)).splitNumber > 0
                 )
-                || (option as ContinousVisualMapOption).calculable
+                || (option as ContinuousVisualMapOption).calculable
             )
         )
         ? 'continuous' : 'piecewise';

--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -58,7 +58,7 @@ import type {SliderDataZoomOption as SliderDataZoomComponentOption} from '../com
 import type {InsideDataZoomOption as InsideDataZoomComponentOption} from '../component/dataZoom/InsideZoomModel';
 
 import type {
-    ContinousVisualMapOption as ContinousVisualMapComponentOption
+    ContinuousVisualMapOption as ContinuousVisualMapComponentOption
 } from '../component/visualMap/ContinuousModel';
 import type {
     PiecewiseVisualMapOption as PiecewiseVisualMapComponentOption
@@ -145,8 +145,14 @@ interface ToolboxComponentOption extends ToolboxOption {
 
 export { SliderDataZoomComponentOption, InsideDataZoomComponentOption };
 export type DataZoomComponentOption = SliderDataZoomComponentOption | InsideDataZoomComponentOption;
-export { ContinousVisualMapComponentOption, PiecewiseVisualMapComponentOption };
-export type VisualMapComponentOption = ContinousVisualMapComponentOption | PiecewiseVisualMapComponentOption;
+export { ContinuousVisualMapComponentOption, PiecewiseVisualMapComponentOption };
+export {
+    /**
+     * @deprecated Use ContinuousVisualMapComponentOption instead.
+     */
+    ContinuousVisualMapComponentOption as ContinousVisualMapComponentOption,
+};
+export type VisualMapComponentOption = ContinuousVisualMapComponentOption | PiecewiseVisualMapComponentOption;
 export { PlainLegendComponentOption, ScrollableLegendComponentOption };
 export type LegendComponentOption = PlainLegendComponentOption | ScrollableLegendComponentOption;
 export {

--- a/src/export/option.ts
+++ b/src/export/option.ts
@@ -146,12 +146,10 @@ interface ToolboxComponentOption extends ToolboxOption {
 export { SliderDataZoomComponentOption, InsideDataZoomComponentOption };
 export type DataZoomComponentOption = SliderDataZoomComponentOption | InsideDataZoomComponentOption;
 export { ContinuousVisualMapComponentOption, PiecewiseVisualMapComponentOption };
-export {
-    /**
-     * @deprecated Use ContinuousVisualMapComponentOption instead.
-     */
-    ContinuousVisualMapComponentOption as ContinousVisualMapComponentOption,
-};
+/**
+ * @deprecated Use `ContinuousVisualMapComponentOption` instead.
+ */
+export type ContinousVisualMapComponentOption = ContinuousVisualMapComponentOption;
 export type VisualMapComponentOption = ContinuousVisualMapComponentOption | PiecewiseVisualMapComponentOption;
 export { PlainLegendComponentOption, ScrollableLegendComponentOption };
 export type LegendComponentOption = PlainLegendComponentOption | ScrollableLegendComponentOption;

--- a/test/ut/spec/component/visualMap/setOption.test.ts
+++ b/test/ut/spec/component/visualMap/setOption.test.ts
@@ -21,7 +21,7 @@
 import { createChart, getECModel } from '../../../core/utHelper';
 import { EChartsType } from '../../../../../src/echarts';
 import { EChartsOption } from '../../../../../src/export/option';
-import { ContinousVisualMapOption } from '../../../../../src/component/visualMap/ContinuousModel';
+import { ContinuousVisualMapOption } from '../../../../../src/component/visualMap/ContinuousModel';
 import { PiecewiseVisualMapOption } from '../../../../../src/component/visualMap/PiecewiseModel';
 import VisualMapModel from '../../../../../src/component/visualMap/VisualMapModel';
 import globalDefault from '../../../../../src/model/globalDefault';
@@ -50,7 +50,7 @@ describe('vsiaulMap_setOption', function () {
         });
 
         const option = chart.getOption();
-        const visualMapOptionGotten = option.visualMap as (ContinousVisualMapOption | PiecewiseVisualMapOption)[];
+        const visualMapOptionGotten = option.visualMap as (ContinuousVisualMapOption | PiecewiseVisualMapOption)[];
 
         expect(visualMapOptionGotten.length).toEqual(1);
         expect(visualMapOptionGotten[0].inRange.color).toEqual(['red', 'blue', 'yellow']);
@@ -70,7 +70,7 @@ describe('vsiaulMap_setOption', function () {
         });
 
         const option = chart.getOption();
-        const visualMapOptionGotten = option.visualMap as (ContinousVisualMapOption | PiecewiseVisualMapOption)[];
+        const visualMapOptionGotten = option.visualMap as (ContinuousVisualMapOption | PiecewiseVisualMapOption)[];
 
         expect(visualMapOptionGotten.length).toEqual(1);
         expect(visualMapOptionGotten[0].color).toEqual(['yellow', 'blue', 'red']);
@@ -104,7 +104,7 @@ describe('vsiaulMap_setOption', function () {
         expectTheSame(chart.getOption() as EChartsOption);
 
         function expectTheSame(option: EChartsOption) {
-            const visualMapOptionGotten = option.visualMap as (ContinousVisualMapOption | PiecewiseVisualMapOption)[];
+            const visualMapOptionGotten = option.visualMap as (ContinuousVisualMapOption | PiecewiseVisualMapOption)[];
             expect(visualMapOptionGotten.length).toEqual(1);
             expect(visualMapOptionGotten[0].inRange.color).toEqual(['red', 'blue', 'yellow']);
             expect(visualMapOptionGotten[0].target.inRange.color).toEqual(['red', 'blue', 'yellow']);
@@ -137,7 +137,7 @@ describe('vsiaulMap_setOption', function () {
         });
 
         const option = chart.getOption();
-        const visualMapOptionGotten = option.visualMap as (ContinousVisualMapOption | PiecewiseVisualMapOption)[];
+        const visualMapOptionGotten = option.visualMap as (ContinuousVisualMapOption | PiecewiseVisualMapOption)[];
 
         expect(visualMapOptionGotten.length).toEqual(1);
         expect(visualMapOptionGotten[0].inRange.hasOwnProperty('color')).toEqual(false);
@@ -171,7 +171,7 @@ describe('vsiaulMap_setOption', function () {
             }
         });
 
-        let visualMapOptionGotten: (ContinousVisualMapOption | PiecewiseVisualMapOption)[];
+        let visualMapOptionGotten: (ContinuousVisualMapOption | PiecewiseVisualMapOption)[];
         visualMapOptionGotten = chart.getOption().visualMap as typeof visualMapOptionGotten;
         expect(visualMapOptionGotten.length).toEqual(1);
         expect(visualMapOptionGotten[0].inRange.hasOwnProperty('color')).toEqual(false);
@@ -234,7 +234,7 @@ describe('vsiaulMap_setOption', function () {
         });
 
         const visualMapOptionGotten = chart.getOption().visualMap as (
-            ContinousVisualMapOption | PiecewiseVisualMapOption
+            ContinuousVisualMapOption | PiecewiseVisualMapOption
         )[];
         expect(!!visualMapOptionGotten[0].target.outOfRange.opacity).toEqual(true);
         done();


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Add `ContinousVisualMapOption` as the type alias of `ContinousVisualMapOption`, and

export of `ContinuousVisualMapComponentOption` along with `ContinuousVisualMapComponentOption`.

The existing types are not changed and marked as `@deprecated`f

This preserves the maximum compatibility so that in case consumer use module augmentation to aument the types they remain working.

The typo types can be removed in the next major release.


### Fixed issues

#21527

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

typo

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

Not sure where the doc is, but if some there is a place to document deprecated code, this can be added there.


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
