### PR TITLE
fix(dataZoom): keep toolbox zoom from dropping stacked areas

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -27,7 +27,7 @@ import { Dictionary } from '../../util/types';
 // TODO Polar?
 import DataZoomModel from './DataZoomModel';
 import { AxisBaseModel } from '../../coord/AxisBaseModel';
-import { unionAxisExtentFromData } from '../../coord/axisHelper';
+import { getDataDimensionsOnAxis, unionAxisExtentFromData } from '../../coord/axisHelper';
 import { ensureScaleRawExtentInfo } from '../../coord/scaleRawExtentInfo';
 import { getAxisMainType, isCoordSupported, DataZoomAxisDimension } from './helper';
 import { SINGLE_REFERRING } from '../../util/model';
@@ -297,7 +297,9 @@ class AxisProxy {
 
         each(seriesModels, function (seriesModel) {
             let seriesData = seriesModel.getData();
-            const dataDims = seriesData.mapDimensionsAll(axisDim);
+            // Use the same dimensions as axis extent calculation. Stacked series
+            // are rendered by their stack result dimension, not the original value dimension.
+            const dataDims = getDataDimensionsOnAxis(seriesData, axisDim);
 
             if (!dataDims.length) {
                 return;

--- a/test/toolbox-dataZoom-stack-area.html
+++ b/test/toolbox-dataZoom-stack-area.html
@@ -1,0 +1,137 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body {
+                margin: 0;
+                width: 100%;
+                height: 100%;
+            }
+            #main {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+        <div id="main"></div>
+        <script>
+            require(['echarts'], function (echarts) {
+                var lower = [0.202, 0.198, 0.194, 0.190, 0.186, 0.181, 0.178, 0.173];
+                var band = [0.045, 0.043, 0.041, 0.039, 0.036, 0.035, 0.036, 0.034];
+                var upper = lower.map(function (value, index) {
+                    return +(value + band[index]).toFixed(3);
+                });
+                var middle = lower.map(function (value, index) {
+                    return +(value + band[index] / 2).toFixed(3);
+                });
+
+                var chart = echarts.init(document.getElementById('main'));
+                chart.setOption({
+                    animation: false,
+                    color: ['#8ebdff', '#5b9cff', '#8ebdff'],
+                    toolbox: {
+                        right: 20,
+                        feature: {
+                            dataZoom: {}
+                        }
+                    },
+                    grid: {
+                        left: 70,
+                        right: 60,
+                        top: 40,
+                        bottom: 55
+                    },
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: ['17', '04:00', '08:00', '12:00', '16:00', '20:00', '00:00', '04:00']
+                    },
+                    yAxis: {
+                        scale: true,
+                        splitLine: {
+                            lineStyle: {
+                                color: '#d8e1f2'
+                            }
+                        }
+                    },
+                    series: [{
+                        name: 'lower',
+                        type: 'line',
+                        symbol: 'none',
+                        data: lower,
+                        lineStyle: {
+                            type: 'dashed',
+                            width: 2,
+                            color: '#8ebdff'
+                        }
+                    }, {
+                        name: 'band-base',
+                        type: 'line',
+                        stack: 'confidence-band',
+                        symbol: 'none',
+                        data: lower,
+                        lineStyle: {
+                            opacity: 0
+                        }
+                    }, {
+                        name: 'band',
+                        type: 'line',
+                        stack: 'confidence-band',
+                        symbol: 'none',
+                        data: band,
+                        areaStyle: {
+                            color: 'rgba(91, 156, 255, 0.35)'
+                        },
+                        lineStyle: {
+                            opacity: 0
+                        }
+                    }, {
+                        name: 'middle',
+                        type: 'line',
+                        symbol: 'none',
+                        data: middle,
+                        lineStyle: {
+                            width: 2,
+                            color: '#5b9cff'
+                        }
+                    }, {
+                        name: 'upper',
+                        type: 'line',
+                        symbol: 'none',
+                        data: upper,
+                        lineStyle: {
+                            type: 'dashed',
+                            width: 2,
+                            color: '#8ebdff'
+                        }
+                    }]
+                });
+                window.__ECHARTS_21111_CHART__ = chart;
+                window.__EC_TEST_READY__ = true;
+            });
+        </script>
+    </body>
+</html>

--- a/test/ut/spec/component/dataZoom/AxisProxy.test.ts
+++ b/test/ut/spec/component/dataZoom/AxisProxy.test.ts
@@ -114,6 +114,8 @@ describe('dataZoom/AxisProxy', function () {
         expect(isNaN(data.get(stackResultDim, 0) as number)).toEqual(true);
         expect(data.get(stackResultDim, 1)).toEqual(102);
         expect(data.get(stackResultDim, 2)).toEqual(103);
+        expect(data.get('y', 1)).toEqual(2);
+        expect(data.get('y', 2)).toEqual(3);
     });
 
 });

--- a/test/ut/spec/component/dataZoom/AxisProxy.test.ts
+++ b/test/ut/spec/component/dataZoom/AxisProxy.test.ts
@@ -1,0 +1,68 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart, getECModel } from '../../../core/utHelper';
+import { EChartsType } from '../../../../../src/echarts';
+
+
+describe('dataZoom/AxisProxy', function () {
+
+    let chart: EChartsType;
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('keeps stacked line data when toolbox dataZoom injects value-axis filtering', function () {
+        chart.setOption({
+            toolbox: {
+                feature: {
+                    dataZoom: {}
+                }
+            },
+            xAxis: {
+                type: 'category',
+                boundaryGap: false,
+                data: ['Mon', 'Tue', 'Wed']
+            },
+            yAxis: {
+                scale: true
+            },
+            series: [{
+                type: 'line',
+                stack: 'total',
+                data: [100, 100, 100]
+            }, {
+                type: 'line',
+                stack: 'total',
+                areaStyle: {},
+                data: [1, 2, 3]
+            }]
+        });
+
+        const data = getECModel(chart).getSeriesByIndex(1).getData();
+        const stackResultDim = data.getCalculationInfo('stackResultDimension');
+        expect(data.count()).toEqual(3);
+        expect(data.get(stackResultDim, 0)).toEqual(101);
+    });
+
+});

