### PR TITLE
chore(workflow): disable misleading PR preview comment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -66,13 +66,17 @@ jobs:
           export SURGE_DOMAIN=https://echarts-pr-$PR_NUMBER.surge.sh
           npx surge --project ./package --domain $SURGE_DOMAIN --token $SURGE_TOKEN
 
-      - name: Create comment for PR preview
-        uses: ./.actions/maintain-one-comment
-        env:
-          PR_NUMBER: ${{ steps.pr-metadata.outputs.NUMBER }}
-          COMMIT_SHA_SHORT: ${{ steps.pr-metadata.outputs.COMMIT_SHA_SHORT }}
-        with:
-          body: |
-            The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?version=PR-${{ env.PR_NUMBER }}@${{ env.COMMIT_SHA_SHORT }}
-          body-include: '<!-- ECHARTS_PR_PREVIEW -->'
-          number: ${{ env.PR_NUMBER }}
+      # Disabled for now because the editor preview URL is misleading under the
+      # current website CSP policy. The preview bundle is still deployed to
+      # surge.sh, but `echarts.apache.org/examples/editor?version=PR-...`
+      # cannot reliably load it.
+      # - name: Create comment for PR preview
+      #   uses: ./.actions/maintain-one-comment
+      #   env:
+      #     PR_NUMBER: ${{ steps.pr-metadata.outputs.NUMBER }}
+      #     COMMIT_SHA_SHORT: ${{ steps.pr-metadata.outputs.COMMIT_SHA_SHORT }}
+      #   with:
+      #     body: |
+      #       The changes brought by this PR can be previewed at: https://echarts.apache.org/examples/editor?version=PR-${{ env.PR_NUMBER }}@${{ env.COMMIT_SHA_SHORT }}
+      #     body-include: '<!-- ECHARTS_PR_PREVIEW -->'
+      #     number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
## Summary

Disable the auto-generated PR preview comment for now.

The current comment points reviewers to:

`https://echarts.apache.org/examples/editor?version=PR-...`

But under the current website CSP policy, the editor cannot reliably load the preview bundle hosted on `echarts-pr-*.surge.sh`, which makes the comment misleading.

This is also consistent with the follow-up change in `apache/echarts-examples`:

- https://github.com/apache/echarts-examples/commit/f7ad8779b7301c37611e1ef847bebbdc8a41bc38
- `use cdn hosted in asf server to avoid csp issue`

That commit effectively disabled the working PR-preview bundle routing in the editor because the external preview host was no longer reliable under the website CSP.

This change keeps the preview deployment itself unchanged and only disables the confusing PR comment.

## Test

- Workflow-only change
