### PR TITLE
[codex] Fix treemap parent select fill with upperLabel

### DIFF
--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -923,7 +923,12 @@ function renderNode(
             const blurStyle = getStateItemStyle(itemStyleBlurModel);
             blurStyle.fill = itemStyleBlurModel.get('borderColor');
             const selectStyle = getStateItemStyle(itemStyleSelectModel);
-            selectStyle.fill = itemStyleSelectModel.get('borderColor');
+            const selectFill = itemStyleSelectModel.get('color');
+            selectStyle.fill = selectFill != null
+                ? selectFill
+                : itemStyleSelectModel.get('borderColor') != null
+                    ? itemStyleSelectModel.get('borderColor')
+                    : visualBorderColor;
 
             if (useUpperLabel) {
                 const upperLabelWidth = thisWidth - 2 * borderWidth;

--- a/test/treemap-upperLabel-select.html
+++ b/test/treemap-upperLabel-select.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+    <div id="main"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            var chart = testHelper.create(echarts, 'main', {
+                title: [
+                    'Treemap parent node should keep **select.itemStyle.color** with **upperLabel**',
+                    'This is the browser regression case for issue #21433'
+                ],
+                height: 420,
+                option: {
+                    animation: false,
+                    series: [{
+                        type: 'treemap',
+                        selectedMode: 'single',
+                        upperLabel: {
+                            show: true,
+                            height: 24
+                        },
+                        select: {
+                            itemStyle: {
+                                color: '#ff0',
+                                borderColor: '#0f0'
+                            }
+                        },
+                        data: [{
+                            name: 'Bob',
+                            value: 10,
+                            children: [{
+                                name: 'Bob 1',
+                                value: 4
+                            }, {
+                                name: 'Bob 2',
+                                value: 6
+                            }]
+                        }]
+                    }]
+                },
+                buttons: [{
+                    text: 'Select Bob',
+                    onclick: runAssertion
+                }]
+            });
+            window.__treemapSelectChart = chart;
+
+            setTimeout(runAssertion, 0);
+
+            function runAssertion() {
+                chart.dispatchAction({
+                    type: 'select',
+                    seriesIndex: 0,
+                    dataIndex: 1
+                });
+
+                testHelper.printAssert(chart, function (assert) {
+                    var seriesModel = chart.getModel().getSeriesByIndex(0);
+                    var data = seriesModel.getData();
+                    var bg = data.getItemGraphicEl(1);
+
+                    assert(bg);
+                    assert(bg.states.select.style.fill === '#ff0');
+                    assert(data.getItemGraphicEl(2));
+                    assert(data.getItemGraphicEl(3));
+                });
+            }
+        });
+    </script>
+</body>
+</html>

--- a/test/treemap-upperLabel-select.html
+++ b/test/treemap-upperLabel-select.html
@@ -36,7 +36,7 @@ under the License.
             var chart = testHelper.create(echarts, 'main', {
                 title: [
                     'Treemap parent node should keep **select.itemStyle.color** with **upperLabel**',
-                    'This is the browser regression case for issue #21433'
+                    'Click Select Bob; the selected parent background should become yellow, not green.'
                 ],
                 height: 420,
                 option: {
@@ -72,26 +72,24 @@ under the License.
                     onclick: runAssertion
                 }]
             });
-            window.__treemapSelectChart = chart;
-
             setTimeout(runAssertion, 0);
 
             function runAssertion() {
                 chart.dispatchAction({
                     type: 'select',
                     seriesIndex: 0,
-                    dataIndex: 1
+                    dataIndex: 0
                 });
 
                 testHelper.printAssert(chart, function (assert) {
                     var seriesModel = chart.getModel().getSeriesByIndex(0);
                     var data = seriesModel.getData();
-                    var bg = data.getItemGraphicEl(1);
+                    var bg = data.getItemGraphicEl(0);
 
                     assert(bg);
                     assert(bg.states.select.style.fill === '#ff0');
+                    assert(data.getItemGraphicEl(1));
                     assert(data.getItemGraphicEl(2));
-                    assert(data.getItemGraphicEl(3));
                 });
             }
         });

--- a/test/ut/spec/series/treemap.test.ts
+++ b/test/ut/spec/series/treemap.test.ts
@@ -1,0 +1,69 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getECModel } from '../../core/utHelper';
+
+describe('treemap', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should use select.itemStyle.color for parent nodes with upperLabel', function () {
+        chart.setOption({
+            series: [{
+                type: 'treemap',
+                selectedMode: 'single',
+                upperLabel: {
+                    show: true,
+                    height: 24
+                },
+                select: {
+                    itemStyle: {
+                        color: '#ff0',
+                        borderColor: '#0f0'
+                    }
+                },
+                data: [{
+                    name: 'Bob',
+                    value: 10,
+                    children: [{
+                        name: 'Bob 1',
+                        value: 4
+                    }, {
+                        name: 'Bob 2',
+                        value: 6
+                    }]
+                }]
+            }]
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByIndex(0);
+        const bg = seriesModel.getData().getItemGraphicEl(0) as any;
+
+        expect(bg.states.select.style.fill).toBe('#ff0');
+    });
+});


### PR DESCRIPTION
## Summary
- keep parent treemap nodes with `upperLabel` using their configured `select.itemStyle.color`
- add a regression test covering parent-node select styling with upper labels

## Root Cause
The parent-node `upperLabel` rendering path hardwired the selected fill color to `borderColor`, so parent nodes ignored `select.itemStyle.color`. That broke parent-node selected styling and led to the hover/select behavior reported in the issue.

## Validation
- `./node_modules/.bin/jest --config test/ut/jest.config.cjs --runInBand test/ut/spec/series/treemap.test.ts`
- `./node_modules/.bin/eslint src/chart/treemap/TreemapView.ts test/ut/spec/series/treemap.test.ts`

Fixes #21433
