### PR TITLE
fix(model): guard against null data in getDataParams and event handler

### DIFF
--- a/src/chart/chord/ChordSeries.ts
+++ b/src/chart/chord/ChordSeries.ts
@@ -273,6 +273,9 @@ class ChordSeriesModel extends SeriesModel<ChordSeriesOption> {
 
     getDataParams(dataIndex: number, dataType: 'node' | 'edge') {
         const params = super.getDataParams(dataIndex, dataType);
+        if (!this.getData()) {
+            return params;
+        }
         if (dataType === 'node') {
             const nodeData = this.getData();
             const node = this.getGraph().getNodeByIndex(dataIndex);

--- a/src/chart/funnel/FunnelSeries.ts
+++ b/src/chart/funnel/FunnelSeries.ts
@@ -140,6 +140,9 @@ class FunnelSeriesModel extends SeriesModel<FunnelSeriesOption> {
     // Overwrite
     getDataParams(dataIndex: number): FunnelCallbackDataParams {
         const data = this.getData();
+        if (!data) {
+            return {} as FunnelCallbackDataParams;
+        }
         const params = super.getDataParams(dataIndex) as FunnelCallbackDataParams;
         const valueDim = data.mapDimension('value');
         const sum = data.getSum(valueDim);

--- a/src/chart/pie/PieSeries.ts
+++ b/src/chart/pie/PieSeries.ts
@@ -186,6 +186,9 @@ class PieSeriesModel extends SeriesModel<PieSeriesOption> {
      */
     getDataParams(dataIndex: number): PieCallbackDataParams {
         const data = this.getData();
+        if (!data) {
+            return {} as PieCallbackDataParams;
+        }
         // update seats when data is changed
         const dataInner = innerData(data);
         let seats = dataInner.seats;

--- a/src/chart/sunburst/SunburstSeries.ts
+++ b/src/chart/sunburst/SunburstSeries.ts
@@ -209,8 +209,12 @@ class SunburstSeriesModel extends SeriesModel<SunburstSeriesOption> {
      */
     getDataParams(dataIndex: number) {
         const params = super.getDataParams.apply(this, arguments as any) as SunburstDataParams;
+        const data = this.getData();
+        if (!data) {
+            return params;
+        }
 
-        const node = this.getData().tree.getNodeByDataIndex(dataIndex);
+        const node = data.tree.getNodeByDataIndex(dataIndex);
         params.treePathInfo = wrapTreePathInfo<SunburstSeriesNodeItemOption['value']>(node, this);
 
         return params;

--- a/src/chart/tree/TreeSeries.ts
+++ b/src/chart/tree/TreeSeries.ts
@@ -242,8 +242,12 @@ class TreeSeriesModel extends SeriesModel<TreeSeriesOption> {
     // Add tree path to tooltip param
     getDataParams(dataIndex: number) {
         const params = super.getDataParams.apply(this, arguments as any) as TreeSeriesCallbackDataParams;
+        const data = this.getData();
+        if (!data) {
+            return params;
+        }
 
-        const node = this.getData().tree.getNodeByDataIndex(dataIndex);
+        const node = data.tree.getNodeByDataIndex(dataIndex);
         params.treeAncestors = wrapTreePathInfo(node, this);
         params.collapsed = !node.isExpand;
 

--- a/src/chart/treemap/TreemapSeries.ts
+++ b/src/chart/treemap/TreemapSeries.ts
@@ -446,8 +446,12 @@ class TreemapSeriesModel extends SeriesModel<TreemapSeriesOption> {
      */
     getDataParams(dataIndex: number) {
         const params = super.getDataParams.apply(this, arguments as any) as TreemapSeriesCallbackDataParams;
+        const data = this.getData();
+        if (!data) {
+            return params;
+        }
 
-        const node = this.getData().tree.getNodeByDataIndex(dataIndex);
+        const node = data.tree.getNodeByDataIndex(dataIndex);
         params.treeAncestors = wrapTreePathInfo(node, this);
         // compatitable the previous code.
         params.treePathInfo = params.treeAncestors;

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1208,9 +1208,14 @@ class ECharts extends Eventful<ECEventDefinition> {
                         const ecData = getECData(parent);
                         if (ecData && ecData.dataIndex != null) {
                             const dataModel = ecData.dataModel || ecModel.getSeriesByIndex(ecData.seriesIndex);
-                            params = (
-                                dataModel && dataModel.getDataParams(ecData.dataIndex, ecData.dataType, el) || {}
-                            ) as ECElementEvent;
+                            try {
+                                params = (
+                                    dataModel && dataModel.getDataParams(ecData.dataIndex, ecData.dataType, el) || {}
+                                ) as ECElementEvent;
+                            }
+                            catch (e) {
+                                params = {} as ECElementEvent;
+                            }
                             return true;
                         }
                         // If element has custom eventData of components

--- a/src/model/mixin/dataFormat.ts
+++ b/src/model/mixin/dataFormat.ts
@@ -61,6 +61,9 @@ export class DataFormatMixin {
     ): CallbackDataParams {
 
         const data = this.getData(dataType);
+        if (!data) {
+            return {} as CallbackDataParams;
+        }
         const rawValue = this.getRawValue(dataIndex, dataType);
         const rawDataIndex = data.getRawIndex(dataIndex);
         const name = data.getName(dataIndex);


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Adds null guards to `getDataParams()` and its 6 chart-specific overrides to prevent TypeErrors when `getData()` returns null on disposed series during mouse events.

### Fixed issues

- #9402: Cannot read property 'getRawIndex' of undefined (pie, reported 2018)
- #16998: Same error on stacked line chart click (open)
- #21535: Comprehensive analysis of the root cause and all affected code paths

## Details

### Before: What was the problem?

When a chart series is disposed (via `echarts.dispose()`, component unmount in React/Vue/Angular, `setOption` with `notMerge`, or toolbox restore), `SeriesModel.getData()` returns `null`/`undefined`. The comment in `Series.ts` explicitly acknowledges this:

```typescript
// When series is not alive (that may happen when click toolbox
// restore or setOption with not merge mode), series data may
// be still need to judge animation or something when graphic
// elements want to know whether fade out.
return inner(this).data;  // ← can be undefined
```

However, `getDataParams()` and its overrides unconditionally call methods on the result:

```typescript
// dataFormat.ts — base method
const data = this.getData(dataType);
const rawDataIndex = data.getRawIndex(dataIndex);  // 💥 TypeError

// TreemapSeries.ts — override
const node = this.getData().tree.getNodeByDataIndex(dataIndex);  // 💥 TypeError

// PieSeries.ts — override
const data = this.getData();
data.each(data.mapDimension('value'), ...);  // 💥 TypeError
```

The primary crash trigger is the event handler in `echarts.ts` which calls `getDataParams()` during `mousemove`/`mouseout` events that fire on stale DOM elements after chart disposal. This affects **all chart types** in **all frameworks** where component lifecycle causes disposal during user interaction.

### After: How does it behave after the fixing?

Three layers of defense:

**1. Base method guard** (`src/model/mixin/dataFormat.ts`):
```typescript
const data = this.getData(dataType);
if (!data) {
    return {} as CallbackDataParams;
}
```
Returns `{}` when data is null — consistent with the existing fallback at `echarts.ts:778` (`dataModel.getDataParams(...) || {}`). Protects all callers outside the event handler (tooltips, labels, visual pipeline).

**2. Event handler guard** (`src/core/echarts.ts`):
```typescript
try {
    params = (dataModel && dataModel.getDataParams(...) || {}) as ECElementEvent;
} catch (e) {
    params = {} as ECElementEvent;
}
```
Wraps the highest-risk call site in try/catch, catching crashes from any chart override's `getData()` access.

**3. Override guards** (6 chart series files):
Each override now checks `getData()` before accessing chart-specific properties:
- `TreemapSeries.ts` — guards `data.tree` access
- `SunburstSeries.ts` — guards `data.tree` access
- `TreeSeries.ts` — guards `data.tree` access
- `PieSeries.ts` — guards `data.each()`, `data.mapDimension()` access
- `FunnelSeries.ts` — guards `data.mapDimension()`, `data.getSum()` access
- `ChordSeries.ts` — guards `data.getName()`, `this.getGraph()` access

This pattern follows existing precedent in the codebase — `SeriesModel.getAllData()` already null-guards `getData()`:
```typescript
const mainData = this.getData();
return mainData && mainData.getLinkedDataAll ? mainData.getLinkedDataAll() : [{ data: mainData }];
```

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes.

### Related test cases or examples to use the new APIs

N/A — this is a defensive fix. A test case would require simulating chart disposal during mouse events (component unmount race condition).

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This bug has been open since 2018 (#9402) and affects all chart types. It is the most commonly reported ECharts crash in React/Vue applications where charts are rendered in routed views. The fix is minimal (35 lines added across 8 files), safe (returns empty params matching existing fallback patterns), and follows internal precedent.