### PR TITLE
fix(radar): pass indicator index to tooltip valueFormatter

### DIFF
--- a/src/chart/radar/RadarSeries.ts
+++ b/src/chart/radar/RadarSeries.ts
@@ -115,13 +115,14 @@ class RadarSeriesModel extends SeriesModel<RadarSeriesOption> {
         return createTooltipMarkup('section', {
             header: nameToDisplay,
             sortBlocks: true,
-            blocks: zrUtil.map(indicatorAxes, axis => {
+            blocks: zrUtil.map(indicatorAxes, (axis, indicatorIndex) => {
                 const val = data.get(data.mapDimension(axis.dim), dataIndex);
                 return createTooltipMarkup('nameValue', {
                     markerType: 'subItem',
                     markerColor: markerColor,
                     name: axis.name,
                     value: val,
+                    dataIndex: indicatorIndex,
                     sortParam: val
                 });
             })

--- a/test/tooltip-valueFormatter.html
+++ b/test/tooltip-valueFormatter.html
@@ -41,6 +41,7 @@ under the License.
         <div id="main1"></div>
         <div id="main2"></div>
         <div id="main3"></div>
+        <div id="main4"></div>
 
 
 
@@ -305,6 +306,52 @@ under the License.
                 });
             </script>
 
+            <script>
+                require(['echarts'], function (echarts) {
+                    var option = {
+                        animation: false,
+                        tooltip: {
+                            trigger: 'item',
+                            position: 'top',
+                            valueFormatter: function (value, dataIndex) {
+                                return value + ' (indicatorIndex: ' + dataIndex + ')';
+                            }
+                        },
+                        radar: {
+                            indicator: [
+                                { name: 'Sales', max: 100 },
+                                { name: 'Administration', max: 100 },
+                                { name: 'Technology', max: 100 }
+                            ]
+                        },
+                        series: [
+                            {
+                                type: 'radar',
+                                data: [
+                                    {
+                                        name: 'Allocated Budget',
+                                        value: [60, 12, 80]
+                                    }
+                                ]
+                            }
+                        ]
+                    };
+
+                    var chart = testHelper.create(echarts, 'main4', {
+                        title: [
+                            'Radar valueFormatter should receive indicator index',
+                            'Expected: indicatorIndex 0, 1, 2'
+                        ],
+                        option: option
+                    });
+
+                    chart.dispatchAction({
+                        type: 'showTip',
+                        dataIndex: 0,
+                        seriesIndex: 0
+                    });
+                });
+            </script>
+
     </body>
 </html>
-

--- a/test/ut/spec/component/tooltip/tooltip.test.ts
+++ b/test/ut/spec/component/tooltip/tooltip.test.ts
@@ -1,0 +1,77 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '../../../../../src/echarts';
+import { createChart, getECModel } from '../../../core/utHelper';
+import {
+    buildTooltipMarkup,
+    TooltipMarkupStyleCreator
+} from '../../../../../src/component/tooltip/tooltipMarkup';
+
+describe('component/tooltip', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should pass radar indicator index to tooltip valueFormatter', function () {
+        chart.setOption({
+            animation: false,
+            radar: {
+                indicator: [
+                    { name: 'Sales', max: 100 },
+                    { name: 'Administration', max: 100 },
+                    { name: 'Technology', max: 100 }
+                ]
+            },
+            series: [{
+                type: 'radar',
+                data: [{
+                    value: [60, 12, 0.8],
+                    name: 'Allocated Budget'
+                }]
+            }]
+        });
+
+        const formatterDataIndexes: number[] = [];
+        const seriesModel = getECModel(chart).getSeriesByIndex(0);
+        const tooltipMarkup = seriesModel.formatTooltip(0, false, null) as any;
+        tooltipMarkup.valueFormatter = function (value: unknown, dataIndex: number): string {
+            formatterDataIndexes.push(dataIndex);
+            return value + '';
+        };
+
+        buildTooltipMarkup(
+            tooltipMarkup,
+            new TooltipMarkupStyleCreator(),
+            'html',
+            null,
+            false,
+            {} as any
+        );
+
+        expect(formatterDataIndexes).toEqual([0, 1, 2]);
+    });
+});


### PR DESCRIPTION
## Summary

- Pass radar indicator indexes through tooltip markup fragments so `tooltip.valueFormatter(value, dataIndex)` receives the indicator index for radar values.
- Add a unit regression for the tooltip markup callback path.
- Add a manual HTML case to `test/tooltip-valueFormatter.html`.

## Root Cause

Radar builds one tooltip `nameValue` block per indicator, but those blocks did not carry their indicator position. The common tooltip markup layer already forwards `fragment.dataIndex` to `valueFormatter`, so radar value formatters received `undefined`.

## Related

Fixes #20109

## Testing

- `npx jest --config test/ut/jest.config.cjs --coverage=false test/ut/spec/component/tooltip/tooltip.test.ts`
- `npm run checktype`
- `npm run lint`
- Screenshot/manual verification of radar tooltip values showing `idx:0`, `idx:1`, and `idx:2`

<img width="1800" height="1240" alt="image" src="https://github.com/user-attachments/assets/61f419ea-484e-4896-a14d-f9a5e0b617cd" />

