### PR TITLE
feat(sankey): support disabling node sorting. close #21561

### DIFF
--- a/src/chart/sankey/SankeySeries.ts
+++ b/src/chart/sankey/SankeySeries.ts
@@ -136,6 +136,11 @@ export interface SankeySeriesOption
      * The number of iterations to change the position of the node
      */
     layoutIterations?: number
+    /**
+     * Whether to sort nodes by current coordinate when resolving collisions.
+     * Set to false to preserve the original node order in each depth column.
+     */
+    sortNodes?: boolean
 
     nodeAlign?: 'justify' | 'left' | 'right'    // TODO justify should be auto
 
@@ -318,6 +323,7 @@ class SankeySeriesModel extends SeriesModel<SankeySeriesOption> {
         draggable: true,
 
         layoutIterations: 32,
+        sortNodes: true,
 
         // true | false | 'move' | 'scale', see module:component/helper/RoamController.
         roam: false,

--- a/src/chart/sankey/SankeySeries.ts
+++ b/src/chart/sankey/SankeySeries.ts
@@ -137,10 +137,10 @@ export interface SankeySeriesOption
      */
     layoutIterations?: number
     /**
-     * Whether to sort nodes by current coordinate when resolving collisions.
-     * Set to false to preserve the original node order in each depth column.
+     * Sorting method used when resolving node collisions within each depth column.
+     * Set to null to preserve the original node order.
      */
-    sortNodes?: boolean
+    sort?: 'desc' | null
 
     nodeAlign?: 'justify' | 'left' | 'right'    // TODO justify should be auto
 
@@ -323,7 +323,7 @@ class SankeySeriesModel extends SeriesModel<SankeySeriesOption> {
         draggable: true,
 
         layoutIterations: 32,
-        sortNodes: true,
+        sort: 'desc',
 
         // true | false | 'move' | 'scale', see module:component/helper/RoamController.
         roam: false,

--- a/src/chart/sankey/sankeyLayout.ts
+++ b/src/chart/sankey/sankeyLayout.ts
@@ -57,9 +57,9 @@ export default function sankeyLayout(ecModel: GlobalModel, api: ExtensionAPI) {
         const orient = seriesModel.get('orient');
 
         const nodeAlign = seriesModel.get('nodeAlign');
-        const sortNodes = seriesModel.get('sortNodes');
+        const sort = seriesModel.get('sort');
 
-        layoutSankey(nodes, edges, nodeWidth, nodeGap, width, height, iterations, orient, nodeAlign, sortNodes);
+        layoutSankey(nodes, edges, nodeWidth, nodeGap, width, height, iterations, orient, nodeAlign, sort);
     });
 }
 
@@ -73,10 +73,10 @@ function layoutSankey(
     iterations: number,
     orient: LayoutOrient,
     nodeAlign: SankeySeriesOption['nodeAlign'],
-    sortNodes: boolean
+    sort: SankeySeriesOption['sort']
 ) {
     computeNodeBreadths(nodes, edges, nodeWidth, width, height, orient, nodeAlign);
-    computeNodeDepths(nodes, edges, height, width, nodeGap, iterations, orient, sortNodes);
+    computeNodeDepths(nodes, edges, height, width, nodeGap, iterations, orient, sort);
     computeEdgeDepths(nodes, orient);
 }
 
@@ -259,7 +259,7 @@ function scaleNodeBreadths(nodes: GraphNode[], kx: number, orient: LayoutOrient)
  * @param nodeGap  the vertical distance between two nodes
  *     in the same column.
  * @param iterations  the number of iterations for the algorithm
- * @param sortNodes  whether to sort the nodes by y-position
+ * @param sort  sorting method used when resolving collisions within each column
  */
 function computeNodeDepths(
     nodes: GraphNode[],
@@ -269,21 +269,21 @@ function computeNodeDepths(
     nodeGap: number,
     iterations: number,
     orient: LayoutOrient,
-    sortNodes: boolean
+    sort: SankeySeriesOption['sort']
 ) {
     const nodesByBreadth = prepareNodesByBreadth(nodes, orient);
 
     initializeNodeDepth(nodesByBreadth, edges, height, width, nodeGap, orient);
-    resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
+    resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sort);
 
     for (let alpha = 1; iterations > 0; iterations--) {
         // 0.99 is a experience parameter, ensure that each iterations of
         // changes as small as possible.
         alpha *= 0.99;
         relaxRightToLeft(nodesByBreadth, alpha, orient);
-        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
+        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sort);
         relaxLeftToRight(nodesByBreadth, alpha, orient);
-        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
+        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sort);
     }
 }
 
