### PR TITLE
fix(parallel): preserve areaSelectStyle on persisted selection

### DIFF
--- a/src/component/helper/BrushController.ts
+++ b/src/component/helper/BrushController.ts
@@ -72,7 +72,9 @@ export interface BrushCoverConfig {
     panelId?: string;
 
     brushMode?: BrushMode;
-    // `brushStyle`, `transformable` is not mandatory, use DEFAULT_BRUSH_OPT by default.
+    // `brushStyle`, `transformable` is not mandatory. When the controller is enabled,
+    // `updateCovers` inherits from the current brush option first, and then falls back
+    // to `DEFAULT_BRUSH_OPT`.
     brushStyle?: Pick<PathStyleProps, BrushStyleKey>;
     transformable?: boolean;
     removeOnClick?: boolean;
@@ -381,8 +383,9 @@ class BrushController extends Eventful<{
             assert(this._mounted);
         }
 
+        const baseBrushOption = this._brushOption || DEFAULT_BRUSH_OPT;
         coverConfigList = map(coverConfigList, function (coverConfig) {
-            return merge(clone(DEFAULT_BRUSH_OPT), coverConfig, true);
+            return merge(clone(baseBrushOption), coverConfig, true);
         }) as BrushCoverConfig[];
 
         const tmpIdPrefix = '\0-brush-index-';

--- a/test/ut/spec/component/helper/BrushController.test.ts
+++ b/test/ut/spec/component/helper/BrushController.test.ts
@@ -1,0 +1,74 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import BrushController from '../../../../../src/component/helper/BrushController';
+import { createChart } from '../../../core/utHelper';
+import { EChartsType } from '../../../../../src/echarts';
+import Rect from 'zrender/src/graphic/shape/Rect';
+
+
+describe('component/helper/BrushController', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('updateCovers inherits the enabled brush style', function () {
+        const controller = new BrushController(chart.getZr()).mount();
+        const brushStyle = {
+            fill: 'rgba(255, 0, 0, 0.35)',
+            stroke: 'rgb(255, 0, 0)',
+            lineWidth: 6,
+            opacity: 0.45
+        };
+
+        controller
+            .enableBrush({
+                brushType: 'lineX',
+                brushStyle: brushStyle,
+                transformable: false,
+                removeOnClick: true
+            })
+            .updateCovers([{
+                brushType: 'lineX',
+                range: [20, 60]
+            }]);
+
+        // @ts-ignore access internal state for behavior verification.
+        const cover = controller._covers[0];
+        // @ts-ignore access internal state for behavior verification.
+        const brushOption = cover.__brushOption;
+        const mainEl = cover.childAt(0) as Rect;
+
+        expect(brushOption.brushStyle).toEqual(brushStyle);
+        expect(brushOption.transformable).toEqual(false);
+        expect(brushOption.removeOnClick).toEqual(true);
+        expect(mainEl.style.fill).toEqual(brushStyle.fill);
+        expect(mainEl.style.stroke).toEqual(brushStyle.stroke);
+        expect(mainEl.style.lineWidth).toEqual(brushStyle.lineWidth);
+        expect(mainEl.style.opacity).toEqual(brushStyle.opacity);
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Preserve `parallelAxis.areaSelectStyle` when persisted parallel-axis selections are rebuilt.

### Fixed issues

- #21583: Parallel axis persisted selection ignores configured `areaSelectStyle`.

## Details

### Before: What was the problem?

`ParallelAxisView` uses `areaSelectStyle` when creating a new axis selection, but the persisted covers are later rebuilt through `BrushController.updateCovers` without carrying over the active brush style. That rebuild path fell back to `DEFAULT_BRUSH_OPT`, so the selected area eventually changed back to the controller fallback style instead of respecting the configured style.

### After: How does it behave after the fixing?

`BrushController.updateCovers` now inherits from the currently enabled brush option before falling back to `DEFAULT_BRUSH_OPT`, so rebuilt covers keep the same `brushStyle`, `transformable`, and `removeOnClick` settings as the active controller. A regression test was added to lock this behavior in.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `npx jest --config test/ut/jest.config.cjs --coverage=false test/ut/spec/component/helper/BrushController.test.ts --runInBand`
- `npm run checktype`
- `npx eslint src/component/helper/BrushController.ts`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

N.A.
