### PR TITLE
feat(candlestick,dataZoom): add `cursor` option for candlestick series and add `cursorGrab` & `cursorGrabbing` option for 'inside' dataZoom

### DIFF
--- a/src/chart/candlestick/CandlestickSeries.ts
+++ b/src/chart/candlestick/CandlestickSeries.ts
@@ -52,6 +52,7 @@ export interface CandlestickStateOption {
 }
 export interface CandlestickDataItemOption
     extends CandlestickStateOption, StatesOptionMixin<CandlestickStateOption, ExtraStateOption> {
+    cursor?: string
     value: CandlestickDataValue
 }
 

--- a/src/chart/candlestick/CandlestickView.ts
+++ b/src/chart/candlestick/CandlestickView.ts
@@ -301,6 +301,9 @@ function setBoxCommon(el: NormalBoxPath, data: SeriesData, dataIndex: number, is
     el.useStyle(data.getItemVisual(dataIndex, 'style'));
     el.style.strokeNoScale = true;
 
+    const cursorStyle = itemModel.getShallow('cursor');
+    cursorStyle && el.attr('cursor', cursorStyle);
+
     el.__simpleBox = isSimpleBox;
 
     setStatesStylesFromModel(el, itemModel);
@@ -429,6 +432,9 @@ function setLargeStyle(sign: number, el: LargeBoxPath, seriesModel: CandlestickS
     el.useStyle(itemStyle);
     el.style.fill = null;
     el.style.stroke = borderColor;
+
+    const cursorStyle = seriesModel.get('cursor');
+    cursorStyle && el.attr('cursor', cursorStyle);
 }
 
 

--- a/src/component/dataZoom/InsideZoomModel.ts
+++ b/src/component/dataZoom/InsideZoomModel.ts
@@ -41,6 +41,12 @@ export interface InsideDataZoomOption extends DataZoomOption {
     preventDefaultMouseMove?: boolean
 
     /**
+     * Mouse cursor styles on states "can grab" and "grabbing".
+     */
+    cursorGrab?: string
+    cursorGrabbing?: string
+
+    /**
      * Inside dataZoom don't support textStyle
      */
     textStyle?: never

--- a/src/component/dataZoom/roams.ts
+++ b/src/component/dataZoom/roams.ts
@@ -29,7 +29,7 @@ import { makeInner } from '../../util/model';
 import { Dictionary, RoamOptionMixin, ZRElementEvent } from '../../util/types';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import InsideZoomModel from './InsideZoomModel';
-import { each, curry, Curry1, HashMap, createHashMap } from 'zrender/src/core/util';
+import { each, curry, Curry1, HashMap, createHashMap, retrieve2 } from 'zrender/src/core/util';
 import {
     DataZoomPayloadBatchItem, collectReferCoordSysModelInfo,
     DataZoomCoordSysMainType, DataZoomReferCoordSysInfo
@@ -198,6 +198,8 @@ function mergeControllerParams(
         'type_undefined': -1
     };
     let preventDefaultMouseMove = true;
+    let cursorGrab: RoamOption['cursorGrab'];
+    let cursorGrabbing: RoamOption['cursorGrabbing'];
 
     dataZoomInfoMap.each(function (dataZoomInfo) {
         const dataZoomModel = dataZoomInfo.model;
@@ -214,6 +216,11 @@ function mergeControllerParams(
         // users may be confused why it does not work when multiple insideZooms exist.
         preventDefaultMouseMove = preventDefaultMouseMove
             && dataZoomModel.get('preventDefaultMouseMove', true);
+
+        // Intuitively, use the last declared setting in ec option when this axis is covered
+        // by multiple `dataZoom`s.
+        cursorGrab = retrieve2(dataZoomModel.get('cursorGrab', true), cursorGrab);
+        cursorGrabbing = retrieve2(dataZoomModel.get('cursorGrabbing', true), cursorGrabbing);
     });
 
     return {
@@ -234,6 +241,8 @@ function mergeControllerParams(
                 roamTrigger: null,
                 isInSelf: coordSysRecord.containsPoint
             },
+            cursorGrab,
+            cursorGrabbing,
         }
     };
 }

--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -53,6 +53,12 @@ export interface RoamOption {
      * If fixed the page when pan
      */
     preventDefaultMouseMove?: boolean
+
+    /**
+     * Cursor styles
+     */
+    cursorGrab?: string // 'grab' by default.
+    cursorGrabbing?: string // 'grabbing' by default.
 }
 type RoamSetting = Omit<Required<RoamOption>, 'zInfo'> & {
     zInfoParsed: {
@@ -174,6 +180,8 @@ class RoamController extends Eventful<RoamEventDefinition> {
                 preventDefaultMouseMove: true,
                 zInfoParsed,
                 triggerInfo,
+                cursorGrab: 'grab', // CSS cursor 'grab'
+                cursorGrabbing: 'grabbing', // CSS cursor 'grabbing'
             });
 
             if (controlType == null) {
@@ -257,7 +265,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
         if (!target && this._checkPointer(e, x, y)) {
             // To indicate users that this area is draggable, otherwise users probably cannot kwown
             // that when hovering out of the shape but still inside the bounding rect.
-            return 'grab';
+            return this._opt.cursorGrab;
         }
         if (forReverse) {
             return target && (target as Displayable).cursor || 'default';
@@ -318,7 +326,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
             return;
         }
 
-        zr.setCursorStyle('grabbing');
+        zr.setCursorStyle(this._opt.cursorGrabbing);
 
         const oldX = this._x;
         const oldY = this._y;

--- a/test/candlestick-cursor.html
+++ b/test/candlestick-cursor.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            .chart {
+                width: 100%;
+                height: 320px;
+            }
+
+            .cursor-log {
+                position: absolute;
+                top: 10px;
+                left: 10px;
+                color: #000;
+            }
+        </style>
+
+        <div id="main0" class="chart"></div>
+        <div id="main1" class="chart"></div>
+
+        <script>
+            require(['echarts', 'data/security-sh-2013.json.js'], function (echarts, rawData) {
+                function makeData(count) {
+                    var data = [];
+                    var base = 120;
+
+                    for (var i = 0; i < count; i++) {
+                        var open = base + (i % 7 - 3);
+                        var close = open + (i % 5 - 2);
+                        var low = Math.min(open, close) - 3;
+                        var high = Math.max(open, close) + 3;
+
+                        data.push([open, close, low, high]);
+                        base += i % 2 ? 1 : -1;
+                    }
+
+                    return data;
+                }
+
+                function splitData(source) {
+                    var categoryData = [];
+                    var values = [];
+
+                    for (var i = 0; i < source.length; i++) {
+                        categoryData.push(source[i][0]);
+                        values.push(source[i].slice(1));
+                    }
+
+                    return {
+                        categoryData: categoryData,
+                        values: values
+                    };
+                }
+
+                function calculateMA(dayCount, data) {
+                    var result = [];
+
+                    for (var i = 0; i < data.values.length; i++) {
+                        if (i < dayCount) {
+                            result.push('-');
+                            continue;
+                        }
+
+                        var sum = 0;
+                        for (var j = 0; j < dayCount; j++) {
+                            sum += data.values[i - j][1];
+                        }
+                        result.push(sum / dayCount);
+                    }
+
+                    return result;
+                }
+
+                function installCursorLog(chart, label) {
+                    var tipDOM = document.createElement('span');
+                    tipDOM.className = 'cursor-log';
+                    chart.getDom().appendChild(tipDOM);
+
+                    chart.getDom().addEventListener('mousemove', function () {
+                        var cursor = chart.getZr().painter.getViewportRoot().style.cursor || 'default';
+                        tipDOM.innerText = label + ' cursor: ' + cursor;
+                    });
+                }
+
+                var upColor = '#ec0000';
+                var upBorderColor = '#8A0000';
+                var downColor = '#00da3c';
+                var downBorderColor = '#008F28';
+                var shData = splitData(rawData);
+
+                var normalChart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Hover candlestick items: cursor should be **move** in normal mode.',
+                        'This chart is similar to the official `candlestick-sh` example and uses `large: false`.'
+                    ],
+                    option: {
+                        title: {
+                            text: '上证指数',
+                            left: 0
+                        },
+                        animation: false,
+                        legend: {
+                            data: ['日K', 'MA5', 'MA10', 'MA20', 'MA30']
+                        },
+                        tooltip: {
+                            trigger: 'axis',
+                            axisPointer: {
+                                type: 'cross'
+                            }
+                        },
+                        grid: {
+                            left: '10%',
+                            right: '10%',
+                            bottom: '15%'
+                        },
+                        xAxis: {
+                            type: 'category',
+                            data: shData.categoryData,
+                            scale: true,
+                            boundaryGap: false,
+                            axisLine: {
+                                onZero: false
+                            },
+                            splitLine: {
+                                show: false
+                            },
+                            splitNumber: 20,
+                            min: 'dataMin',
+                            max: 'dataMax'
+                        },
+                        yAxis: {
+                            scale: true,
+                            splitArea: {
+                                show: true
+                            }
+                        },
+                        dataZoom: [
+                            {
+                                type: 'inside',
+                                start: 50,
+                                end: 100
+                            },
+                            {
+                                show: true,
+                                type: 'slider',
+                                top: '90%',
+                                start: 50,
+                                end: 100
+                            }
+                        ],
+                        series: [
+                            {
+                                name: '日K',
+                                type: 'candlestick',
+                                large: false,
+                                cursor: 'crosshair',
+                                data: shData.values,
+                                itemStyle: {
+                                    color: upColor,
+                                    color0: downColor,
+                                    borderColor: upBorderColor,
+                                    borderColor0: downBorderColor
+                                }
+                            },
+                            {
+                                name: 'MA5',
+                                type: 'line',
+                                data: calculateMA(5, shData),
+                                smooth: true,
+                                showSymbol: false,
+                                lineStyle: {
+                                    width: 1
+                                }
+                            },
+                            {
+                                name: 'MA10',
+                                type: 'line',
+                                data: calculateMA(10, shData),
+                                smooth: true,
+                                showSymbol: false,
+                                lineStyle: {
+                                    width: 1
+                                }
+                            },
+                            {
+                                name: 'MA20',
+                                type: 'line',
+                                data: calculateMA(20, shData),
+                                smooth: true,
+                                showSymbol: false,
+                                lineStyle: {
+                                    width: 1
+                                }
+                            },
+                            {
+                                name: 'MA30',
+                                type: 'line',
+                                data: calculateMA(30, shData),
+                                smooth: true,
+                                showSymbol: false,
+                                lineStyle: {
+                                    width: 1
+                                }
+                            }
+                        ]
+                    }
+                });
+                installCursorLog(normalChart, 'normal');
+
+                var categoryDataLarge = [];
+                for (var j = 0; j < 800; j++) {
+                    categoryDataLarge.push('large-' + j);
+                }
+
+                var largeChart = testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Hover candlestick items: cursor should be **move** in large mode.',
+                        'This chart uses more than the default `largeThreshold`.'
+                    ],
+                    option: {
+                        animation: false,
+                        xAxis: {
+                            type: 'category',
+                            data: categoryDataLarge
+                        },
+                        yAxis: {
+                            scale: true
+                        },
+                        dataZoom: [{
+                            type: 'inside',
+                            start: 0,
+                            end: 20
+                        }],
+                        series: [{
+                            type: 'candlestick',
+                            cursor: 'move',
+                            data: makeData(categoryDataLarge.length)
+                        }]
+                    }
+                });
+                installCursorLog(largeChart, 'large');
+            });
+        </script>
+    </body>
+</html>