@@ -360,11 +360,11 @@ function resolveCollisions(
     height: number,
     width: number,
     orient: LayoutOrient,
-    sortNodes: boolean
+    sort: SankeySeriesOption['sort']
 ) {
     const keyAttr = orient === 'vertical' ? 'x' : 'y';
     zrUtil.each(nodesByBreadth, function (nodes) {
-        if (sortNodes !== false) {
+        if (sort !== null) {
             nodes.sort(function (a, b) {
                 return a.getLayout()[keyAttr] - b.getLayout()[keyAttr];
             });

--- a/src/chart/sankey/sankeyLayout.ts
+++ b/src/chart/sankey/sankeyLayout.ts
@@ -57,8 +57,9 @@ export default function sankeyLayout(ecModel: GlobalModel, api: ExtensionAPI) {
         const orient = seriesModel.get('orient');
 
         const nodeAlign = seriesModel.get('nodeAlign');
+        const sortNodes = seriesModel.get('sortNodes');
 
-        layoutSankey(nodes, edges, nodeWidth, nodeGap, width, height, iterations, orient, nodeAlign);
+        layoutSankey(nodes, edges, nodeWidth, nodeGap, width, height, iterations, orient, nodeAlign, sortNodes);
     });
 }
 
@@ -71,10 +72,11 @@ function layoutSankey(
     height: number,
     iterations: number,
     orient: LayoutOrient,
-    nodeAlign: SankeySeriesOption['nodeAlign']
+    nodeAlign: SankeySeriesOption['nodeAlign'],
+    sortNodes: boolean
 ) {
     computeNodeBreadths(nodes, edges, nodeWidth, width, height, orient, nodeAlign);
-    computeNodeDepths(nodes, edges, height, width, nodeGap, iterations, orient);
+    computeNodeDepths(nodes, edges, height, width, nodeGap, iterations, orient, sortNodes);
     computeEdgeDepths(nodes, orient);
 }
 
@@ -257,6 +259,7 @@ function scaleNodeBreadths(nodes: GraphNode[], kx: number, orient: LayoutOrient)
  * @param nodeGap  the vertical distance between two nodes
  *     in the same column.
  * @param iterations  the number of iterations for the algorithm
+ * @param sortNodes  whether to sort the nodes by y-position
  */
 function computeNodeDepths(
     nodes: GraphNode[],
@@ -265,21 +268,22 @@ function computeNodeDepths(
     width: number,
     nodeGap: number,
     iterations: number,
-    orient: LayoutOrient
+    orient: LayoutOrient,
+    sortNodes: boolean
 ) {
     const nodesByBreadth = prepareNodesByBreadth(nodes, orient);
 
     initializeNodeDepth(nodesByBreadth, edges, height, width, nodeGap, orient);
-    resolveCollisions(nodesByBreadth, nodeGap, height, width, orient);
+    resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
 
     for (let alpha = 1; iterations > 0; iterations--) {
         // 0.99 is a experience parameter, ensure that each iterations of
         // changes as small as possible.
         alpha *= 0.99;
         relaxRightToLeft(nodesByBreadth, alpha, orient);
-        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient);
+        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
         relaxLeftToRight(nodesByBreadth, alpha, orient);
-        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient);
+        resolveCollisions(nodesByBreadth, nodeGap, height, width, orient, sortNodes);
     }
 }
 
@@ -355,13 +359,16 @@ function resolveCollisions(
     nodeGap: number,
     height: number,
     width: number,
-    orient: LayoutOrient
+    orient: LayoutOrient,
+    sortNodes: boolean
 ) {
     const keyAttr = orient === 'vertical' ? 'x' : 'y';
     zrUtil.each(nodesByBreadth, function (nodes) {
-        nodes.sort(function (a, b) {
-            return a.getLayout()[keyAttr] - b.getLayout()[keyAttr];
-        });
+        if (sortNodes !== false) {
+            nodes.sort(function (a, b) {
+                return a.getLayout()[keyAttr] - b.getLayout()[keyAttr];
+            });
+        }
         let nodeX;
         let node;
         let dy;

--- a/test/sankey-node-sorting.html
+++ b/test/sankey-node-sorting.html
@@ -1,0 +1,97 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+	<script src="lib/simpleRequire.js"></script>
+	<script src="lib/config.js"></script>
+	<script src="lib/jquery.min.js"></script>
+	<script src="lib/facePrint.js"></script>
+	<script src="lib/testHelper.js"></script>
+	<!-- <script src="ut/lib/canteen.js"></script> -->
+	<link rel="stylesheet" href="lib/reset.css"/>
+</head>
+<body>
+<style>
+</style>
+
+
+<div id="main0"></div>
+<div id="main1"></div>
+<div id="main2"></div>
+
+
+<script>
+    require([
+        "echarts"
+    ], function (echarts) {
+        const data = {
+            nodes: [
+                {name: "A"}, {name: "A-out-0", depth: 1}, {name: "A-out-1", depth: 1}, {name: "A-out-2", depth: 1},
+                {name: "A-out-3", depth: 1}, {name: "A-to-B-1"}, {name: "A-to-B-2"}, {name: "A-to-B-3"}, {name: "B"}, {name: "B-in-1", depth: 1},
+                {name: "B-in-2", depth: 1}, {name: "A-to-C-1"}, {name: "A-to-C-2"}, {name: "A-to-C-3"}, {name: "C"}
+            ], links: [
+                {source: "A", target: "A-out-0", value: 1}, {source: "A", target: "A-out-1", value: 2},
+                {source: "A", target: "A-out-2", value: 3}, {source: "A", target: "A-out-3", value: 30},
+                {source: "A", target: "A-to-B-1", value: 3}, {source: "A", target: "A-to-B-2", value: 7},
+                {source: "A", target: "A-to-B-3", value: 9}, {source: "A", target: "A-to-C-1", value: 3},
+				{source: "A", target: "A-to-C-2", value: 7}, {source: "A", target: "A-to-C-3", value: 9},
+                {source: "A-to-B-1", target: "B", value: 3}, {source: "A-to-B-2", target: "B", value: 7},
+                {source: "A-to-B-3", target: "B", value: 9}, {source: "B-in-1", target: "B", value: 1},
+                {source: "B-in-2", target: "B", value: 2},
+				{source: "A-to-C-1", target: "C", value: 1}, {source: "A-to-C-2", target: "C", value: 7},
+				{source: "A-to-C-3", target: "C", value: 9}
+            ]
+        };
+        let option = {
+            series: [
+                {
+                    type: "sankey",
+                    data: data.nodes,
+                    links: data.links
+                }
+            ]
+        };
+
+        const chart0 = testHelper.create(echarts, "main0", {
+            title: "Default behaviour, sortNodes: true, has links crossing over each other",
+			option: {series: [{type: "sankey", data: data.nodes, links: data.links, sortNodes: true}]}
+        });
+        window.addEventListener("resize", chart0.resize);
+
+        const chart1 = testHelper.create(echarts, "main1", {
+            title: "Suggested workaround, layoutIterations: 0, has all levels aligned to the top",
+            option: {series: [{type: "sankey", data: data.nodes, links: data.links, layoutIterations: 0}]}
+        });
+        window.addEventListener("resize", chart1.resize);
+
+        const chart2 = testHelper.create(echarts, "main2", {
+            title: "sortNodes: false gives user a chance to sort nodes manually, while still optimising the layout",
+            option: {series: [{type: "sankey", data: data.nodes, links: data.links, sortNodes: false}]}
+        });
+        window.addEventListener("resize", chart2.resize);
+
+    });
+</script>
+
+
+</body>
+</html>

--- a/test/sankey-node-sorting.html
+++ b/test/sankey-node-sorting.html
@@ -61,19 +61,9 @@ under the License.
 				{source: "A-to-C-3", target: "C", value: 9}
             ]
         };
-        let option = {
-            series: [
-                {
-                    type: "sankey",
-                    data: data.nodes,
-                    links: data.links
-                }
-            ]
-        };
-
         const chart0 = testHelper.create(echarts, "main0", {
-            title: "Default behaviour, sortNodes: true, has links crossing over each other",
-			option: {series: [{type: "sankey", data: data.nodes, links: data.links, sortNodes: true}]}
+            title: "Default behaviour, sort: 'desc', has links crossing over each other",
+            option: {series: [{type: "sankey", data: data.nodes, links: data.links, sort: "desc"}]}
         });
         window.addEventListener("resize", chart0.resize);
 
@@ -84,8 +74,8 @@ under the License.
         window.addEventListener("resize", chart1.resize);
 
         const chart2 = testHelper.create(echarts, "main2", {
-            title: "sortNodes: false gives user a chance to sort nodes manually, while still optimising the layout",
-            option: {series: [{type: "sankey", data: data.nodes, links: data.links, sortNodes: false}]}
+            title: "sort: null preserves input node order while still optimising the layout",
+            option: {series: [{type: "sankey", data: data.nodes, links: data.links, sort: null}]}
         });
         window.addEventListener("resize", chart2.resize);
 

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -39,7 +39,6 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
-        <div id="main4"></div>
 
 
 
@@ -175,38 +174,6 @@ under the License.
                     chart.on('click', function (params) {
                        console.log(params, params.data);
                     });
-                }
-            });
-        </script>
-
-        <script>
-            require([
-                'echarts',
-                './data/energy.json'
-            ], function (echarts, data) {
-                var option = {
-                    series: [
-                        {
-                            type: 'sankey',
-                            sortNodes: false,
-                            nodeGap: 4,
-                            data: data.nodes,
-                            links: data.links,
-                            lineStyle: {
-                                color: 'gradient',
-                                curveness: 0.5
-                            }
-                        }
-                    ]
-                };
-
-                var chart = testHelper.create(echarts, 'main4', {
-                    title: 'sortNodes: false keeps input node order per depth',
-                    option: option
-                });
-
-                if (chart) {
-                    window.addEventListener('resize', chart.resize);
                 }
             });
         </script>

