### PR TITLE
test(time): fix roundTime_locale DST failure in time.test.ts

### DIFF
--- a/test/ut/spec/util/time.test.ts
+++ b/test/ut/spec/util/time.test.ts
@@ -157,34 +157,22 @@ describe('util/time', function () {
         });
 
         it('roundTime_locale', function () {
-            const timezoneStr = getISOTimezone();
-            const time1 = new Date(`1986-10-06T11:25:45.678${timezoneStr}`);
+            const time1 = new Date(1986, 9, 6, 11, 25, 45, 678);
 
             expect(roundTime(new Date(time1), 'year', false).getTime())
-                .toEqual(new Date(`1986-01-01T00:00:00.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 0, 1).getTime());
             expect(roundTime(new Date(time1), 'month', false).getTime())
-                .toEqual(new Date(`1986-10-01T00:00:00.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 1).getTime());
             expect(roundTime(new Date(time1), 'day', false).getTime())
-                .toEqual(new Date(`1986-10-06T00:00:00.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 6).getTime());
             expect(roundTime(new Date(time1), 'hour', false).getTime())
-                .toEqual(new Date(`1986-10-06T11:00:00.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 6, 11).getTime());
             expect(roundTime(new Date(time1), 'minute', false).getTime())
-                .toEqual(new Date(`1986-10-06T11:25:00.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 6, 11, 25).getTime());
             expect(roundTime(new Date(time1), 'second', false).getTime())
-                .toEqual(new Date(`1986-10-06T11:25:45.000${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 6, 11, 25, 45).getTime());
             expect(roundTime(new Date(time1), 'millisecond', false).getTime())
-                .toEqual(new Date(`1986-10-06T11:25:45.678${timezoneStr}`).getTime());
+                .toEqual(new Date(1986, 9, 6, 11, 25, 45, 678).getTime());
         });
     });
 });
-
-// return timezone format like `'-06:00'` or `'+05:45'`
-function getISOTimezone(): string {
-    const offsetMinutes = (new Date(0)).getTimezoneOffset();
-    // Invert sign because getTimezoneOffset() returns minutes behind UTC
-    const sign = offsetMinutes > 0 ? '-' : '+';
-    const absMinutes = Math.abs(offsetMinutes);
-    const hours = Math.floor(absMinutes / 60);
-    const minutes = absMinutes % 60;
-    return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-}


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fixes the `roundTime_locale` test in `test/ut/spec/util/time.test.ts` which fails in any DST-observing timezone (~70% of world timezones).

### Fixed issues

- #21538

## Details

### Before: What was the problem?

The `getISOTimezone()` helper computed the UTC offset from `new Date(0)` (January 1, 1970) and applied that fixed offset string to construct expected dates across different months (January and October 1986):

```typescript
function getISOTimezone(): string {
    const offsetMinutes = (new Date(0)).getTimezoneOffset(); // ← always January offset
    // ...
}

// January offset applied to October date:
new Date(\`1986-10-01T00:00:00.000\${timezoneStr}\`)
```

In DST-observing timezones the offset in January differs from October. For example, US Eastern: January = UTC-5 (EST), October = UTC-4 (EDT). The test constructs "midnight EST" for an October date, but `roundTime()` correctly rounds to midnight EDT — producing a 1-hour mismatch.

This affects any developer running `npm run test` in a DST-observing timezone (US, EU, Australia, NZ, Brazil, etc.).

### After: How does it behave after the fixing?

Replaced ISO string construction with the `Date` constructor using numeric arguments:

```typescript
const time1 = new Date(1986, 9, 6, 11, 25, 45, 678);

expect(roundTime(new Date(time1), 'year', false).getTime())
    .toEqual(new Date(1986, 0, 1).getTime());
expect(roundTime(new Date(time1), 'month', false).getTime())
    .toEqual(new Date(1986, 9, 1).getTime());
```

The `Date` constructor with numeric arguments always interprets them in the machine's **local** timezone, automatically using the correct offset for each specific date (including DST transitions). This is exactly what `roundTime(..., false)` computes — local time boundaries — so the expected and actual values always agree regardless of timezone.

The `getISOTimezone()` helper is removed as it has no other callers in the codebase.

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes.

### Related test cases or examples to use the new APIs

The fix is to the test itself. Full test suite passes (24/24 suites, 189/189 tests) after this change.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This is a test-only change — no production code modified. The fix is 8 lines added, 20 lines removed (simpler code that works in all timezones).