### PR TITLE
Fix axisLabel.height not taking effect without backgroundColor

### DIFF
--- a/src/label/labelStyle.ts
+++ b/src/label/labelStyle.ts
@@ -651,7 +651,9 @@ function setTokenTextStyle<TNuance extends TextCommonOptionNuanceBase>(
             textStyle.verticalAlign = baseline;
         }
     }
-    if (!isBlock || !opt.disableBox) {
+    // Enable box when height is explicitly set, so height property can take effect
+    const hasExplicitHeight = textStyleModel.getShallow('height') != null;
+    if (!isBlock || !opt.disableBox || hasExplicitHeight) {
         for (let i = 0; i < TEXT_PROPS_BOX.length; i++) {
             const key = TEXT_PROPS_BOX[i];
             const val = textStyleModel.getShallow(key);


### PR DESCRIPTION
Fixes #21504. The height property was being set on text style but had no visual effect without a backgroundColor because zrender only uses height for background box rendering. This fix enables box properties processing when height is explicitly set, so that zrender can properly render the box with the specified height.