--- a/test/candlestick-cursor.html
+++ b/test/candlestick-cursor.html
@@ -163,6 +163,7 @@ under the License.
                         },
                         dataZoom: [
                             {
+                                id: 'inside1',
                                 type: 'inside',
                                 start: 50,
                                 end: 100
@@ -230,7 +231,33 @@ under the License.
                                 }
                             }
                         ]
-                    }
+                    },
+                    inputsStyle: 'compact',
+                    inputs: [{
+                        type: 'select',
+                        text: 'insideZoom.cursorGrab:',
+                        values: [undefined, 'crosshair'],
+                        onchange() {
+                            normalChart.setOption({
+                                dataZoom: {
+                                    id: 'inside1',
+                                    cursorGrab: this.value
+                                },
+                            });
+                        }
+                    }, {
+                        type: 'select',
+                        text: 'insideZoom.cursorGrabbing:',
+                        values: [undefined, 'crosshair'],
+                        onchange() {
+                            normalChart.setOption({
+                                dataZoom: {
+                                    id: 'inside1',
+                                    cursorGrabbing: this.value
+                                },
+                            });
+                        }
+                    }]
                 });
                 installCursorLog(normalChart, 'normal');
 


### PR DESCRIPTION
close #21551

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fixes the missing `cursor` support on `candlestick` series and adds a manual test page for verification.

### Fixed issues

- #21551: `cursor` does not take effect on `candlestick` series


## Details

### Before: What was the problem?

`cursor` is a supported option on some series types, but it did not work on `candlestick`.

The main reason was that `candlestick` view did not forward the cursor option to zrender elements:
- in normal mode, the candlestick path did not read `itemModel.getShallow('cursor')`
- in large mode, the large candlestick paths did not apply `series.cursor`

As a result, hovering candlestick elements still showed the default cursor.

### After: How does it behave after the fixing?

After this change:
- `series.cursor` works on `candlestick` in normal mode
- `data[i].cursor` also works in normal mode
- `series.cursor` works on `candlestick` in large mode

The fix is kept minimal by only wiring the existing cursor option through `CandlestickView` and adding a manual test page:
- `test/candlestick-cursor.html`

The test page includes:
- a normal-mode candlestick chart similar to the `candlestick-sh` example
- a large-mode candlestick chart for verifying the large rendering path


## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/candlestick-cursor.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Local verification:
- `eslint`
- `tsc --noEmit`
- manual verification in `test/candlestick-cursor.html`
