### PR TITLE
[codex] Fix empty heatmap cells leaking splitArea background

### DIFF
--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -21,6 +21,7 @@ import * as graphic from '../../util/graphic';
 import { toggleHoverEmphasis } from '../../util/states';
 import HeatmapLayer from './HeatmapLayer';
 import * as zrUtil from 'zrender/src/core/util';
+import tokens from '../../visual/tokens';
 import ChartView from '../../view/Chart';
 import HeatmapSeriesModel, { HeatmapDataItemOption } from './HeatmapSeries';
 import type GlobalModel from '../../model/Global';
@@ -29,7 +30,7 @@ import type VisualMapModel from '../../component/visualMap/VisualMapModel';
 import type PiecewiseModel from '../../component/visualMap/PiecewiseModel';
 import type ContinuousModel from '../../component/visualMap/ContinuousModel';
 import { CoordinateSystem, isCoordinateSystemType } from '../../coord/CoordinateSystem';
-import { StageHandlerProgressParams, Dictionary, OptionDataValue } from '../../util/types';
+import { StageHandlerProgressParams, Dictionary, OptionDataValue, ZRColor } from '../../util/types';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import type Calendar from '../../coord/calendar/Calendar';
 import { setLabelStyle, getLabelStatesModels } from '../../label/labelStyle';
