### PR TITLE
fix(axis): Show min/max split line for all axis types

### DIFF
--- a/src/component/axis/AngleAxisView.ts
+++ b/src/component/axis/AngleAxisView.ts
@@ -138,23 +138,30 @@ interface AngleAxisElementBuilder {
 const angelAxisElementsBuilders: Record<typeof elementList[number], AngleAxisElementBuilder> = {
 
     axisLine(group, angleAxisModel, polar, ticksAngles, minorTickAngles, radiusExtent) {
+        const axisLineModel = angleAxisModel.getModel('axisLine');
         const lineStyleModel = angleAxisModel.getModel(['axisLine', 'lineStyle']);
         const angleAxis = polar.getAngleAxis();
         const RADIAN = Math.PI / 180;
         const angleExtent = angleAxis.getExtent();
-
-        // extent id of the axis radius (r0 and r)
-        const rId = getRadiusIdx(polar);
-        const r0Id = rId ? 0 : 1;
-        let shape;
+        const showMinLine = axisLineModel.get('showMinLine') !== false;
+        const showMaxLine = axisLineModel.get('showMaxLine') !== false;
         const shapeType = Math.abs(angleExtent[1] - angleExtent[0]) === 360 ? 'Circle' : 'Arc';
+        const minRadius = radiusExtent[0];
+        const maxRadius = radiusExtent[1];
 
-        if (radiusExtent[r0Id] === 0) {
-            shape = new graphic[shapeType]({
+        if (!showMinLine && !showMaxLine) {
+            return;
+        }
+
+        const addBoundaryLine = (radius: number) => {
+            if (!isFinite(radius)) {
+                return;
+            }
+            const shape = new graphic[shapeType]({
                 shape: {
                     cx: polar.cx,
                     cy: polar.cy,
-                    r: radiusExtent[rId],
+                    r: Math.max(radius, 0),
                     startAngle: -angleExtent[0] * RADIAN,
                     endAngle: -angleExtent[1] * RADIAN,
                     clockwise: angleAxis.inverse
@@ -163,22 +170,21 @@ const angelAxisElementsBuilders: Record<typeof elementList[number], AngleAxisEle
                 z2: 1,
                 silent: true
             });
+            shape.style.fill = null;
+            group.add(shape);
+        };
+
+        if (Math.abs(minRadius - maxRadius) < 1e-4) {
+            addBoundaryLine(minRadius);
+            return;
         }
-        else {
-            shape = new graphic.Ring({
-                shape: {
-                    cx: polar.cx,
-                    cy: polar.cy,
-                    r: radiusExtent[rId],
-                    r0: radiusExtent[r0Id]
-                },
-                style: lineStyleModel.getLineStyle(),
-                z2: 1,
-                silent: true
-            });
+
+        if (showMinLine) {
+            addBoundaryLine(minRadius);
         }
-        shape.style.fill = null;
-        group.add(shape);
+        if (showMaxLine) {
+            addBoundaryLine(maxRadius);
+        }
     },
 
     axisTick(group, angleAxisModel, polar, ticksAngles, minorTickAngles, radiusExtent) {

--- a/src/component/axis/AngleAxisView.ts
+++ b/src/component/axis/AngleAxisView.ts
@@ -311,6 +311,8 @@ const angelAxisElementsBuilders: Record<typeof elementList[number], AngleAxisEle
         const splitLineModel = angleAxisModel.getModel('splitLine');
         const lineStyleModel = splitLineModel.getModel('lineStyle');
         let lineColors = lineStyleModel.get('color');
+        const showMinLine = splitLineModel.get('showMinLine') !== false;
+        const showMaxLine = splitLineModel.get('showMaxLine') !== false;
         let lineCount = 0;
 
         lineColors = lineColors instanceof Array ? lineColors : [lineColors];
@@ -318,6 +320,9 @@ const angelAxisElementsBuilders: Record<typeof elementList[number], AngleAxisEle
         const splitLines: graphic.Line[][] = [];
 
         for (let i = 0; i < ticksAngles.length; i++) {
+            if ((i === 0 && !showMinLine) || (i === ticksAngles.length - 1 && !showMaxLine)) {
+                continue;
+            }
             const colorIndex = (lineCount++) % lineColors.length;
             splitLines[colorIndex] = splitLines[colorIndex] || [];
             splitLines[colorIndex].push(new graphic.Line({

--- a/src/component/axis/RadiusAxisView.ts
+++ b/src/component/axis/RadiusAxisView.ts
@@ -101,6 +101,8 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         const splitLineModel = radiusAxisModel.getModel('splitLine');
         const lineStyleModel = splitLineModel.getModel('lineStyle');
         let lineColors = lineStyleModel.get('color');
+        const showMinLine = splitLineModel.get('showMinLine') !== false;
+        const showMaxLine = splitLineModel.get('showMaxLine') !== false;
         let lineCount = 0;
 
         const angleAxis = polar.getAngleAxis();
@@ -113,6 +115,9 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         const splitLines: graphic.Circle[][] = [];
 
         for (let i = 0; i < ticksCoords.length; i++) {
+            if ((i === 0 && !showMinLine) || (i === ticksCoords.length - 1 && !showMaxLine)) {
+                continue;
+            }
             const colorIndex = (lineCount++) % lineColors.length;
             splitLines[colorIndex] = splitLines[colorIndex] || [];
             splitLines[colorIndex].push(new graphic[shapeType]({

--- a/src/component/axis/SingleAxisView.ts
+++ b/src/component/axis/SingleAxisView.ts
@@ -96,6 +96,8 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         const splitLineModel = axisModel.getModel('splitLine');
         const lineStyleModel = splitLineModel.getModel('lineStyle');
         let lineColors = lineStyleModel.get('color');
+        const showMinLine = splitLineModel.get('showMinLine') !== false;
+        const showMaxLine = splitLineModel.get('showMaxLine') !== false;
         lineColors = lineColors instanceof Array ? lineColors : [lineColors];
         const lineWidth = lineStyleModel.get('width');
 
@@ -115,6 +117,9 @@ const axisElementBuilders: Record<typeof selfBuilderAttrs[number], AxisElementBu
         const p2 = [];
 
         for (let i = 0; i < ticksCoords.length; ++i) {
+            if ((i === 0 && !showMinLine) || (i === ticksCoords.length - 1 && !showMaxLine)) {
+                continue;
+            }
             const tickCoord = axis.toGlobalCoord(ticksCoords[i].coord);
             if (isHorizontal) {
                 p1[0] = tickCoord;

--- a/src/component/polar/install.ts
+++ b/src/component/polar/install.ts
@@ -44,6 +44,11 @@ const angleAxisExtraOption: AngleAxisOption = {
 
     splitNumber: 12,
 
+    axisLine: {
+        showMinLine: true,
+        showMaxLine: true
+    },
+
     axisLabel: {
         rotate: 0
     }

--- a/src/coord/polar/AxisModel.ts
+++ b/src/coord/polar/AxisModel.ts
@@ -42,7 +42,11 @@ export type AngleAxisOption = AxisBaseOption & {
     endAngle?: number;
     clockwise?: boolean;
 
-    axisLabel?: AxisBaseOption['axisLabel']
+    axisLabel?: AxisBaseOption['axisLabel'];
+    axisLine?: NonNullable<AxisBaseOption['axisLine']> & {
+        showMinLine?: boolean;
+        showMaxLine?: boolean;
+    }
 };
 
 export type RadiusAxisOption = AxisBaseOption & {

--- a/test/axis-axisLine.html
+++ b/test/axis-axisLine.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+
+    <body>
+        <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+        <div id="main3"></div>
+        <div id="main4"></div>
+        <div id="main5"></div>
+
+        <script>
+            require(['echarts'], function (echarts) {
+                function makeOption(angleAxisOption, radiusAxisOption) {
+                    return {
+                        polar: {
+                            radius: [60, 160]
+                        },
+                        angleAxis: Object.assign({
+                            type: 'category',
+                            data: ['A', 'B', 'C', 'D'],
+                            axisLine: {
+                                show: true,
+                                lineStyle: {
+                                    color: '#cc2222',
+                                    width: 8
+                                }
+                            },
+                            splitLine: {show: false},
+                            splitArea: {show: false}
+                        }, angleAxisOption || {}),
+                        radiusAxis: Object.assign({
+                            type: 'value',
+                            min: 0,
+                            max: 4,
+                            interval: 1,
+                            splitLine: {show: false},
+                            axisLine: {show: false},
+                            axisTick: {show: false},
+                            axisLabel: {show: false}
+                        }, radiusAxisOption || {}),
+                        series: [{
+                            type: 'bar',
+                            coordinateSystem: 'polar',
+                            data: [1, 2, 3, 4],
+                            itemStyle: {
+                                color: 'rgba(0, 0, 0, 0.18)'
+                            }
+                        }]
+                    };
+                }
+
+                testHelper.create(echarts, 'main0', {
+                    title: 'Default behavior: showMinLine/showMaxLine omitted',
+                    option: makeOption({
+                        axisLine: {
+                            lineStyle: {
+                                color: '#bb5500',
+                                width: 8
+                            }
+                        }
+                    })
+                });
+
+                testHelper.create(echarts, 'main1', {
+                    title: 'Full circle: hide min axisLine boundary (showMinLine: false)',
+                    option: makeOption({
+                        axisLine: {
+                            showMinLine: false,
+                            showMaxLine: true,
+                            lineStyle: {
+                                color: '#cc2222',
+                                width: 8
+                            }
+                        }
+                    })
+                });
+
+                testHelper.create(echarts, 'main2', {
+                    title: 'Partial angle: hide max axisLine boundary (showMaxLine: false)',
+                    option: makeOption({
+                        data: ['A', 'B', 'C', 'D', 'E'],
+                        startAngle: 90,
+                        endAngle: -90,
+                        axisLine: {
+                            showMinLine: true,
+                            showMaxLine: false,
+                            lineStyle: {
+                                color: '#2244cc',
+                                width: 8
+                            }
+                        }
+                    })
+                });
+
+                testHelper.create(echarts, 'main3', {
+                    title: 'radiusAxis.inverse: true + showMaxLine: true (data max boundary)',
+                    option: makeOption({
+                        data: ['A', 'B', 'C', 'D'],
+                        axisLine: {
+                            showMinLine: false,
+                            showMaxLine: true,
+                            lineStyle: {
+                                color: '#228844',
+                                width: 8
+                            }
+                        }
+                    }, {
+                        inverse: true
+                    })
+                });
+
+                testHelper.create(echarts, 'main4', {
+                    title: 'Both disabled: showMinLine: false + showMaxLine: false',
+                    option: makeOption({
+                        axisLine: {
+                            showMinLine: false,
+                            showMaxLine: false,
+                            lineStyle: {
+                                color: '#aa22aa',
+                                width: 8
+                            }
+                        }
+                    })
+                });
+
+                testHelper.create(echarts, 'main5', {
+                    title: 'Edge case: category radiusAxis boundary vs angleAxis.axisLine boundary',
+                    option: {
+                        polar: {
+                            radius: [60, 160]
+                        },
+                        angleAxis: {
+                            type: 'value',
+                            min: 0,
+                            max: 360,
+                            splitNumber: 4,
+                            axisLine: {
+                                show: true,
+                                lineStyle: {
+                                    color: '#c92121',
+                                    width: 6
+                                }
+                            },
+                            axisTick: {
+                                show: false
+                            },
+                            axisLabel: {
+                                show: false
+                            },
+                            splitLine: {
+                                show: false
+                            }
+                        },
+                        radiusAxis: {
+                            type: 'category',
+                            boundaryGap: true,
+                            data: ['L1', 'L2', 'L3', 'L4'],
+                            axisLine: {
+                                show: false
+                            },
+                            axisTick: {
+                                show: false
+                            },
+                            axisLabel: {
+                                show: false
+                            },
+                            splitLine: {
+                                show: true,
+                                lineStyle: {
+                                    color: '#111',
+                                    width: 2
+                                }
+                            }
+                        },
+                        series: [{
+                            type: 'bar',
+                            coordinateSystem: 'polar',
+                            data: [0, 90, 180, 270],
+                            itemStyle: {
+                                color: 'rgba(0, 0, 0, 0.12)'
+                            }
+                        }]
+                    }
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/test/axis-splitLine.html
+++ b/test/axis-splitLine.html
@@ -34,50 +34,82 @@ under the License.
     </head>
 
     <body>
-        <div id="main"></div>
+        <div id="main0"></div>
+        <div id="main1"></div>
 
         <script>
             require(['echarts'], function (echarts) {
-                var chartDom = document.getElementById('main');
-                var myChart = echarts.init(chartDom);
-                var option;
-
-                option = {
-                    xAxis: {
-                    type: 'category',
-                    data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-                    splitLine: {
-                        show: true,
-                        showMinLine: false, // do not show the first splitLine
-                        showMaxLine: false, // do not show the last splitLine
-                        lineStyle: {
-                            color: 'black',
-                            width:3
-                        }
-                    },
-                },
-                    yAxis: {
-                    type: 'value',
-                    axisLine: {
-                        show: true,
-                        lineStyle: {
-                            color: 'rgba(255,100,0,0.8)',
-                            width: 12
-                        }
+                testHelper.create(echarts, 'main0', {
+                    title: 'Cartesian axis splitLine with showMinLine/showMaxLine',
+                    option: {
+                        xAxis: {
+                            type: 'category',
+                            data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                            splitLine: {
+                                show: true,
+                                showMinLine: false, // do not show the first splitLine
+                                showMaxLine: false, // do not show the last splitLine
+                                lineStyle: {
+                                    color: 'black',
+                                    width: 3
+                                }
+                            }
+                        },
+                        yAxis: {
+                            type: 'value',
+                            axisLine: {
+                                show: true,
+                                lineStyle: {
+                                    color: 'rgba(255,100,0,0.8)',
+                                    width: 12
+                                }
+                            }
+                        },
+                        series: [
+                            {
+                                data: [150, 230, 224, 218, 135, 147, 260],
+                                type: 'line'
+                            }
+                        ]
                     }
-                },
-                    series: [
-                        {
-                        data: [150, 230, 224, 218, 135, 147, 260],
-                        type: 'line'
-                        }
-                    ]
-                };
+                });
 
-                option && myChart.setOption(option);
-            })
+                testHelper.create(echarts, 'main1', {
+                    title: 'radiusAxis splitLine with showMinLine/showMaxLine',
+                    option: {
+                        polar: {
+                            radius: [60, 160]
+                        },
+                        angleAxis: {
+                            type: 'category',
+                            data: ['A', 'B', 'C', 'D'],
+                            splitLine: {
+                                show: false
+                            }
+                        },
+                        radiusAxis: {
+                            min: 0,
+                            max: 4,
+                            interval: 1,
+                            splitLine: {
+                                show: true,
+                                showMinLine: false, // do not show the innermost splitLine
+                                showMaxLine: false, // do not show the outermost splitLine
+                                lineStyle: {
+                                    color: 'black',
+                                    width: 3
+                                }
+                            }
+                        },
+                        series: [{
+                            type: 'bar',
+                            coordinateSystem: 'polar',
+                            data: [1, 2, 3, 4]
+                        }]
+                    }
+                });
+            });
         </script>
 
     </body>
 </html>
-

--- a/test/axis-splitLine.html
+++ b/test/axis-splitLine.html
@@ -37,6 +37,7 @@ under the License.
         <div id="main0"></div>
         <div id="main1"></div>
         <div id="main2"></div>
+        <div id="main3"></div>
 
         <script>
             require(['echarts'], function (echarts) {
@@ -140,6 +141,31 @@ under the License.
                             type: 'bar',
                             coordinateSystem: 'polar',
                             data: [1, 2, 3, 4, 5]
+                        }]
+                    }
+                });
+
+                testHelper.create(echarts, 'main3', {
+                    title: 'singleAxis splitLine with showMinLine/showMaxLine',
+                    option: {
+                        singleAxis: {
+                            type: 'category',
+                            data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                            splitLine: {
+                                show: true,
+                                showMinLine: false, // do not show the first splitLine
+                                showMaxLine: false, // do not show the last splitLine
+                                lineStyle: {
+                                    color: 'black',
+                                    width: 3
+                                }
+                            }
+                        },
+                        series: [{
+                            type: 'scatter',
+                            coordinateSystem: 'singleAxis',
+                            data: [0, 1, 2, 3, 4, 5, 6],
+                            symbolSize: 10
                         }]
                     }
                 });

--- a/test/axis-splitLine.html
+++ b/test/axis-splitLine.html
@@ -36,6 +36,7 @@ under the License.
     <body>
         <div id="main0"></div>
         <div id="main1"></div>
+        <div id="main2"></div>
 
         <script>
             require(['echarts'], function (echarts) {
@@ -105,6 +106,40 @@ under the License.
                             type: 'bar',
                             coordinateSystem: 'polar',
                             data: [1, 2, 3, 4]
+                        }]
+                    }
+                });
+
+                testHelper.create(echarts, 'main2', {
+                    title: 'angleAxis splitLine with showMinLine/showMaxLine',
+                    option: {
+                        polar: {
+                            radius: [50, 160]
+                        },
+                        angleAxis: {
+                            type: 'category',
+                            startAngle: 90,
+                            endAngle: -90,
+                            data: ['A', 'B', 'C', 'D', 'E'],
+                            splitLine: {
+                                show: true,
+                                showMinLine: false, // do not show the first splitLine
+                                showMaxLine: false, // do not show the last splitLine
+                                lineStyle: {
+                                    color: 'black',
+                                    width: 3
+                                }
+                            }
+                        },
+                        radiusAxis: {
+                            splitLine: {
+                                show: false
+                            }
+                        },
+                        series: [{
+                            type: 'bar',
+                            coordinateSystem: 'polar',
+                            data: [1, 2, 3, 4, 5]
                         }]
                     }
                 });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Add the missing implementation of `splitLine.showMinLine`/`.showMaxLine` to radius, angle and single axis. Also add support for these properties to `axisLine` for polar angle axis.

## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

https://github.com/apache/echarts/pull/20114 added `splitLine.showMinLine` and `.showMaxLine` and implemented it for the cartesian axis. The current documentation shows the option to be supported for other axis as well:

* https://echarts.apache.org/en/option.html#radiusAxis.splitLine.showMinLine
* https://echarts.apache.org/en/option.html#singleAxis.splitLine.showMinLine
* https://echarts.apache.org/en/option.html#angleAxis.splitLine.showMinLine

However there was simply no implementation in place. This PR fixes that.

Also, while on it, I also added support for these properties to `axisLine` for polar angle axis.

### After: How does it behave after the fixing?

#### The split line fix
<img height="200" alt="Screenshot 2026-04-14 at 13 18 06" src="https://github.com/user-attachments/assets/1242a36c-62f2-40b7-ab88-68c8fe6ba6fa" />
<img height="200" alt="Screenshot 2026-04-14 at 13 18 29" src="https://github.com/user-attachments/assets/b6bbfe4a-7e55-4e3d-9de5-d56241158ad2" />
<img height="200" alt="Screenshot 2026-04-14 at 13 18 50" src="https://github.com/user-attachments/assets/18d5c360-e498-414f-975e-c56122e712c3" />

#### The axis line feature

<img height="200" alt="Screenshot 2026-04-14 at 13 19 44" src="https://github.com/user-attachments/assets/8bceab15-24e4-4a08-bf9d-2d0ec6fac30d" />
<img height="200" alt="Screenshot 2026-04-14 at 13 19 59" src="https://github.com/user-attachments/assets/8f24695f-fb47-4d2b-b55b-a55f5a7a693a" />
<img height="200" alt="Screenshot 2026-04-14 at 13 20 15" src="https://github.com/user-attachments/assets/255c5f69-b027-45b1-b108-4e2e2f96877b" />
<img height="200" alt="Screenshot 2026-04-14 at 13 20 29" src="https://github.com/user-attachments/assets/aa117e29-df32-4818-a0d5-59bab08ca91f" />
<img height="200" alt="Screenshot 2026-04-14 at 13 20 44" src="https://github.com/user-attachments/assets/80b86f4f-5962-4b4f-9fa7-b079cdab35d7" />

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#505

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

This is my first PR in this repo. Please let me know if I missed some of the conventions.