### PR TITLE
[codex] Enable normalized stacked area charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Instructions
+
+This file applies to the entire repository.
+
+## Fix Completion Requirements
+
+- Every bug fix must include an HTML test case, usually under `test/`, that reproduces or verifies the fixed behavior.
+- Prefer updating an existing relevant HTML test when it clearly covers the scenario; otherwise add a focused new HTML test.
+- Every completed fix must include screenshot evidence from the HTML test case in the final report.
+- The screenshot should show the fixed state clearly enough for visual review. When the fix is interaction-dependent, capture the relevant interaction state after reproducing it.
+- If a screenshot or HTML test case cannot be produced, the final report must explain the blocker and the closest verification that was performed.
+
+## Verification
+
+- Run the smallest relevant automated checks for the changed area.
+- For visual or rendering fixes, open the HTML test case in a browser and capture a screenshot before claiming completion.
+
+## Generated Files
+
+- Do not manually modify files under `dist/`; they are generated automatically when publishing to npm.

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -114,6 +114,10 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption<CallbackD
     connectNulls?: boolean
 
     // Normalize stacked line values by the stack total.
+    // This only takes effect when all series in the same `stack` group
+    // are `series.line` and all of them have `stackNormalize: true`.
+    // Otherwise, the stack falls back to regular stacking, so enabling
+    // this on only one series in the stack has no effect.
     stackNormalize?: boolean
 
     showSymbol?: boolean

--- a/src/chart/line/LineSeries.ts
+++ b/src/chart/line/LineSeries.ts
@@ -113,6 +113,9 @@ export interface LineSeriesOption extends SeriesOption<LineStateOption<CallbackD
 
     connectNulls?: boolean
 
+    // Normalize stacked line values by the stack total.
+    stackNormalize?: boolean
+
     showSymbol?: boolean
     // false | 'auto': follow the label interval strategy.
     // true: show all symbols.

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-import {createHashMap, each} from 'zrender/src/core/util';
+import {createHashMap, each, HashMap} from 'zrender/src/core/util';
 import GlobalModel from '../model/Global';
 import SeriesModel from '../model/Series';
 import { SeriesOption, SeriesStackOptionMixin } from '../util/types';
@@ -41,6 +41,19 @@ type StackInfo = Pick<
     data: SeriesData
     seriesModel: SeriesModel<StackSeriesOption>
 };
+
+interface StackTotal {
+    all: number
+    positive: number
+    negative: number
+}
+
+type StackTotalMap = HashMap<StackTotal, string | number>;
+
+interface StackTotalMaps {
+    byIndex: StackTotalMap
+    byDimension: StackTotalMap
+}
 
 // (1) [Caution]: the logic is correct based on the premises:
 //     data processing stage is blocked in stream.
@@ -117,6 +130,8 @@ function shouldNormalizeStack(stackInfoList: StackInfo[]) {
 }
 
 function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
