### PR TITLE
[codex] Support radial label rotation in chord chart

### DIFF
--- a/src/chart/chord/ChordPiece.ts
+++ b/src/chart/chord/ChordPiece.ts
@@ -188,9 +188,10 @@ export default class ChordPiece extends graphic.Sector {
         for (let i = 0; i < SPECIAL_STATES.length; i++) {
             const stateName = SPECIAL_STATES[i];
             const stateRotate = labelStateModels[stateName].getShallow('rotate');
-            label.ensureState(stateName).rotation = stateRotate == null
-                ? labelRotate
-                : getLabelRotation(stateRotate, midAngle, dx);
+            const state = label.ensureState(stateName);
+            state.rotation = stateRotate != null
+                ? getLabelRotation(stateRotate, midAngle, dx)
+                : null;
         }
 
         label.attr({

--- a/src/chart/chord/ChordPiece.ts
+++ b/src/chart/chord/ChordPiece.ts
@@ -26,10 +26,17 @@ import type Model from '../../model/Model';
 import type { GraphNode } from '../../data/Graph';
 import { getLabelStatesModels, setLabelStyle } from '../../label/labelStyle';
 import type { BuiltinTextPosition } from 'zrender/src/core/types';
-import { setStatesStylesFromModel, toggleHoverEmphasis } from '../../util/states';
+import { setStatesStylesFromModel, SPECIAL_STATES, toggleHoverEmphasis } from '../../util/states';
 import { getECData } from '../../util/innerStore';
 
 const RADIAN = Math.PI / 180;
+
+function getLabelRotation(rotate: number | 'radial', midAngle: number, dx: number): number {
+    if (rotate === 'radial') {
+        return dx < 0 ? -midAngle + Math.PI : -midAngle;
+    }
+    return isNumber(rotate) ? rotate * RADIAN : 0;
+}
 
 export default class ChordPiece extends graphic.Sector {
 
@@ -176,13 +183,14 @@ export default class ChordPiece extends graphic.Sector {
             ? normalLabelModel.get('verticalAlign') || 'middle'
             : (dy > 0 ? 'top' : 'bottom');
 
-        let labelRotate = 0;
-        const rotate = normalLabelModel.get('rotate');
-        if (rotate === 'radial') {
-            labelRotate = dx < 0 ? -midAngle + Math.PI : -midAngle;
-        }
-        else if (isNumber(rotate)) {
-            labelRotate = rotate * RADIAN;
+        const labelRotate = getLabelRotation(normalLabelModel.get('rotate'), midAngle, dx);
+
+        for (let i = 0; i < SPECIAL_STATES.length; i++) {
+            const stateName = SPECIAL_STATES[i];
+            const stateRotate = labelStateModels[stateName].getShallow('rotate');
+            if (stateRotate != null) {
+                label.ensureState(stateName).rotation = getLabelRotation(stateRotate, midAngle, dx);
+            }
         }
 
         label.attr({

--- a/src/chart/chord/ChordPiece.ts
+++ b/src/chart/chord/ChordPiece.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import { extend, retrieve3 } from 'zrender/src/core/util';
+import { extend, isNumber, retrieve3 } from 'zrender/src/core/util';
 import * as graphic from '../../util/graphic';
 import SeriesData from '../../data/SeriesData';
 import { getSectorCornerRadius } from '../helper/sectorHelper';
@@ -28,6 +28,8 @@ import { getLabelStatesModels, setLabelStyle } from '../../label/labelStyle';
 import type { BuiltinTextPosition } from 'zrender/src/core/types';
 import { setStatesStylesFromModel, toggleHoverEmphasis } from '../../util/states';
 import { getECData } from '../../util/innerStore';
+
+const RADIAN = Math.PI / 180;
 
 export default class ChordPiece extends graphic.Sector {
 
@@ -174,10 +176,19 @@ export default class ChordPiece extends graphic.Sector {
             ? normalLabelModel.get('verticalAlign') || 'middle'
             : (dy > 0 ? 'top' : 'bottom');
 
+        let labelRotate = 0;
+        const rotate = normalLabelModel.get('rotate');
+        if (rotate === 'radial') {
+            labelRotate = dx < 0 ? -midAngle + Math.PI : -midAngle;
+        }
+        else if (isNumber(rotate)) {
+            labelRotate = rotate * RADIAN;
+        }
+
         label.attr({
             x: dx * r + layout.cx,
             y: dy * r + layout.cy,
-            rotation: 0,
+            rotation: labelRotate,
             style: {
                 align,
                 verticalAlign
@@ -185,4 +196,3 @@ export default class ChordPiece extends graphic.Sector {
         });
     }
 }
-

--- a/src/chart/chord/ChordPiece.ts
+++ b/src/chart/chord/ChordPiece.ts
@@ -188,9 +188,9 @@ export default class ChordPiece extends graphic.Sector {
         for (let i = 0; i < SPECIAL_STATES.length; i++) {
             const stateName = SPECIAL_STATES[i];
             const stateRotate = labelStateModels[stateName].getShallow('rotate');
-            if (stateRotate != null) {
-                label.ensureState(stateName).rotation = getLabelRotation(stateRotate, midAngle, dx);
-            }
+            label.ensureState(stateName).rotation = stateRotate == null
+                ? labelRotate
+                : getLabelRotation(stateRotate, midAngle, dx);
         }
 
         label.attr({

--- a/src/chart/chord/ChordPiece.ts
+++ b/src/chart/chord/ChordPiece.ts
@@ -28,12 +28,20 @@ import { getLabelStatesModels, setLabelStyle } from '../../label/labelStyle';
 import type { BuiltinTextPosition } from 'zrender/src/core/types';
 import { setStatesStylesFromModel, SPECIAL_STATES, toggleHoverEmphasis } from '../../util/states';
 import { getECData } from '../../util/innerStore';
+import { normalizeRadian } from 'zrender/src/contain/util';
+import { isRadianAroundZero } from '../../util/number';
 
 const RADIAN = Math.PI / 180;
+const LABEL_FLIP_START_ANGLE = Math.PI * 0.5;
+const LABEL_FLIP_END_ANGLE = Math.PI * 1.5;
 
-function getLabelRotation(rotate: number | 'radial', midAngle: number, dx: number): number {
+function getLabelRotation(rotate: number | 'radial', midAngle: number): number {
     if (rotate === 'radial') {
-        return dx < 0 ? -midAngle + Math.PI : -midAngle;
+        const midAngleNormal = normalizeRadian(midAngle);
+        const needsFlip = midAngleNormal > LABEL_FLIP_START_ANGLE
+            && !isRadianAroundZero(midAngleNormal - LABEL_FLIP_START_ANGLE)
+            && midAngleNormal < LABEL_FLIP_END_ANGLE;
+        return normalizeRadian(-midAngle + (needsFlip ? Math.PI : 0));
     }
     return isNumber(rotate) ? rotate * RADIAN : 0;
 }
@@ -183,14 +191,14 @@ export default class ChordPiece extends graphic.Sector {
             ? normalLabelModel.get('verticalAlign') || 'middle'
             : (dy > 0 ? 'top' : 'bottom');
 
-        const labelRotate = getLabelRotation(normalLabelModel.get('rotate'), midAngle, dx);
+        const labelRotate = getLabelRotation(normalLabelModel.get('rotate'), midAngle);
 
         for (let i = 0; i < SPECIAL_STATES.length; i++) {
             const stateName = SPECIAL_STATES[i];
             const stateRotate = labelStateModels[stateName].getShallow('rotate');
             const state = label.ensureState(stateName);
             state.rotation = stateRotate != null
-                ? getLabelRotation(stateRotate, midAngle, dx)
+                ? getLabelRotation(stateRotate, midAngle)
                 : null;
         }
 

--- a/src/chart/chord/ChordSeries.ts
+++ b/src/chart/chord/ChordSeries.ts
@@ -152,21 +152,21 @@ export interface ChordSeriesOption
     emphasis?: {
         focus?: Exclude<ChordNodeItemOption['emphasis'], undefined>['focus']
         scale?: boolean | number
-        label?: SeriesLabelOption
+        label?: ChordNodeLabelOption
         edgeLabel?: SeriesLabelOption
         itemStyle?: ItemStyleOption
         lineStyle?: LineStyleOption
     }
 
     blur?: {
-        label?: SeriesLabelOption
+        label?: ChordNodeLabelOption
         edgeLabel?: SeriesLabelOption
         itemStyle?: ItemStyleOption
         lineStyle?: LineStyleOption
     }
 
     select?: {
-        label?: SeriesLabelOption
+        label?: ChordNodeLabelOption
         edgeLabel?: SeriesLabelOption
         itemStyle?: ItemStyleOption
         lineStyle?: LineStyleOption

--- a/src/chart/chord/ChordSeries.ts
+++ b/src/chart/chord/ChordSeries.ts
@@ -97,9 +97,10 @@ export interface ChordEdgeLineStyleOption extends LineStyleOption {
     curveness?: number
 }
 
-export interface ChordNodeLabelOption extends Omit<SeriesLabelOption<CallbackDataParams>, 'position'> {
+export interface ChordNodeLabelOption extends Omit<SeriesLabelOption<CallbackDataParams>, 'position' | 'rotate'> {
     silent?: boolean
     position?: SeriesLabelOption['position'] | 'outside'
+    rotate?: number | 'radial'
 }
 
 export interface ChordEdgeStateOption {

--- a/test/chord-label-rotate.html
+++ b/test/chord-label-rotate.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+    <div id="main-radial"></div>
+    <div id="main-state"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            function createChordOption(labelOption, stateOptions) {
+                return {
+                    animation: false,
+                    series: {
+                        type: 'chord',
+                        startAngle: 0,
+                        padAngle: 0,
+                        label: labelOption,
+                        emphasis: stateOptions && stateOptions.emphasis,
+                        blur: stateOptions && stateOptions.blur,
+                        select: stateOptions && stateOptions.select,
+                        data: [
+                            {name: 'Alpha'},
+                            {name: 'Beta'}
+                        ],
+                        edges: [{
+                            source: 'Alpha',
+                            target: 'Beta',
+                            value: 1
+                        }]
+                    }
+                };
+            }
+
+            function getNodeLabel(chart, dataIndex) {
+                var seriesModel = chart.getModel().getSeriesByType('chord')[0];
+                return seriesModel.getData().getItemGraphicEl(dataIndex).getTextContent();
+            }
+
+            function getExpectedRadialRotation(chart, dataIndex) {
+                var seriesModel = chart.getModel().getSeriesByType('chord')[0];
+                var data = seriesModel.getData();
+                var layout = data.getItemLayout(dataIndex);
+                var midAngle = (layout.startAngle + layout.endAngle) / 2;
+                return Math.cos(midAngle) < 0 ? -midAngle + Math.PI : -midAngle;
+            }
+
+            function nearlyEqual(actual, expected) {
+                return Math.abs(actual - expected) < 1e-8;
+            }
+
+            var radialChart = testHelper.create(echarts, 'main-radial', {
+                title: [
+                    'Chord node labels support **rotate: radial**',
+                    'Labels should follow the node angle and remain readable.'
+                ],
+                height: 360,
+                option: createChordOption({
+                    show: true,
+                    rotate: 'radial'
+                })
+            });
+
+            var stateChart = testHelper.create(echarts, 'main-state', {
+                title: [
+                    'Chord node labels keep numeric and state rotations',
+                    'Normal label is 45 degrees; emphasis label is radial.'
+                ],
+                height: 360,
+                option: createChordOption({
+                    show: true,
+                    rotate: 45
+                }, {
+                    emphasis: {
+                        label: {
+                            rotate: 'radial'
+                        }
+                    },
+                    blur: {
+                        label: {
+                            rotate: 30
+                        }
+                    },
+                    select: {
+                        label: {
+                            rotate: 60
+                        }
+                    }
+                })
+            });
+
+            setTimeout(function () {
+                testHelper.printAssert(radialChart, function (assert) {
+                    var label = getNodeLabel(radialChart, 0);
+                    assert(nearlyEqual(label.rotation, getExpectedRadialRotation(radialChart, 0)));
+                });
+
+                testHelper.printAssert(stateChart, function (assert) {
+                    var label = getNodeLabel(stateChart, 0);
+                    assert(nearlyEqual(label.rotation, Math.PI / 4));
+                    assert(nearlyEqual(label.states.emphasis.rotation, getExpectedRadialRotation(stateChart, 0)));
+                    assert(nearlyEqual(label.states.blur.rotation, Math.PI / 6));
+                    assert(nearlyEqual(label.states.select.rotation, Math.PI / 3));
+                });
+            }, 0);
+        });
+    </script>
+</body>
+</html>

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -91,4 +91,54 @@ describe('series/chord', function () {
         expect(textContent.rotation).toBeCloseTo(Math.PI / 4);
     });
 
+    it('applies state label rotation', function () {
+        chart.setOption({
+            series: {
+                type: 'chord',
+                startAngle: 0,
+                padAngle: 0,
+                label: {
+                    show: true,
+                    rotate: 0
+                },
+                emphasis: {
+                    label: {
+                        rotate: 'radial'
+                    }
+                },
+                blur: {
+                    label: {
+                        rotate: 30
+                    }
+                },
+                select: {
+                    label: {
+                        rotate: 45
+                    }
+                },
+                data: [
+                    {name: 'a'},
+                    {name: 'b'}
+                ],
+                edges: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 1
+                }]
+            }
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        const data = seriesModel.getData();
+        const textContent = data.getItemGraphicEl(0).getTextContent();
+        const layout = data.getItemLayout(0);
+        const midAngle = (layout.startAngle + layout.endAngle) / 2;
+        const expectedRotation = Math.cos(midAngle) < 0 ? -midAngle + Math.PI : -midAngle;
+
+        expect(textContent.rotation).toBeCloseTo(0);
+        expect(textContent.states.emphasis.rotation).toBeCloseTo(expectedRotation);
+        expect(textContent.states.blur.rotation).toBeCloseTo(Math.PI / 6);
+        expect(textContent.states.select.rotation).toBeCloseTo(Math.PI / 4);
+    });
+
 });

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -1,0 +1,68 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import ChordSeriesModel from '@/src/chart/chord/ChordSeries';
+import { createChart, getECModel } from '../../core/utHelper';
+
+describe('series/chord', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('supports radial label rotation', function () {
+        chart.setOption({
+            series: {
+                type: 'chord',
+                startAngle: 0,
+                padAngle: 0,
+                label: {
+                    show: true,
+                    rotate: 'radial'
+                },
+                data: [
+                    {name: 'a'},
+                    {name: 'b'}
+                ],
+                edges: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 1
+                }]
+            }
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        const data = seriesModel.getData();
+        const textContent = data.getItemGraphicEl(0).getTextContent();
+        const layout = data.getItemLayout(0);
+        const midAngle = (layout.startAngle + layout.endAngle) / 2;
+        const expectedRotation = Math.cos(midAngle) < 0 ? -midAngle + Math.PI : -midAngle;
+
+        expect(textContent.rotation).toBeCloseTo(expectedRotation);
+    });
+
+});

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -189,7 +189,10 @@ describe('series/chord', function () {
 
         expect(textContent).toBe(oldTextContent);
         expect(textContent.rotation).toBeCloseTo(0);
-        expect(textContent.states.emphasis.rotation).toBeCloseTo(0);
+        expect(textContent.states.emphasis.rotation).toBeNull();
+
+        textContent.useState('emphasis', false, true);
+        expect(textContent.rotation).toBeCloseTo(0);
     });
 
 });

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -141,4 +141,55 @@ describe('series/chord', function () {
         expect(textContent.states.select.rotation).toBeCloseTo(Math.PI / 4);
     });
 
+    it('clears stale state label rotation on option update', function () {
+        const option = {
+            series: {
+                type: 'chord',
+                label: {
+                    show: true,
+                    rotate: 0
+                },
+                emphasis: {
+                    label: {
+                        rotate: 45
+                    }
+                },
+                data: [
+                    {name: 'a'},
+                    {name: 'b'}
+                ],
+                edges: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 1
+                }]
+            }
+        };
+        chart.setOption(option);
+
+        let seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        let textContent = seriesModel.getData().getItemGraphicEl(0).getTextContent();
+        const oldTextContent = textContent;
+
+        expect(textContent.states.emphasis.rotation).toBeCloseTo(Math.PI / 4);
+
+        chart.setOption({
+            series: {
+                ...option.series,
+                emphasis: {
+                    label: {
+                        rotate: null
+                    }
+                }
+            }
+        });
+
+        seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        textContent = seriesModel.getData().getItemGraphicEl(0).getTextContent();
+
+        expect(textContent).toBe(oldTextContent);
+        expect(textContent.rotation).toBeCloseTo(0);
+        expect(textContent.states.emphasis.rotation).toBeCloseTo(0);
+    });
+
 });

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -65,4 +65,30 @@ describe('series/chord', function () {
         expect(textContent.rotation).toBeCloseTo(expectedRotation);
     });
 
+    it('converts numeric label rotation from degrees to radians', function () {
+        chart.setOption({
+            series: {
+                type: 'chord',
+                label: {
+                    show: true,
+                    rotate: 45
+                },
+                data: [
+                    {name: 'a'},
+                    {name: 'b'}
+                ],
+                edges: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 1
+                }]
+            }
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        const textContent = seriesModel.getData().getItemGraphicEl(0).getTextContent();
+
+        expect(textContent.rotation).toBeCloseTo(Math.PI / 4);
+    });
+
 });

--- a/test/ut/spec/series/chord.test.ts
+++ b/test/ut/spec/series/chord.test.ts
@@ -21,6 +21,28 @@ import { EChartsType } from '@/src/echarts';
 import ChordSeriesModel from '@/src/chart/chord/ChordSeries';
 import { createChart, getECModel } from '../../core/utHelper';
 
+const PI2 = Math.PI * 2;
+const LABEL_FLIP_START_ANGLE = Math.PI * 0.5;
+const LABEL_FLIP_END_ANGLE = Math.PI * 1.5;
+const RADIAN_EPSILON = 1e-4;
+
+function normalizeRadian(radian: number): number {
+    return (radian % PI2 + PI2) % PI2;
+}
+
+function isRadianAroundZero(radian: number): boolean {
+    return radian > -RADIAN_EPSILON && radian < RADIAN_EPSILON;
+}
+
+function getExpectedRadialLabelRotation(layout: {startAngle: number, endAngle: number}): number {
+    const midAngle = (layout.startAngle + layout.endAngle) / 2;
+    const midAngleNormal = normalizeRadian(midAngle);
+    const needsFlip = midAngleNormal > LABEL_FLIP_START_ANGLE
+        && !isRadianAroundZero(midAngleNormal - LABEL_FLIP_START_ANGLE)
+        && midAngleNormal < LABEL_FLIP_END_ANGLE;
+    return normalizeRadian(-midAngle + (needsFlip ? Math.PI : 0));
+}
+
 describe('series/chord', function () {
 
     let chart: EChartsType;
@@ -59,10 +81,39 @@ describe('series/chord', function () {
         const data = seriesModel.getData();
         const textContent = data.getItemGraphicEl(0).getTextContent();
         const layout = data.getItemLayout(0);
-        const midAngle = (layout.startAngle + layout.endAngle) / 2;
-        const expectedRotation = Math.cos(midAngle) < 0 ? -midAngle + Math.PI : -midAngle;
 
-        expect(textContent.rotation).toBeCloseTo(expectedRotation);
+        expect(textContent.rotation).toBeCloseTo(getExpectedRadialLabelRotation(layout));
+    });
+
+    it('handles radial label rotation on startAngle boundary', function () {
+        chart.setOption({
+            series: {
+                type: 'chord',
+                startAngle: 180,
+                padAngle: 0,
+                label: {
+                    show: true,
+                    rotate: 'radial'
+                },
+                data: [
+                    {name: 'a'},
+                    {name: 'b'}
+                ],
+                edges: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 1
+                }]
+            }
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByType('chord')[0] as ChordSeriesModel;
+        const data = seriesModel.getData();
+        const textContent = data.getItemGraphicEl(0).getTextContent();
+        const layout = data.getItemLayout(0);
+
+        expect((layout.startAngle + layout.endAngle) / 2).toBeCloseTo(Math.PI * 1.5);
+        expect(textContent.rotation).toBeCloseTo(Math.PI * 0.5);
     });
 
     it('converts numeric label rotation from degrees to radians', function () {
@@ -132,11 +183,9 @@ describe('series/chord', function () {
         const data = seriesModel.getData();
         const textContent = data.getItemGraphicEl(0).getTextContent();
         const layout = data.getItemLayout(0);
-        const midAngle = (layout.startAngle + layout.endAngle) / 2;
-        const expectedRotation = Math.cos(midAngle) < 0 ? -midAngle + Math.PI : -midAngle;
 
         expect(textContent.rotation).toBeCloseTo(0);
-        expect(textContent.states.emphasis.rotation).toBeCloseTo(expectedRotation);
+        expect(textContent.states.emphasis.rotation).toBeCloseTo(getExpectedRadialLabelRotation(layout));
         expect(textContent.states.blur.rotation).toBeCloseTo(Math.PI / 6);
         expect(textContent.states.select.rotation).toBeCloseTo(Math.PI / 4);
     });


### PR DESCRIPTION
## Summary

- Add `label.rotate: 'radial'` support for chord node labels.
- Keep numeric chord `label.rotate` working by applying degree-to-radian conversion in the chord label layout path.
- Add a regression test that verifies rendered chord node text receives the expected radial rotation.

Fixes #21199.

## Validation

- `npx jest --config test/ut/jest.config.cjs --runTestsByPath test/ut/spec/series/chord.test.ts --coverage=false`
- `npm test -- --runInBand --coverage=false`
- `npm run checktype`
- `npm run lint -- --no-cache src/chart/chord/ChordPiece.ts src/chart/chord/ChordSeries.ts`
- `npx eslint --no-cache test/ut/spec/series/chord.test.ts`
- `npx tsc -p test/ut/tsconfig.json --noEmit --moduleResolution node --skipLibCheck`

## Note

`npm run checkheader` currently fails on pre-existing files outside this change (`test/ut/coverage/*`, `test/line-area-empty-dimension-name.html`, and `test/visualmap-seriesTargets.html`). The files changed in this PR have license headers.

## ScreenShot
<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/0db00812-4319-432c-97dd-4592239a25b2" />