--- a/test/sankey.html
+++ b/test/sankey.html
@@ -39,6 +39,7 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
+        <div id="main4"></div>
 
 
 
@@ -174,6 +175,38 @@ under the License.
                     chart.on('click', function (params) {
                        console.log(params, params.data);
                     });
+                }
+            });
+        </script>
+
+        <script>
+            require([
+                'echarts',
+                './data/energy.json'
+            ], function (echarts, data) {
+                var option = {
+                    series: [
+                        {
+                            type: 'sankey',
+                            sortNodes: false,
+                            nodeGap: 4,
+                            data: data.nodes,
+                            links: data.links,
+                            lineStyle: {
+                                color: 'gradient',
+                                curveness: 0.5
+                            }
+                        }
+                    ]
+                };
+
+                var chart = testHelper.create(echarts, 'main4', {
+                    title: 'sortNodes: false keeps input node order per depth',
+                    option: option
+                });
+
+                if (chart) {
+                    window.addEventListener('resize', chart.resize);
                 }
             });
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

Adds a new Sankey series option `sortNodes?: boolean` that allows disabling automatic node sorting within each depth level while preserving all other layout optimizations.



### Fixed issues

- #21561: Allow preserving custom node ordering within Sankey depth levels



## Details

### Before: What was the problem?