+    const stackTotalMaps = normalizeStack ? calculateStackTotalMaps(stackInfoList) : null;
+
     each(stackInfoList, function (targetStackInfo, idxInStack) {
         const resultVal: number[] = [];
         const resultNaN = [NaN, NaN];
@@ -129,7 +144,7 @@ function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
         // depending on legend selection.
         targetData.modify(dims, function (v0, v1, dataIndex) {
             let sum = normalizeStack
-                ? normalizeStackValue(stackInfoList, targetStackInfo, dataIndex, stackStrategy)
+                ? normalizeStackValue(stackTotalMaps!, targetStackInfo, dataIndex, stackStrategy)
                 : targetData.get(targetStackInfo.stackedDimension, dataIndex) as number;
 
             // Consider `connectNulls` of line area, if value is NaN, stackedOver
@@ -184,8 +199,56 @@ function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
     });
 }
 
+function calculateStackTotalMaps(stackInfoList: StackInfo[]) {
+    const stackTotalMaps: StackTotalMaps = {
+        byIndex: createHashMap<StackTotal, string | number>(),
+        byDimension: createHashMap<StackTotal, string | number>()
+    };
+
+    for (let i = 0; i < stackInfoList.length; i++) {
+        const stackInfo = stackInfoList[i];
+        const data = stackInfo.data;
+
+        for (let dataIndex = 0, len = data.count(); dataIndex < len; dataIndex++) {
+            const value = data.get(stackInfo.stackedDimension, dataIndex) as number;
+
+            if (isNaN(value)) {
+                continue;
+            }
+
+            addStackTotal(stackTotalMaps.byIndex, data.getRawIndex(dataIndex), value);
+
+            if (stackInfo.stackedByDimension) {
+                addStackTotal(
+                    stackTotalMaps.byDimension,
+                    data.get(stackInfo.stackedByDimension, dataIndex) as number,
+                    value
+                );
+            }
+        }
+    }
+
+    return stackTotalMaps;
+}
+
+function addStackTotal(stackTotalMap: StackTotalMap, key: string | number, value: number) {
+    const total = stackTotalMap.get(key) || stackTotalMap.set(key, {
+        all: 0,
+        positive: 0,
+        negative: 0
+    });
+
+    total.all = addSafe(total.all, value);
+    if (value > 0) {
+        total.positive = addSafe(total.positive, value);
+    }
+    else if (value < 0) {
+        total.negative = addSafe(total.negative, value);
+    }
+}
+
 function normalizeStackValue(
-    stackInfoList: StackInfo[],
+    stackTotalMaps: StackTotalMaps,
     targetStackInfo: StackInfo,
     dataIndex: number,
     stackStrategy: StackSeriesOption['stackStrategy']
@@ -196,41 +259,33 @@ function normalizeStackValue(
         return NaN;
     }
 
-    const total = getStackTotal(stackInfoList, targetStackInfo, dataIndex, rawValue, stackStrategy);
+    const stackTotalMap = targetStackInfo.isStackedByIndex
+        ? stackTotalMaps.byIndex
+        : stackTotalMaps.byDimension;
+    const key = targetStackInfo.isStackedByIndex
+        ? targetStackInfo.data.getRawIndex(dataIndex)
+        : targetStackInfo.data.get(targetStackInfo.stackedByDimension, dataIndex) as number;
+    const totalInfo = stackTotalMap.get(key);
+    const total = totalInfo && getStackTotal(totalInfo, rawValue, stackStrategy);
     return total ? rawValue / Math.abs(total) : 0;
 }
 
 function getStackTotal(
-    stackInfoList: StackInfo[],
-    targetStackInfo: StackInfo,
-    dataIndex: number,
+    totalInfo: StackTotal,
     targetValue: number,
     stackStrategy: StackSeriesOption['stackStrategy']
 ) {
-    const targetData = targetStackInfo.data;
-    const isStackedByIndex = targetStackInfo.isStackedByIndex;
-    let byValue: number;
-    let total = 0;
-
-    if (!isStackedByIndex) {
-        byValue = targetData.get(targetStackInfo.stackedByDimension, dataIndex) as number;
+    if (stackStrategy === 'all') {
+        return totalInfo.all;
+    }
+    else if (stackStrategy === 'positive') {
+        return totalInfo.positive;
+    }
+    else if (stackStrategy === 'negative') {
+        return totalInfo.negative;
     }
 
-    for (let i = 0; i < stackInfoList.length; i++) {
-        const stackInfo = stackInfoList[i];
-        const rawIndex = isStackedByIndex
-            ? targetData.getRawIndex(dataIndex)
-            : stackInfo.data.rawIndexOf(stackInfo.stackedByDimension, byValue);
-
-        if (rawIndex >= 0) {
-            const value = stackInfo.data.getByRawIndex(stackInfo.stackedDimension, rawIndex) as number;
-            if (!isNaN(value) && isStackedValueInStrategy(value, targetValue, stackStrategy)) {
-                total = addSafe(total, value);
-            }
-        }
-    }
-
-    return total;
+    return targetValue >= 0 ? totalInfo.positive : totalInfo.negative;
 }
 
 function isStackedValueInStrategy(

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -49,6 +49,7 @@ interface StackTotal {
 }
 
 type StackTotalMap = HashMap<StackTotal, string | number>;
+type StackTotalKey = string | number;
 
 interface StackTotalMaps {
     byIndex?: StackTotalMap
@@ -223,20 +224,18 @@ function calculateStackTotalMap(stackInfoList: StackInfo[], isStackedByIndex: bo
                 continue;
             }
 
-            addStackTotal(
-                stackTotalMap,
-                isStackedByIndex
-                    ? data.getRawIndex(dataIndex)
-                    : data.get(stackInfo.stackedByDimension, dataIndex) as number,
-                value
-            );
+            const key: StackTotalKey = isStackedByIndex
+                ? data.getRawIndex(dataIndex)
+                : data.get(stackInfo.stackedByDimension, dataIndex) as StackTotalKey;
+
+            addStackTotal(stackTotalMap, key, value);
         }
     }
 
     return stackTotalMap;
 }
 
-function addStackTotal(stackTotalMap: StackTotalMap, key: string | number, value: number) {
+function addStackTotal(stackTotalMap: StackTotalMap, key: StackTotalKey, value: number) {
     const total = stackTotalMap.get(key) || stackTotalMap.set(key, {
         all: 0,
         positive: 0,
@@ -266,9 +265,9 @@ function normalizeStackValue(
     }
 
     const stackTotalMap = getStackTotalMap(stackInfoList, stackTotalMaps, targetStackInfo.isStackedByIndex);
-    const key = targetStackInfo.isStackedByIndex
+    const key: StackTotalKey = targetStackInfo.isStackedByIndex
         ? targetStackInfo.data.getRawIndex(dataIndex)
-        : targetStackInfo.data.get(targetStackInfo.stackedByDimension, dataIndex) as number;
+        : targetStackInfo.data.get(targetStackInfo.stackedByDimension, dataIndex) as StackTotalKey;
     const totalInfo = stackTotalMap.get(key);
     const total = totalInfo && getStackTotal(totalInfo, rawValue, stackStrategy);
     return total ? rawValue / Math.abs(total) : 0;

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -106,17 +106,14 @@ export default function dataStack(ecModel: GlobalModel) {
 }
 
 function shouldNormalizeStack(stackInfoList: StackInfo[]) {
-    let hasStackNormalize = false;
-
     for (let i = 0; i < stackInfoList.length; i++) {
         const seriesModel = stackInfoList[i].seriesModel;
-        if (seriesModel.type !== 'series.line') {
+        if (seriesModel.type !== 'series.line' || !seriesModel.get('stackNormalize')) {
             return false;
         }
-        hasStackNormalize = hasStackNormalize || !!seriesModel.get('stackNormalize');
     }
 
-    return hasStackNormalize;
+    return stackInfoList.length > 0;
 }
 
 function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -51,8 +51,8 @@ interface StackTotal {
 type StackTotalMap = HashMap<StackTotal, string | number>;
 
 interface StackTotalMaps {
-    byIndex: StackTotalMap
-    byDimension: StackTotalMap
+    byIndex?: StackTotalMap
+    byDimension?: StackTotalMap
 }
 
 // (1) [Caution]: the logic is correct based on the premises:
@@ -130,7 +130,7 @@ function shouldNormalizeStack(stackInfoList: StackInfo[]) {
 }
 
 function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
-    const stackTotalMaps = normalizeStack ? calculateStackTotalMaps(stackInfoList) : null;
+    const stackTotalMaps: StackTotalMaps = {};
 
     each(stackInfoList, function (targetStackInfo, idxInStack) {
         const resultVal: number[] = [];
@@ -144,7 +144,7 @@ function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
         // depending on legend selection.
         targetData.modify(dims, function (v0, v1, dataIndex) {
             let sum = normalizeStack
-                ? normalizeStackValue(stackTotalMaps!, targetStackInfo, dataIndex, stackStrategy)
+                ? normalizeStackValue(stackInfoList, stackTotalMaps, targetStackInfo, dataIndex, stackStrategy)
                 : targetData.get(targetStackInfo.stackedDimension, dataIndex) as number;
 
             // Consider `connectNulls` of line area, if value is NaN, stackedOver
@@ -199,11 +199,18 @@ function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
     });
 }
 
-function calculateStackTotalMaps(stackInfoList: StackInfo[]) {
-    const stackTotalMaps: StackTotalMaps = {
-        byIndex: createHashMap<StackTotal, string | number>(),
-        byDimension: createHashMap<StackTotal, string | number>()
-    };
+function getStackTotalMap(
+    stackInfoList: StackInfo[],
+    stackTotalMaps: StackTotalMaps,
+    isStackedByIndex: boolean
+) {
+    const totalMapKey = isStackedByIndex ? 'byIndex' : 'byDimension';
+    return stackTotalMaps[totalMapKey]
+        || (stackTotalMaps[totalMapKey] = calculateStackTotalMap(stackInfoList, isStackedByIndex));
+}
+
+function calculateStackTotalMap(stackInfoList: StackInfo[], isStackedByIndex: boolean) {
+    const stackTotalMap = createHashMap<StackTotal, string | number>();
 
     for (let i = 0; i < stackInfoList.length; i++) {
         const stackInfo = stackInfoList[i];
@@ -216,19 +223,17 @@ function calculateStackTotalMaps(stackInfoList: StackInfo[]) {
                 continue;
             }
 
-            addStackTotal(stackTotalMaps.byIndex, data.getRawIndex(dataIndex), value);
-
-            if (stackInfo.stackedByDimension) {
-                addStackTotal(
-                    stackTotalMaps.byDimension,
-                    data.get(stackInfo.stackedByDimension, dataIndex) as number,
-                    value
-                );
-            }
+            addStackTotal(
+                stackTotalMap,
+                isStackedByIndex
+                    ? data.getRawIndex(dataIndex)
+                    : data.get(stackInfo.stackedByDimension, dataIndex) as number,
+                value
+            );
         }
     }
 
-    return stackTotalMaps;
+    return stackTotalMap;
 }
 
 function addStackTotal(stackTotalMap: StackTotalMap, key: string | number, value: number) {
@@ -248,6 +253,7 @@ function addStackTotal(stackTotalMap: StackTotalMap, key: string | number, value
 }
 
 function normalizeStackValue(
+    stackInfoList: StackInfo[],
     stackTotalMaps: StackTotalMaps,
     targetStackInfo: StackInfo,
     dataIndex: number,
@@ -259,9 +265,7 @@ function normalizeStackValue(
         return NaN;
     }
 
-    const stackTotalMap = targetStackInfo.isStackedByIndex
-        ? stackTotalMaps.byIndex
-        : stackTotalMaps.byDimension;
+    const stackTotalMap = getStackTotalMap(stackInfoList, stackTotalMaps, targetStackInfo.isStackedByIndex);
     const key = targetStackInfo.isStackedByIndex
         ? targetStackInfo.data.getRawIndex(dataIndex)
         : targetStackInfo.data.get(targetStackInfo.stackedByDimension, dataIndex) as number;

--- a/src/processor/dataStack.ts
+++ b/src/processor/dataStack.ts
@@ -24,8 +24,14 @@ import { SeriesOption, SeriesStackOptionMixin } from '../util/types';
 import SeriesData, { DataCalculationInfo } from '../data/SeriesData';
 import { addSafe } from '../util/number';
 
+interface StackNormalizeOption {
+    stackNormalize?: boolean
+}
+
+type StackSeriesOption = SeriesOption & SeriesStackOptionMixin & StackNormalizeOption;
+
 type StackInfo = Pick<
-    DataCalculationInfo<SeriesOption & SeriesStackOptionMixin>,
+    DataCalculationInfo<StackSeriesOption>,
     'stackedDimension'
     | 'isStackedByIndex'
     | 'stackedByDimension'
@@ -33,7 +39,7 @@ type StackInfo = Pick<
     | 'stackedOverDimension'
 > & {
     data: SeriesData
-    seriesModel: SeriesModel<SeriesOption & SeriesStackOptionMixin>
+    seriesModel: SeriesModel<StackSeriesOption>
 };
 
 // (1) [Caution]: the logic is correct based on the premises:
@@ -43,7 +49,7 @@ type StackInfo = Pick<
 //     Should be executed after series is filtered and before stack calculation.
 export default function dataStack(ecModel: GlobalModel) {
     const stackInfoMap = createHashMap<StackInfo[]>();
-    ecModel.eachSeries(function (seriesModel: SeriesModel<SeriesOption & SeriesStackOptionMixin>) {
+    ecModel.eachSeries(function (seriesModel: SeriesModel<StackSeriesOption>) {
         const stack = seriesModel.get('stack');
         // Compatible: when `stack` is set as '', do not stack.
         if (stack) {
@@ -95,11 +101,25 @@ export default function dataStack(ecModel: GlobalModel) {
         });
 
         // Calculate stack values
-        calculateStack(stackInfoList);
+        calculateStack(stackInfoList, shouldNormalizeStack(stackInfoList));
     });
 }
 
-function calculateStack(stackInfoList: StackInfo[]) {
+function shouldNormalizeStack(stackInfoList: StackInfo[]) {
+    let hasStackNormalize = false;
+
+    for (let i = 0; i < stackInfoList.length; i++) {
+        const seriesModel = stackInfoList[i].seriesModel;
+        if (seriesModel.type !== 'series.line') {
+            return false;
+        }
+        hasStackNormalize = hasStackNormalize || !!seriesModel.get('stackNormalize');
+    }
+
+    return hasStackNormalize;
+}
+
+function calculateStack(stackInfoList: StackInfo[], normalizeStack: boolean) {
     each(stackInfoList, function (targetStackInfo, idxInStack) {
         const resultVal: number[] = [];
         const resultNaN = [NaN, NaN];
@@ -111,7 +131,9 @@ function calculateStack(stackInfoList: StackInfo[]) {
         // Should not write on raw data, because stack series model list changes
         // depending on legend selection.
         targetData.modify(dims, function (v0, v1, dataIndex) {
-            let sum = targetData.get(targetStackInfo.stackedDimension, dataIndex) as number;
+            let sum = normalizeStack
+                ? normalizeStackValue(stackInfoList, targetStackInfo, dataIndex, stackStrategy)
+                : targetData.get(targetStackInfo.stackedDimension, dataIndex) as number;
 
             // Consider `connectNulls` of line area, if value is NaN, stackedOver
             // should also be NaN, to draw a appropriate belt area.
@@ -146,13 +168,7 @@ function calculateStack(stackInfoList: StackInfo[]) {
                     ) as number;
 
                     // Considering positive stack, negative stack and empty data
-                    if (
-                        stackStrategy === 'all' // single stack group
-                        || (stackStrategy === 'positive' && val > 0)
-                        || (stackStrategy === 'negative' && val < 0)
-                        || (stackStrategy === 'samesign' && sum >= 0 && val > 0) // All positive stack
-                        || (stackStrategy === 'samesign' && sum <= 0 && val < 0) // All negative stack
-                    ) {
+                    if (isStackedValueInStrategy(val, sum, stackStrategy)) {
                         // The sum has to be very small to be affected by the
                         // floating arithmetic problem. An incorrect result will probably
                         // cause axis min/max to be filtered incorrectly.
@@ -169,4 +185,65 @@ function calculateStack(stackInfoList: StackInfo[]) {
             return resultVal;
         });
     });
+}
+
+function normalizeStackValue(
+    stackInfoList: StackInfo[],
+    targetStackInfo: StackInfo,
+    dataIndex: number,
+    stackStrategy: StackSeriesOption['stackStrategy']
+) {
+    const rawValue = targetStackInfo.data.get(targetStackInfo.stackedDimension, dataIndex) as number;
+
+    if (isNaN(rawValue)) {
+        return NaN;
+    }
+
+    const total = getStackTotal(stackInfoList, targetStackInfo, dataIndex, rawValue, stackStrategy);
+    return total ? rawValue / Math.abs(total) : 0;
+}
+
+function getStackTotal(
+    stackInfoList: StackInfo[],
+    targetStackInfo: StackInfo,
+    dataIndex: number,
+    targetValue: number,
+    stackStrategy: StackSeriesOption['stackStrategy']
+) {
+    const targetData = targetStackInfo.data;
+    const isStackedByIndex = targetStackInfo.isStackedByIndex;
+    let byValue: number;
+    let total = 0;
+
+    if (!isStackedByIndex) {
+        byValue = targetData.get(targetStackInfo.stackedByDimension, dataIndex) as number;
+    }
+
+    for (let i = 0; i < stackInfoList.length; i++) {
+        const stackInfo = stackInfoList[i];
+        const rawIndex = isStackedByIndex
+            ? targetData.getRawIndex(dataIndex)
+            : stackInfo.data.rawIndexOf(stackInfo.stackedByDimension, byValue);
+
+        if (rawIndex >= 0) {
+            const value = stackInfo.data.getByRawIndex(stackInfo.stackedDimension, rawIndex) as number;
+            if (!isNaN(value) && isStackedValueInStrategy(value, targetValue, stackStrategy)) {
+                total = addSafe(total, value);
+            }
+        }
+    }
+
+    return total;
+}
+
+function isStackedValueInStrategy(
+    value: number,
+    targetValue: number,
+    stackStrategy: StackSeriesOption['stackStrategy']
+) {
+    return stackStrategy === 'all'
+        || (stackStrategy === 'positive' && value > 0)
+        || (stackStrategy === 'negative' && value < 0)
+        || (stackStrategy === 'samesign' && targetValue >= 0 && value > 0)
+        || (stackStrategy === 'samesign' && targetValue <= 0 && value < 0);
 }

--- a/test/area-stack.html
+++ b/test/area-stack.html
@@ -44,6 +44,7 @@ under the License.
         <div id="stack-all"></div>
         <div id="stack-positive"></div>
         <div id="stack-negative"></div>
+        <div id="stack-normalize"></div>
 
         <script>
 
@@ -749,6 +750,82 @@ under the License.
                 testHelper.create(echarts, 'stack-negative', {
                     title: 'Stacking with positive and negative values (stackStrategy: negative)',
                     option: option
+                });
+            });
+
+        </script>
+
+        <script>
+
+            require(['echarts'], function (echarts) {
+
+                var option = {
+                    legend: {
+                        top: 25
+                    },
+                    tooltip: {
+                        trigger: 'axis'
+                    },
+                    grid: {
+                        top: 80,
+                        left: 45,
+                        right: 30,
+                        bottom: 40
+                    },
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+                    },
+                    yAxis: {
+                        type: 'value',
+                        min: 0,
+                        max: 1
+                    },
+                    series: [
+                        {
+                            name: 'Direct',
+                            type: 'line',
+                            stack: 'normalized',
+                            stackNormalize: true,
+                            areaStyle: {},
+                            symbol: 'none',
+                            data: [10, 30, 20, 40, 25]
+                        },
+                        {
+                            name: 'Email',
+                            type: 'line',
+                            stack: 'normalized',
+                            stackNormalize: true,
+                            areaStyle: {},
+                            symbol: 'none',
+                            data: [20, 10, 30, 20, 25]
+                        },
+                        {
+                            name: 'Ads',
+                            type: 'line',
+                            stack: 'normalized',
+                            stackNormalize: true,
+                            areaStyle: {},
+                            symbol: 'none',
+                            data: [30, 40, 10, 20, 25]
+                        },
+                        {
+                            name: 'Search',
+                            type: 'line',
+                            stack: 'normalized',
+                            stackNormalize: true,
+                            areaStyle: {},
+                            symbol: 'none',
+                            data: [40, 20, 40, 20, 25]
+                        }
+                    ]
+                };
+
+                testHelper.create(echarts, 'stack-normalize', {
+                    title: 'Normalized stacked area (top boundary should stay at 1)',
+                    option: option,
+                    height: 420
                 });
             });
 

--- a/test/area-stack.html
+++ b/test/area-stack.html
@@ -759,6 +759,20 @@ under the License.
 
             require(['echarts'], function (echarts) {
 
+                var xAxisData = [];
+                var directData = [];
+                var emailData = [];
+                var adsData = [];
+                var searchData = [];
+
+                for (var i = 0; i < 100; i++) {
+                    xAxisData.push('Day ' + (i + 1));
+                    directData.push(Math.round(28 + Math.sin(i / 5) * 12 + (i % 9)));
+                    emailData.push(Math.round(24 + Math.cos(i / 7) * 10 + (i % 7)));
+                    adsData.push(Math.round(20 + Math.sin(i / 9 + 1) * 8 + (i % 5) * 2));
+                    searchData.push(Math.round(30 + Math.cos(i / 6 + 2) * 14 + (i % 11)));
+                }
+
                 var option = {
                     legend: {
                         top: 25
@@ -775,7 +789,7 @@ under the License.
                     xAxis: {
                         type: 'category',
                         boundaryGap: false,
-                        data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+                        data: xAxisData
                     },
                     yAxis: {
                         type: 'value',
@@ -790,7 +804,7 @@ under the License.
                             stackNormalize: true,
                             areaStyle: {},
                             symbol: 'none',
-                            data: [10, 30, 20, 40, 25]
+                            data: directData
                         },
                         {
                             name: 'Email',
@@ -799,7 +813,7 @@ under the License.
                             stackNormalize: true,
                             areaStyle: {},
                             symbol: 'none',
-                            data: [20, 10, 30, 20, 25]
+                            data: emailData
                         },
                         {
                             name: 'Ads',
@@ -808,7 +822,7 @@ under the License.
                             stackNormalize: true,
                             areaStyle: {},
                             symbol: 'none',
-                            data: [30, 40, 10, 20, 25]
+                            data: adsData
                         },
                         {
                             name: 'Search',
@@ -817,7 +831,7 @@ under the License.
                             stackNormalize: true,
                             areaStyle: {},
                             symbol: 'none',
-                            data: [40, 20, 40, 20, 25]
+                            data: searchData
                         }
                     ]
                 };

--- a/test/ut/spec/series/lineStack.test.ts
+++ b/test/ut/spec/series/lineStack.test.ts
@@ -78,6 +78,85 @@ describe('series.line stack', function () {
         expect(getStackResultValue(chart, 2, 1)).toBeCloseTo(1);
     });
 
+    it('normalizes negative stacked values with samesign strategy', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-2]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-3]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [5]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBeCloseTo(-0.4);
+        expect(getStackResultValue(chart, 1, 0)).toBeCloseTo(-1);
+        expect(getStackResultValue(chart, 2, 0)).toBeCloseTo(1);
+    });
+
+    it('normalizes stacked values with all strategy', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A', 'B']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'all',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [2, -2]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'all',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-1, -3]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'all',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [3, 1]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBeCloseTo(0.5);
+        expect(getStackResultValue(chart, 1, 0)).toBeCloseTo(0.25);
+        expect(getStackResultValue(chart, 2, 0)).toBeCloseTo(1);
+
+        expect(getStackResultValue(chart, 0, 1)).toBeCloseTo(-0.5);
+        expect(getStackResultValue(chart, 1, 1)).toBeCloseTo(-1.25);
+        expect(getStackResultValue(chart, 2, 1)).toBeCloseTo(-1);
+    });
+
     it('keeps regular stacked values when stackNormalize is not enabled', function () {
         chart.setOption({
             xAxis: {

--- a/test/ut/spec/series/lineStack.test.ts
+++ b/test/ut/spec/series/lineStack.test.ts
@@ -157,6 +157,84 @@ describe('series.line stack', function () {
         expect(getStackResultValue(chart, 2, 1)).toBeCloseTo(-1);
     });
 
+    it('normalizes stacked values with positive strategy', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'positive',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-1]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'positive',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [2]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'positive',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [3]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBeCloseTo(-0.2);
+        expect(getStackResultValue(chart, 1, 0)).toBeCloseTo(0.4);
+        expect(getStackResultValue(chart, 2, 0)).toBeCloseTo(1);
+    });
+
+    it('normalizes stacked values with negative strategy', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'negative',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [1]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'negative',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-2]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackStrategy: 'negative',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [-3]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBeCloseTo(0.2);
+        expect(getStackResultValue(chart, 1, 0)).toBeCloseTo(-0.4);
+        expect(getStackResultValue(chart, 2, 0)).toBeCloseTo(-1);
+    });
+
     it('keeps regular stacked values when stackNormalize is not enabled', function () {
         chart.setOption({
             xAxis: {

--- a/test/ut/spec/series/lineStack.test.ts
+++ b/test/ut/spec/series/lineStack.test.ts
@@ -1,0 +1,106 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import SeriesModel from '@/src/model/Series';
+import { createChart, getECModel } from '../../core/utHelper';
+
+function getStackResultValue(chart: EChartsType, seriesIndex: number, dataIndex: number): number {
+    const seriesModel = getECModel(chart).getSeriesByIndex(seriesIndex) as SeriesModel;
+    const data = seriesModel.getData();
+    return data.get(data.getCalculationInfo('stackResultDimension'), dataIndex) as number;
+}
+
+describe('series.line stack', function () {
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('normalizes stacked area values to the stack total', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A', 'B']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [1, 2]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [3, 6]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [6, 2]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBeCloseTo(0.1);
+        expect(getStackResultValue(chart, 1, 0)).toBeCloseTo(0.4);
+        expect(getStackResultValue(chart, 2, 0)).toBeCloseTo(1);
+
+        expect(getStackResultValue(chart, 0, 1)).toBeCloseTo(0.2);
+        expect(getStackResultValue(chart, 1, 1)).toBeCloseTo(0.8);
+        expect(getStackResultValue(chart, 2, 1)).toBeCloseTo(1);
+    });
+
+    it('keeps regular stacked values when stackNormalize is not enabled', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    areaStyle: {},
+                    data: [1]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    areaStyle: {},
+                    data: [3]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBe(1);
+        expect(getStackResultValue(chart, 1, 0)).toBe(4);
+    });
+});

--- a/test/ut/spec/series/lineStack.test.ts
+++ b/test/ut/spec/series/lineStack.test.ts
@@ -103,4 +103,31 @@ describe('series.line stack', function () {
         expect(getStackResultValue(chart, 0, 0)).toBe(1);
         expect(getStackResultValue(chart, 1, 0)).toBe(4);
     });
+
+    it('keeps regular stacked values when only part of the stack enables stackNormalize', function () {
+        chart.setOption({
+            xAxis: {
+                data: ['A']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'line',
+                    stack: 'total',
+                    stackNormalize: true,
+                    areaStyle: {},
+                    data: [1]
+                },
+                {
+                    type: 'line',
+                    stack: 'total',
+                    areaStyle: {},
+                    data: [3]
+                }
+            ]
+        });
+
+        expect(getStackResultValue(chart, 0, 0)).toBe(1);
+        expect(getStackResultValue(chart, 1, 0)).toBe(4);
+    });
 });


### PR DESCRIPTION
## Summary

- add `series.line.stackNormalize` for normalized stacked area charts
- normalize line stack calculation by each stack category total while preserving default stack behavior
- add unit coverage plus a 100-point HTML visual case for screenshot review
- document that `dist/` is generated during npm publish and should not be edited manually

## Validation

- `npx jest --config test/ut/jest.config.cjs --coverage=false test/ut/spec/series/lineStack.test.ts`
- `npm run checktype`
- `npx eslint src/processor/dataStack.ts src/chart/line/LineSeries.ts test/ut/spec/series/lineStack.test.ts`
- `git diff --check` on changed source, HTML, test, and AGENTS files
- Browser preview of the normalized stacked area HTML case with 100 data points

## Notes

- `dist/` was not modified; generated files are left to the npm publish flow.
- `npm run test:dts:fast` is currently blocked by existing NodeNext declaration errors before this option is exercised.