@@ -130,11 +131,12 @@ class HeatmapView extends ChartView {
         this.group.removeAll();
 
         const coordSys = seriesModel.coordinateSystem;
+        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.neutral00;
         if (coordSys.type === 'cartesian2d'
             || coordSys.type === 'calendar'
             || coordSys.type === 'matrix'
         ) {
-            this._renderOnGridLike(seriesModel, api, 0, seriesModel.getData().count());
+            this._renderOnGridLike(seriesModel, api, emptyCellFill, 0, seriesModel.getData().count());
         }
         else if (isGeoCoordSys(coordSys)) {
             this._renderOnGeo(
@@ -154,6 +156,7 @@ class HeatmapView extends ChartView {
         api: ExtensionAPI
     ) {
         const coordSys = seriesModel.coordinateSystem;
+        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.neutral00;
         if (coordSys) {
             // geo does not support incremental rendering?
             if (isGeoCoordSys(coordSys)) {
@@ -161,7 +164,7 @@ class HeatmapView extends ChartView {
             }
             else {
                 this._progressiveEls = [];
-                this._renderOnGridLike(seriesModel, api, params.start, params.end, true);
+                this._renderOnGridLike(seriesModel, api, emptyCellFill, params.start, params.end, true);
             }
         }
     }
@@ -173,6 +176,7 @@ class HeatmapView extends ChartView {
     _renderOnGridLike(
         seriesModel: HeatmapSeriesModel,
         api: ExtensionAPI,
+        emptyCellFill: ZRColor,
         start: number,
         end: number,
         incremental?: boolean
@@ -236,10 +240,11 @@ class HeatmapView extends ChartView {
             if (isCartesian2d) {
                 const dataDimX = data.get(dataDims[0], idx);
                 const dataDimY = data.get(dataDims[1], idx);
+                const value = data.get(dataDims[2], idx) as number;
 
-                // Ignore empty data and out of extent data
-                if (isNaN(data.get(dataDims[2], idx) as number)
-                    || isNaN(dataDimX as number)
+                // Ignore out of extent data. Preserve empty cells so splitArea
+                // does not show through inconsistently behind them.
+                if (isNaN(dataDimX as number)
                     || isNaN(dataDimY as number)
                     || dataDimX < xAxisExtent[0]
                     || dataDimX > xAxisExtent[1]
@@ -253,6 +258,7 @@ class HeatmapView extends ChartView {
                     dataDimX,
                     dataDimY
                 ]);
+                const emptyCell = isNaN(value);
 
                 rect = new graphic.Rect({
                     shape: {
@@ -261,10 +267,15 @@ class HeatmapView extends ChartView {
                         width,
                         height
                     },
-                    style
+                    style: emptyCell
+                        ? zrUtil.extend(zrUtil.extend({}, style), {
+                            fill: emptyCellFill
+                        })
+                        : style
                 });
             }
             else if (isMatrix) {
+                const value = data.get(dataDims[2], idx) as number;
                 const shape = coordSys.dataToLayout([
                     data.get(dataDims[0], idx),
                     data.get(dataDims[1], idx)
@@ -272,10 +283,15 @@ class HeatmapView extends ChartView {
                 if (zrUtil.eqNaN(shape.x)) {
                     continue;
                 }
+                const emptyCell = isNaN(value);
                 rect = new graphic.Rect({
                     z2: 1,
                     shape,
-                    style,
+                    style: emptyCell
+                        ? zrUtil.extend(zrUtil.extend({}, style), {
+                            fill: emptyCellFill
+                        })
+                        : style,
                 });
             }
             else { // Calendar

--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -131,7 +131,7 @@ class HeatmapView extends ChartView {
         this.group.removeAll();
 
         const coordSys = seriesModel.coordinateSystem;
-        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.neutral00;
+        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.background;
         if (coordSys.type === 'cartesian2d'
             || coordSys.type === 'calendar'
             || coordSys.type === 'matrix'
@@ -156,7 +156,7 @@ class HeatmapView extends ChartView {
         api: ExtensionAPI
     ) {
         const coordSys = seriesModel.coordinateSystem;
-        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.neutral00;
+        const emptyCellFill: ZRColor = ecModel.get('backgroundColor') || tokens.color.background;
         if (coordSys) {
             // geo does not support incremental rendering?
             if (isGeoCoordSys(coordSys)) {

--- a/test/heatmap-empty-cell-splitArea.html
+++ b/test/heatmap-empty-cell-splitArea.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+    <div id="main"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            var bgColor = '#fff1a8';
+            var option = {
+                backgroundColor: bgColor,
+                animation: false,
+                grid: {
+                    left: 70,
+                    right: 30,
+                    top: 50,
+                    bottom: 50
+                },
+                xAxis: {
+                    type: 'category',
+                    data: ['value', 'empty A', 'empty B'],
+                    splitArea: {
+                        show: true,
+                        areaStyle: {
+                            color: ['#5470c6', '#91cc75']
+                        }
+                    }
+                },
+                yAxis: {
+                    type: 'category',
+                    data: ['row'],
+                    splitArea: {
+                        show: true,
+                        areaStyle: {
+                            color: ['#ee6666']
+                        }
+                    }
+                },
+                visualMap: {
+                    min: 0,
+                    max: 10,
+                    show: false,
+                    inRange: {
+                        color: ['#73c0de', '#fac858']
+                    }
+                },
+                series: [{
+                    type: 'heatmap',
+                    data: [
+                        [0, 0, 8],
+                        [1, 0, ''],
+                        [2, 0, '']
+                    ],
+                    label: {
+                        show: true
+                    }
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main', {
+                title: [
+                    'Empty heatmap cells should cover **splitArea** with chart background',
+                    'The last two cells should be pale yellow, not blue/green splitArea colors.'
+                ],
+                height: 280,
+                option: option
+            });
+
+            setTimeout(function () {
+                testHelper.printAssert(chart, function (assert) {
+                    var data = chart.getModel().getSeriesByIndex(0).getData();
+                    var filledCell = data.getItemGraphicEl(0);
+                    var emptyCellA = data.getItemGraphicEl(1);
+                    var emptyCellB = data.getItemGraphicEl(2);
+
+                    assert(filledCell);
+                    assert(emptyCellA);
+                    assert(emptyCellB);
+                    assert(emptyCellA.style.fill === bgColor);
+                    assert(emptyCellB.style.fill === bgColor);
+                });
+            }, 0);
+        });
+    </script>
+</body>
+</html>

--- a/test/ut/spec/series/heatmap.test.ts
+++ b/test/ut/spec/series/heatmap.test.ts
@@ -1,0 +1,82 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getGraphicElements } from '../../core/utHelper';
+
+describe('heatmap', function () {
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({
+            width: 240,
+            height: 160
+        });
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should render empty cells so splitArea does not leak through', function () {
+        chart.setOption({
+            backgroundColor: '#fff',
+            animation: false,
+            visualMap: {
+                min: 0,
+                max: 10,
+                show: false
+            },
+            grid: {
+                left: 20,
+                right: 20,
+                top: 20,
+                bottom: 20
+            },
+            xAxis: {
+                type: 'category',
+                data: ['a', 'b', 'c'],
+                splitArea: {
+                    show: true
+                }
+            },
+            yAxis: {
+                type: 'category',
+                data: ['row'],
+                splitArea: {
+                    show: true
+                }
+            },
+            series: [{
+                type: 'heatmap',
+                data: [
+                    [0, 0, 8],
+                    [1, 0, ''],
+                    [2, 0, '']
+                ]
+            }]
+        }, true);
+
+        const rects = getGraphicElements(chart, 'series')
+            .filter(el => el.type === 'rect');
+
+        expect(rects).toHaveLength(3);
+        expect(rects.filter(rect => (rect as any).style.fill === '#fff')).toHaveLength(2);
+    });
+});

--- a/test/ut/spec/series/heatmap.test.ts
+++ b/test/ut/spec/series/heatmap.test.ts
@@ -19,6 +19,7 @@
 
 import { EChartsType } from '@/src/echarts';
 import { createChart, getGraphicElements } from '../../core/utHelper';
+import tokens from '@/src/visual/tokens';
 
 describe('heatmap', function () {
     let chart: EChartsType;
@@ -78,5 +79,49 @@ describe('heatmap', function () {
 
         expect(rects).toHaveLength(3);
         expect(rects.filter(rect => (rect as any).style.fill === '#fff')).toHaveLength(2);
+    });
+
+    it('should use token background for empty cells by default', function () {
+        chart.setOption({
+            animation: false,
+            visualMap: {
+                min: 0,
+                max: 10,
+                show: false
+            },
+            grid: {
+                left: 20,
+                right: 20,
+                top: 20,
+                bottom: 20
+            },
+            xAxis: {
+                type: 'category',
+                data: ['a', 'b'],
+                splitArea: {
+                    show: true
+                }
+            },
+            yAxis: {
+                type: 'category',
+                data: ['row'],
+                splitArea: {
+                    show: true
+                }
+            },
+            series: [{
+                type: 'heatmap',
+                data: [
+                    [0, 0, 8],
+                    [1, 0, '']
+                ]
+            }]
+        }, true);
+
+        const rects = getGraphicElements(chart, 'series')
+            .filter(el => el.type === 'rect');
+
+        expect(rects).toHaveLength(2);
+        expect(rects.filter(rect => (rect as any).style.fill === tokens.color.background)).toHaveLength(1);
     });
 });


### PR DESCRIPTION
## Summary
- render placeholder heatmap cells for empty values so splitArea bands do not leak through and create inconsistent empty-cell backgrounds
- add a regression test covering the empty heatmap splitArea behavior

## Root Cause
Empty heatmap cells on cartesian-style heatmaps were skipped entirely. With `splitArea` enabled, the alternating axis background showed through those skipped cells, so adjacent empty cells could appear inconsistent.

## Validation
- `./node_modules/.bin/jest --config test/ut/jest.config.cjs --runInBand test/ut/spec/series/heatmap.test.ts`
- `./node_modules/.bin/eslint src/chart/heatmap/HeatmapView.ts test/ut/spec/series/heatmap.test.ts`

Fixes #21290