--- a/test/ut/spec/component/dataZoom/AxisProxy.test.ts
+++ b/test/ut/spec/component/dataZoom/AxisProxy.test.ts
@@ -32,11 +32,13 @@ describe('dataZoom/AxisProxy', function () {
         chart.dispose();
     });
 
-    it('keeps stacked line data when toolbox dataZoom injects value-axis filtering', function () {
+    function setToolboxStackedLineOption(filterMode?: 'filter' | 'weakFilter' | 'empty') {
         chart.setOption({
             toolbox: {
                 feature: {
-                    dataZoom: {}
+                    dataZoom: filterMode
+                        ? {filterMode: filterMode}
+                        : {}
                 }
             },
             xAxis: {
@@ -58,11 +60,60 @@ describe('dataZoom/AxisProxy', function () {
                 data: [1, 2, 3]
             }]
         });
+    }
+
+    it('keeps stacked line data when toolbox dataZoom injects value-axis filtering', function () {
+        setToolboxStackedLineOption();
 
         const data = getECModel(chart).getSeriesByIndex(1).getData();
         const stackResultDim = data.getCalculationInfo('stackResultDimension');
         expect(data.count()).toEqual(3);
         expect(data.get(stackResultDim, 0)).toEqual(101);
+    });
+
+    it('keeps stacked line data when toolbox dataZoom uses weakFilter', function () {
+        setToolboxStackedLineOption('weakFilter');
+
+        const data = getECModel(chart).getSeriesByIndex(1).getData();
+        const stackResultDim = data.getCalculationInfo('stackResultDimension');
+        expect(data.count()).toEqual(3);
+        expect(data.get(stackResultDim, 0)).toEqual(101);
+    });
+
+    it('empties stacked line data by stack result dimension', function () {
+        chart.setOption({
+            xAxis: {
+                type: 'category',
+                boundaryGap: false,
+                data: ['Mon', 'Tue', 'Wed']
+            },
+            yAxis: {
+                scale: true
+            },
+            dataZoom: {
+                yAxisIndex: 0,
+                filterMode: 'empty',
+                startValue: 102,
+                endValue: 103
+            },
+            series: [{
+                type: 'line',
+                stack: 'total',
+                data: [100, 100, 100]
+            }, {
+                type: 'line',
+                stack: 'total',
+                areaStyle: {},
+                data: [1, 2, 3]
+            }]
+        });
+
+        const data = getECModel(chart).getSeriesByIndex(1).getData();
+        const stackResultDim = data.getCalculationInfo('stackResultDimension');
+        expect(data.count()).toEqual(3);
+        expect(isNaN(data.get(stackResultDim, 0) as number)).toEqual(true);
+        expect(data.get(stackResultDim, 1)).toEqual(102);
+        expect(data.get(stackResultDim, 2)).toEqual(103);
     });
 
 });


### PR DESCRIPTION
## Summary

Fixes #21111.

Toolbox `dataZoom` injects internal `dataZoom.select` components for the target axes. When a value axis uses `scale: true`, the generated dataZoom window is based on the axis extent, which already uses the stacked result dimension for stacked series. The filtering path still used the raw axis dimension, so stacked area data could be filtered away before rendering.

This changes `AxisProxy` filtering to reuse the same axis-dimension selection helper used by extent calculation, keeping stacked data filtered by its rendered stack result dimension.

## Changes

- Reuse `getDataDimensionsOnAxis` in dataZoom filtering.
- Add a focused unit regression for toolbox-injected dataZoom with a scaled y-axis and stacked line data.
- Add an HTML visual test for a toolbox dataZoom stacked confidence band.

## Validation

- `./node_modules/.bin/jest --config test/ut/jest.config.cjs --coverage=false test/ut/spec/component/dataZoom --runInBand`
- `npm run checktype`
- `./node_modules/.bin/eslint src/component/dataZoom/AxisProxy.ts test/ut/spec/component/dataZoom/AxisProxy.test.ts`
- `git diff --check -- src/component/dataZoom/AxisProxy.ts test/toolbox-dataZoom-stack-area.html test/ut/spec/component/dataZoom/AxisProxy.test.ts`
- Chrome headless screenshot of `test/toolbox-dataZoom-stack-area.html`

`npm run checkheader` still fails on pre-existing unrelated files missing headers; the new files are not listed in that failure.

<img width="1160" height="430" alt="image" src="https://github.com/user-attachments/assets/5b6a3d88-e113-4ae1-bce3-a006978db6c1" />
