### PR TITLE
docs: fix typos in source code comments

### DIFF
--- a/src/component/legend/ScrollableLegendView.ts
+++ b/src/component/legend/ScrollableLegendView.ts
@@ -437,7 +437,7 @@ class ScrollableLegendView extends LegendView {
         // Strategy:
         // (1) Always align based on the left/top most item.
         // (2) It is user-friendly that the last item shown in the
-        // current window is shown at the begining of next window.
+        // current window is shown at the beginning of next window.
         // Otherwise if half of the last item is cut by the window,
         // it will have no chance to display entirely.
         // (3) Consider that item size probably be different, we

--- a/src/coord/matrix/MatrixBodyCorner.ts
+++ b/src/coord/matrix/MatrixBodyCorner.ts
@@ -54,7 +54,7 @@ export interface MatrixBodyCornerCell {
     option: MatrixBodyCornerCellOption | NullUndefined;
     // `matrix.body/corner.data[i].coord` can locate a rect of cells (say, area).
     // `inSpanOf` refers to the top-left cell, which represents that area.
-    // The top-left cell has `inSpanOf` refering to itself.
+    // The top-left cell has `inSpanOf` referring to itself.
     inSpanOf: MatrixBodyCornerCell | NullUndefined;
     // If existing, it indicates cell merging, and this cell is the top-left cell
     // of the merging area.

--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -884,7 +884,7 @@ function doUpdateZ(
         label.z = z;
         label.zlevel = zlevel;
         // lift z2 of text content
-        // TODO if el.emphasis.z2 is spcefied, what about textContent.
+        // TODO if el.emphasis.z2 is specified, what about textContent.
         isFinite(maxZ2) && (label.z2 = maxZ2 + 2);
     }
     if (labelLine) {


### PR DESCRIPTION

**Repo:** apache/echarts (⭐ 59000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three small spelling mistakes in code comments across the ECharts source tree: `spcefied` → `specified` in `src/util/graphic.ts`, `begining` → `beginning` in `src/component/legend/ScrollableLegendView.ts`, and `refering` → `referring` in `src/coord/matrix/MatrixBodyCorner.ts`.

## Why
These are pure comment fixes that improve readability and grep-ability of the codebase without changing any runtime behavior. Comments are documentation that contributors and maintainers read regularly, and consistent spelling helps when searching for terms or reviewing diffs.

## Testing
No behavioral change — only comment text is modified. The TypeScript compiler treats comments as whitespace, so existing builds and tests remain unaffected. A `git diff` confirms only `//` comment lines are touched.

## Risk
Low — comment-only changes with no impact on emitted JavaScript or type-checking.