Currently, the Sankey layout automatically sorts nodes within each depth level to reduce edge crossings and improve visual clarity. While this generally produces good layouts, it prevents developers from enforcing a custom semantic ordering of nodes within the same level.

In many practical use cases, node order within a level conveys meaning (e.g. ranking, process steps, grouped categories, or domain-specific logic). The automatic sorting step overrides the input order, making diagrams harder to interpret or inconsistent with external logic.

A common workaround is to set:

```js
layoutIterations: 0
```

However, this disables useful layout behaviors such as:

- vertical alignment optimization
- collision resolution improvements
- balanced node spacing
- refined edge positioning via Gauss–Seidel relaxation

As a result, nodes in each depth column remain aligned at the top, often producing visually suboptimal layouts.

Developers currently lack a way to preserve node order while still benefiting from layout optimization.

---

### After: How does it behave after the fixing?

A new optional series configuration property is introduced:

```ts
sortNodes?: boolean
```

Default:

```ts
sortNodes: true
```

When set to:

```js
series: {
  type: 'sankey',
  sortNodes: false
}
```

the layout algorithm:

- preserves the original input order of nodes within each depth level
- skips the per-column sorting step during collision resolution
- continues to apply:
  - node breadth calculation
  - node scaling
  - collision resolution adjustments
  - Gauss–Seidel relaxation iterations
  - edge positioning and thickness calculation

This enables deterministic node ordering without sacrificing layout quality.

A visual test case was added to `test/sankey.html` demonstrating the preserved ordering behavior.

Implementation details:

- Added `sortNodes?: boolean` to `SankeySeriesOption`
- Default value set to `true` to ensure backward compatibility
- Propagated `sortNodes` into the layout pipeline
- Conditionally skipped sorting inside `resolveCollisions`
- Added test scenario for manual verification



## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in [apache/echarts-doc#500
](https://github.com/apache/echarts-doc/pull/500)


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Added manual visual test in:

```
test/sankey.html
```

Test demonstrates that:

```
sortNodes: false
```

preserves input node ordering within each depth level while keeping layout iterations active.



### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This feature provides a minimal API addition that enables deterministic ordering of nodes within Sankey depth levels, while preserving existing layout improvements.

It serves as a practical alternative to `layoutIterations: 0`, which disables useful layout refinements.

### Demonstration of the fix
<img width="642" height="1392" alt="127 0 0 1_8080_test_sankey-node-sorting html (5)" src="https://github.com/user-attachments/assets/f8710bb5-92e5-4b5c-9162-e79e3dd9dd1a" />