### PR TITLE
fix(states): guard against undefined view in blurSeries

### DIFF
--- a/src/util/states.ts
+++ b/src/util/states.ts
@@ -478,6 +478,9 @@ export function blurSeries(
             // TODO blurScope: coordinate system
         )) {
             const view = api.getViewOfSeriesModel(seriesModel);
+            if (!view || !view.group) {
+                return;
+            }
             view.group.traverse(function (child) {
                 // For the elements that have been triggered by other components,
                 // and are still required to be highlighted,


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Adds a null guard in `blurSeries()` to prevent a TypeError when `api.getViewOfSeriesModel()` returns `undefined` for disposed series during mouse events.

### Fixed issues

- #21559: Cannot read properties of undefined (reading 'group') in blurSeries during React re-render
- Related: #9402, #21535 (same class of bug — stale series references during mouse events)

## Details

### Before: What was the problem?

In `blurSeries()` (`src/util/states.ts`), `api.getViewOfSeriesModel(seriesModel)` can return `undefined` when a series model still exists in `GlobalModel` but its view has been disposed during a React/Vue re-render cycle (via `setOption` with `notMerge`, or component unmount). The code unconditionally accesses `view.group`:

```typescript
const view = api.getViewOfSeriesModel(seriesModel);
view.group.traverse(function (child) {  // 💥 TypeError if view is undefined
```

This is triggered by `mousemove` events that fire on stale DOM elements during the window between disposal and re-creation. The call path is:

```
HandlerDomProxy.mousemove → Handler.mousemove → Handler.dispatchToElement →
Eventful.trigger → handleGlobalMouseOverForHighDown → blurSeries →
eachSeries callback → view.group.traverse  💥
```

### After: How does it behave after the fixing?

```typescript
const view = api.getViewOfSeriesModel(seriesModel);
if (!view || !view.group) {
    return;
}
view.group.traverse(function (child) {
```

The blur effect is simply skipped for disposed series — consistent with the existing pattern in `toggleSeriesBlurState` and `allLeaveBlur` which already handle undefined views gracefully.

### Related test cases or examples to use the new APIs

This is a race condition triggered by real user mouse interaction during framework re-renders. The fix is defensive — it prevents a crash on a code path that can legitimately receive undefined, matching patterns already used elsewhere in the same file.

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This is a 3-line addition (null guard + return + closing brace). It is the same class of bug addressed in #21537 (`getDataParams` null guard) — both stem from stale series references during mouse events on disposed charts. This PR specifically guards the `blurSeries` → `view.group` access path which is not covered by the `getDataParams` fix.

Author: David Langlands <david@grantllama.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>