### PR TITLE
fix(sunburst): center drilled root labels

### DIFF
--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -220,6 +220,8 @@ class SunburstPiece extends graphic.Sector {
             const flipStartAngle = Math.PI * 0.5;
             const flipEndAngle = Math.PI * 1.5;
             const midAngleNormal = normalizeRadian(rotateType === 'tangential' ? Math.PI / 2 - midAngle : midAngle);
+            const isFullCircle = isRadianAroundZero(Math.abs(angle) - 2 * Math.PI);
+            let isLabelAtCenter = false;
 
             // For text that is up-side down, rotate 180 degrees to make sure
             // it's readable
@@ -233,9 +235,10 @@ class SunburstPiece extends graphic.Sector {
             }
             else {
                 if (!textAlign || textAlign === 'center') {
-                    // Put label in the center if it's a circle
-                    if (layout.r0 === 0 && isRadianAroundZero(angle - 2 * Math.PI)) {
+                    // Put label in the center if it's a full circle.
+                    if (isFullCircle) {
                         r = 0;
+                        isLabelAtCenter = true;
                     }
                     else {
                         r = (layout.r + layout.r0) / 2;
@@ -259,7 +262,10 @@ class SunburstPiece extends graphic.Sector {
             state.y = r * dy + layout.cy;
 
             let rotate = 0;
-            if (rotateType === 'radial') {
+            if (isLabelAtCenter) {
+                rotate = 0;
+            }
+            else if (rotateType === 'radial') {
                 rotate = normalizeRadian(-midAngle)
                     + (needsFlip ? Math.PI : 0);
             }

--- a/src/chart/sunburst/SunburstPiece.ts
+++ b/src/chart/sunburst/SunburstPiece.ts
@@ -168,6 +168,7 @@ class SunburstPiece extends graphic.Sector {
 
         const layout = this.node.getLayout();
         const angle = layout.endAngle - layout.startAngle;
+        const isViewRoot = this.node === seriesModel.getViewRoot();
 
         const midAngle = (layout.startAngle + layout.endAngle) / 2;
         const dx = Math.cos(midAngle);
@@ -235,8 +236,8 @@ class SunburstPiece extends graphic.Sector {
             }
             else {
                 if (!textAlign || textAlign === 'center') {
-                    // Put label in the center if it's a full circle.
-                    if (isFullCircle) {
+                    // Put root/view-root labels in the center if it's a full circle.
+                    if (isFullCircle && (layout.r0 === 0 || isViewRoot)) {
                         r = 0;
                         isLabelAtCenter = true;
                     }

--- a/test/sunburst-drilldown-root-label.html
+++ b/test/sunburst-drilldown-root-label.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+<body>
+    <div id="main"></div>
+    <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                animation: false,
+                series: {
+                    type: 'sunburst',
+                    radius: [0, '80%'],
+                    label: {
+                        show: true,
+                        align: 'center'
+                    },
+                    data: [
+                        {
+                            name: 'South China',
+                            children: [
+                                {name: 'Guangdong', value: 2},
+                                {name: 'Guangxi', value: 1}
+                            ]
+                        },
+                        {
+                            name: 'North China',
+                            children: [
+                                {name: 'Beijing', value: 2},
+                                {name: 'Tianjin', value: 1}
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            var chart = testHelper.create(echarts, 'main', {
+                title: [
+                    'Drilled sunburst root label should stay **centered**',
+                    'After drilling into South China, its full annular sector label should be at chart center.'
+                ],
+                height: 420,
+                option: option,
+                buttons: [{
+                    text: 'Drill to South China',
+                    onclick: drillToSouthChina
+                }]
+            });
+
+            setTimeout(function () {
+                drillToSouthChina();
+                testHelper.printAssert(chart, function (assert) {
+                    var seriesModel = chart.getModel().getSeriesByType('sunburst')[0];
+                    var viewRoot = seriesModel.getViewRoot();
+                    var layout = viewRoot.getLayout();
+                    var label = seriesModel.getData().getItemGraphicEl(viewRoot.dataIndex).getTextContent();
+
+                    assert(viewRoot.name === 'South China');
+                    assert(layout.r0 > 0);
+                    assert(Math.abs(Math.abs(layout.endAngle - layout.startAngle) - Math.PI * 2) < 1e-8);
+                    assert(Math.abs(label.x - layout.cx) < 1e-8);
+                    assert(Math.abs(label.y - layout.cy) < 1e-8);
+                    assert(Math.abs(label.rotation) < 1e-8);
+                });
+            }, 0);
+
+            function drillToSouthChina() {
+                var seriesModel = chart.getModel().getSeriesByType('sunburst')[0];
+                var targetNode = findNodeByName(seriesModel, 'South China');
+
+                chart.dispatchAction({
+                    type: 'sunburstRootToNode',
+                    targetNode: targetNode
+                });
+            }
+
+            function findNodeByName(seriesModel, name) {
+                var targetNode;
+                seriesModel.getData().tree.root.eachNode(function (node) {
+                    if (node.name === name) {
+                        targetNode = node;
+                    }
+                });
+                return targetNode;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/test/ut/spec/series/sunburst.test.ts
+++ b/test/ut/spec/series/sunburst.test.ts
@@ -1,0 +1,102 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import SunburstSeriesModel from '@/src/chart/sunburst/SunburstSeries';
+import { TreeNode } from '@/src/data/Tree';
+import { createChart, getECModel } from '../../core/utHelper';
+
+function findNodeByName(seriesModel: SunburstSeriesModel, name: string): TreeNode {
+    let targetNode: TreeNode;
+
+    seriesModel.getData().tree.root.eachNode(node => {
+        if (node.name === name) {
+            targetNode = node;
+        }
+    });
+
+    return targetNode;
+}
+
+describe('series/sunburst', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({
+            width: 400,
+            height: 400
+        });
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('centers label when rootToNode makes an annular sector full circle', function () {
+        chart.setOption({
+            animation: false,
+            series: {
+                type: 'sunburst',
+                radius: [0, '80%'],
+                label: {
+                    show: true,
+                    align: 'center'
+                },
+                data: [
+                    {
+                        name: '华南',
+                        children: [
+                            {name: '广东', value: 2},
+                            {name: '广西', value: 1}
+                        ]
+                    },
+                    {
+                        name: '华北',
+                        children: [
+                            {name: '北京', value: 2},
+                            {name: '天津', value: 1}
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let seriesModel = getECModel(chart).getSeriesByType('sunburst')[0] as SunburstSeriesModel;
+        const targetNode = findNodeByName(seriesModel, '华南');
+
+        chart.dispatchAction({
+            type: 'sunburstRootToNode',
+            targetNode: targetNode
+        });
+
+        seriesModel = getECModel(chart).getSeriesByType('sunburst')[0] as SunburstSeriesModel;
+        const viewRoot = seriesModel.getViewRoot();
+        const layout = viewRoot.getLayout();
+        const label = seriesModel.getData().getItemGraphicEl(viewRoot.dataIndex).getTextContent();
+
+        expect(viewRoot.name).toBe('华南');
+        expect(layout.r0).toBeGreaterThan(0);
+        expect(Math.abs(layout.endAngle - layout.startAngle)).toBeCloseTo(Math.PI * 2);
+        expect(label.x).toBeCloseTo(layout.cx);
+        expect(label.y).toBeCloseTo(layout.cy);
+        expect(label.rotation).toBeCloseTo(0);
+    });
+
+});

--- a/test/ut/spec/series/sunburst.test.ts
+++ b/test/ut/spec/series/sunburst.test.ts
@@ -23,13 +23,17 @@ import { TreeNode } from '@/src/data/Tree';
 import { createChart, getECModel } from '../../core/utHelper';
 
 function findNodeByName(seriesModel: SunburstSeriesModel, name: string): TreeNode {
-    let targetNode: TreeNode;
+    let targetNode: TreeNode | undefined;
 
     seriesModel.getData().tree.root.eachNode(node => {
         if (node.name === name) {
             targetNode = node;
         }
     });
+
+    if (!targetNode) {
+        throw new Error(`Node "${name}" not found.`);
+    }
 
     return targetNode;
 }
@@ -97,6 +101,44 @@ describe('series/sunburst', function () {
         expect(label.x).toBeCloseTo(layout.cx);
         expect(label.y).toBeCloseTo(layout.cy);
         expect(label.rotation).toBeCloseTo(0);
+    });
+
+    it('keeps non-view-root annular full-circle labels in their ring', function () {
+        chart.setOption({
+            animation: false,
+            series: {
+                type: 'sunburst',
+                radius: [0, '80%'],
+                label: {
+                    show: true,
+                    align: 'center'
+                },
+                data: [
+                    {
+                        name: 'root-sector',
+                        children: [
+                            {
+                                name: 'annular-child',
+                                value: 1
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        const seriesModel = getECModel(chart).getSeriesByType('sunburst')[0] as SunburstSeriesModel;
+        const childNode = findNodeByName(seriesModel, 'annular-child');
+        const layout = childNode.getLayout();
+        const label = seriesModel.getData().getItemGraphicEl(childNode.dataIndex).getTextContent();
+        const labelDistance = Math.sqrt(
+            Math.pow(label.x - layout.cx, 2) + Math.pow(label.y - layout.cy, 2)
+        );
+
+        expect(childNode).not.toBe(seriesModel.getViewRoot());
+        expect(layout.r0).toBeGreaterThan(0);
+        expect(Math.abs(layout.endAngle - layout.startAngle)).toBeCloseTo(Math.PI * 2);
+        expect(labelDistance).toBeCloseTo((layout.r + layout.r0) / 2);
     });
 
 });


### PR DESCRIPTION
## Summary

Fixes #21133.

When sunburstRootToNode drills into a node, that node can become a full 360-degree annular sector. Its label represents the centered view root rather than an angular slice, so the label should be placed at the chart center and should not inherit radial/tangential rotation.

This PR updates the sunburst label layout for full-circle centered labels and adds a Jest regression test covering both center position and zero rotation.

## Root Cause

SunburstPiece only centered labels for full circles when r0 === 0. After drilldown, the view root is a full annular sector with r0 > 0, so the label was placed at the annulus midpoint and still received radial rotation.

## Verification

- git diff --check
- eslint src/chart/sunburst/SunburstPiece.ts test/ut/spec/series/sunburst.test.ts
- tsc --noEmit
- jest --config test/ut/jest.config.cjs --coverage=false --runInBand test/ut/spec/series


## Screenshot
<img width="1000" height="760" alt="image" src="https://github.com/user-attachments/assets/d564ba40-8f98-4efa-b1cd-e8f889227ef3" />
