### PR TITLE
feat(transform): add native financial indicator dataset transform

### DIFF
--- a/src/component/transform/indicatorTransform.ts
+++ b/src/component/transform/indicatorTransform.ts
@@ -1,0 +1,215 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import {
+    DataTransformOption, ExternalDataTransform, ExternalDataTransformResultItem
+} from '../../data/helper/transform';
+import { throwError } from '../../util/log';
+import { DimensionLoose } from '../../util/types';
+
+export interface IndicatorTransformOption extends DataTransformOption {
+    type: 'echarts:indicator';
+    config: {
+        indicator?: 'sma' | 'ema' | 'macd' | 'bollinger';
+        period?: number;
+        sourceDimension?: DimensionLoose;
+        // MACD specific
+        shortPeriod?: number;
+        longPeriod?: number;
+        signalPeriod?: number;
+    };
+}
+
+export const indicatorTransform: ExternalDataTransform<IndicatorTransformOption> = {
+
+    type: 'echarts:indicator',
+
+    transform: function (params) {
+        const upstream = params.upstream;
+        const config = params.config || {};
+        const indicator = config.indicator || 'sma';
+        const period = config.period || 14;
+        
+        let sourceDimension = config.sourceDimension;
+        // Default to the last dimension if not specified
+        if (sourceDimension == null) {
+            const dims = upstream.cloneAllDimensionInfo();
+            sourceDimension = dims.length > 0 ? dims[dims.length - 1].name || dims[dims.length - 1].index : 0;
+        }
+
+        const dimInfo = upstream.getDimensionInfo(sourceDimension);
+        if (!dimInfo) {
+            throwError('Can not find dimension info via: ' + sourceDimension);
+            return { data: [] }; // Prevent ts error
+        }
+        
+        const dimIdx = dimInfo.index;
+        
+        const resultData: any[][] = [];
+        const upstreamCount = upstream.count();
+        
+        const upstreamDims = upstream.cloneAllDimensionInfo();
+        const dimensions: any[] = upstreamDims.map(d => d.name || d.index);
+        
+        // Prepare dimensions
+        if (indicator === 'sma' || indicator === 'ema') {
+            dimensions.push(indicator.toUpperCase());
+        } else if (indicator === 'bollinger') {
+            dimensions.push('Upper', 'Lower');
+        } else if (indicator === 'macd') {
+            dimensions.push('MACD', 'Signal', 'Histogram');
+        }
+        
+        // Retrieve source values
+        const values: number[] = [];
+        for (let i = 0; i < upstreamCount; i++) {
+            const val = upstream.retrieveValue(i, dimIdx);
+            const num = parseFloat(val as string);
+            values.push(isNaN(num) ? 0 : num);
+        }
+        
+        // Calculate SMA
+        const sma = (data: number[], p: number) => {
+            const res: (number | string)[] = [];
+            let sum = 0;
+            for (let i = 0; i < data.length; i++) {
+                sum += data[i];
+                if (i < p - 1) {
+                    res.push('-');
+                } else {
+                    res.push(sum / p);
+                    sum -= data[i - p + 1];
+                }
+            }
+            return res;
+        };
+
+        // Calculate EMA
+        const ema = (data: number[], p: number) => {
+            const res: (number | string)[] = [];
+            const k = 2 / (p + 1);
+            let currentEma = 0;
+            for (let i = 0; i < data.length; i++) {
+                if (i < p - 1) {
+                    res.push('-');
+                    currentEma += data[i]; // Accumulate sum for the first p-1 elements
+                } else if (i === p - 1) {
+                    currentEma += data[i];
+                    currentEma = currentEma / p; // Calculate initial SMA
+                    res.push(currentEma);
+                } else {
+                    currentEma = (data[i] - currentEma) * k + currentEma;
+                    res.push(currentEma);
+                }
+            }
+            return res;
+        };
+
+        let outputCols: (number|string)[][] = [];
+
+        if (indicator === 'sma') {
+            outputCols.push(sma(values, period));
+        } else if (indicator === 'ema') {
+            outputCols.push(ema(values, period));
+        } else if (indicator === 'bollinger') {
+            const smaVals = sma(values, period);
+            const upper: (number | string)[] = [];
+            const lower: (number | string)[] = [];
+            for (let i = 0; i < values.length; i++) {
+                if (i < period - 1) {
+                    upper.push('-');
+                    lower.push('-');
+                } else {
+                    const mean = smaVals[i] as number;
+                    let sumSq = 0;
+                    for (let j = 0; j < period; j++) {
+                        sumSq += Math.pow(values[i - j] - mean, 2);
+                    }
+                    const stdDev = Math.sqrt(sumSq / period);
+                    upper.push(mean + 2 * stdDev);
+                    lower.push(mean - 2 * stdDev);
+                }
+            }
+            outputCols.push(upper, lower);
+        } else if (indicator === 'macd') {
+            const shortP = config.shortPeriod || 12;
+            const longP = config.longPeriod || 26;
+            const sigP = config.signalPeriod || 9;
+            
+            const emaShort = ema(values, shortP);
+            const emaLong = ema(values, longP);
+            
+            const macdVals: (number | string)[] = [];
+            for (let i = 0; i < values.length; i++) {
+                if (emaShort[i] === '-' || emaLong[i] === '-') {
+                    macdVals.push('-');
+                } else {
+                    macdVals.push((emaShort[i] as number) - (emaLong[i] as number));
+                }
+            }
+            
+            const validMacd: number[] = [];
+            let firstValidIdx = -1;
+            for (let i = 0; i < macdVals.length; i++) {
+                if (macdVals[i] !== '-') {
+                    if (firstValidIdx === -1) firstValidIdx = i;
+                    validMacd.push(macdVals[i] as number);
+                }
+            }
+            
+            const signalLine = ema(validMacd, sigP);
+            const finalSignal: (number | string)[] = [];
+            const histogram: (number | string)[] = [];
+            
+            for (let i = 0; i < values.length; i++) {
+                if (i < firstValidIdx) {
+                    finalSignal.push('-');
+                    histogram.push('-');
+                } else {
+                    const sigVal = signalLine[i - firstValidIdx];
+                    finalSignal.push(sigVal);
+                    if (sigVal === '-' || macdVals[i] === '-') {
+                        histogram.push('-');
+                    } else {
+                        histogram.push((macdVals[i] as number) - (sigVal as number));
+                    }
+                }
+            }
+            outputCols.push(macdVals, finalSignal, histogram);
+        }
+
+        // Assemble rows
+        for (let i = 0; i < upstreamCount; i++) {
+            const row: any[] = [];
+            for (let d = 0; d < upstreamDims.length; d++) {
+                row.push(upstream.retrieveValue(i, upstreamDims[d].index));
+            }
+            // Append indicator columns
+            for (let c = 0; c < outputCols.length; c++) {
+                row.push(outputCols[c][i]);
+            }
+            resultData.push(row);
+        }
+        
+        return {
+            data: resultData as ExternalDataTransformResultItem['data'],
+            dimensions: dimensions
+        };
+    }
+};

--- a/src/component/transform/install.ts
+++ b/src/component/transform/install.ts
@@ -20,8 +20,10 @@
 import { EChartsExtensionInstallRegisters } from '../../extension';
 import {filterTransform} from './filterTransform';
 import {sortTransform} from './sortTransform';
+import {indicatorTransform} from './indicatorTransform';
 
 export function install(registers: EChartsExtensionInstallRegisters) {
     registers.registerTransform(filterTransform);
     registers.registerTransform(sortTransform);
+    registers.registerTransform(indicatorTransform);
 }

--- a/test/data-transform-indicator.html
+++ b/test/data-transform-indicator.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style></style>
+
+        <div id="main_indicator_sma_ema"></div>
+        <div id="main_indicator_bollinger"></div>
+        <div id="main_indicator_macd"></div>
+
+        <script>
+            var STOCK_DATA = [
+                ['Date', 'Open', 'Close', 'Lowest', 'Highest'],
+                ['2017-10-24', 20, 30, 10, 35],
+                ['2017-10-25', 40, 35, 30, 55],
+                ['2017-10-26', 33, 38, 33, 40],
+                ['2017-10-27', 40, 40, 32, 42],
+                ['2017-10-28', 40, 45, 39, 46],
+                ['2017-10-29', 46, 50, 45, 52],
+                ['2017-10-30', 52, 49, 48, 55],
+                ['2017-10-31', 48, 45, 42, 50],
+                ['2017-11-01', 44, 42, 40, 48],
+                ['2017-11-02', 41, 44, 40, 46],
+                ['2017-11-03', 44, 48, 42, 50],
+                ['2017-11-04', 48, 52, 45, 55],
+                ['2017-11-05', 52, 58, 50, 60],
+                ['2017-11-06', 58, 55, 52, 60],
+                ['2017-11-07', 54, 50, 48, 56]
+            ];
+
+        </script>
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                dataset: [{
+                    id: 'raw',
+                    source: STOCK_DATA
+                }, {
+                    id: 'sma5',
+                    fromDatasetId: 'raw',
+                    transform: {
+                        type: 'echarts:indicator',
+                        config: { indicator: 'sma', period: 5, sourceDimension: 'Close' }
+                    }
+                }, {
+                    id: 'ema5',
+                    fromDatasetId: 'raw',
+                    transform: {
+                        type: 'echarts:indicator',
+                        config: { indicator: 'ema', period: 5, sourceDimension: 'Close' }
+                    }
+                }],
+                tooltip: { trigger: 'axis' },
+                legend: {},
+                xAxis: { type: 'category' },
+                yAxis: { scale: true },
+                series: [{
+                    type: 'candlestick',
+                    name: 'K-Line',
+                    datasetId: 'raw',
+                    encode: {
+                        x: 'Date',
+                        y: ['Open', 'Close', 'Lowest', 'Highest']
+                    }
+                }, {
+                    type: 'line',
+                    name: 'SMA5',
+                    datasetId: 'sma5',
+                    encode: { x: 'Date', y: 'SMA' },
+                    smooth: true
+                }, {
+                    type: 'line',
+                    name: 'EMA5',
+                    datasetId: 'ema5',
+                    encode: { x: 'Date', y: 'EMA' },
+                    smooth: true
+                }]
+            };
+
+            testHelper.create(echarts, 'main_indicator_sma_ema', {
+                title: 'Test SMA and EMA transform on K-Line data',
+                height: 400,
+                option: option
+            });
+        });
+        </script>
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                dataset: [{
+                    id: 'raw',
+                    source: STOCK_DATA
+                }, {
+                    id: 'bollinger',
+                    fromDatasetId: 'raw',
+                    transform: {
+                        type: 'echarts:indicator',
+                        config: { indicator: 'bollinger', period: 5, sourceDimension: 'Close' }
+                    }
+                }],
+                tooltip: { trigger: 'axis' },
+                legend: {},
+                xAxis: { type: 'category' },
+                yAxis: { scale: true },
+                series: [{
+                    type: 'candlestick',
+                    name: 'K-Line',
+                    datasetId: 'raw',
+                    encode: {
+                        x: 'Date',
+                        y: ['Open', 'Close', 'Lowest', 'Highest']
+                    }
+                }, {
+                    type: 'line',
+                    name: 'Upper Band',
+                    datasetId: 'bollinger',
+                    encode: { x: 'Date', y: 'Upper' },
+                    lineStyle: { type: 'dashed' },
+                    itemStyle: { color: 'green' }
+                }, {
+                    type: 'line',
+                    name: 'Lower Band',
+                    datasetId: 'bollinger',
+                    encode: { x: 'Date', y: 'Lower' },
+                    lineStyle: { type: 'dashed' },
+                    itemStyle: { color: 'green' }
+                }]
+            };
+
+            testHelper.create(echarts, 'main_indicator_bollinger', {
+                title: 'Test Bollinger Bands transform',
+                height: 400,
+                option: option
+            });
+        });
+        </script>
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                dataset: [{
+                    id: 'raw',
+                    source: STOCK_DATA
+                }, {
+                    id: 'macd',
+                    fromDatasetId: 'raw',
+                    transform: {
+                        type: 'echarts:indicator',
+                        config: { 
+                            indicator: 'macd', 
+                            shortPeriod: 3, 
+                            longPeriod: 6, 
+                            signalPeriod: 3, 
+                            sourceDimension: 'Close' 
+                        }
+                    }
+                }],
+                tooltip: { trigger: 'axis' },
+                legend: {},
+                xAxis: { type: 'category' },
+                yAxis: { scale: true },
+                series: [{
+                    type: 'line',
+                    name: 'MACD',
+                    datasetId: 'macd',
+                    encode: { x: 'Date', y: 'MACD' }
+                }, {
+                    type: 'line',
+                    name: 'Signal',
+                    datasetId: 'macd',
+                    encode: { x: 'Date', y: 'Signal' },
+                    lineStyle: { type: 'dashed' }
+                }, {
+                    type: 'bar',
+                    name: 'Histogram',
+                    datasetId: 'macd',
+                    encode: { x: 'Date', y: 'Histogram' }
+                }]
+            };
+
+            testHelper.create(echarts, 'main_indicator_macd', {
+                title: 'Test MACD transform',
+                height: 400,
+                option: option
+            });
+        });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION

### What problem does this feature solve?
Currently, developers building financial/candlestick charts must rely on external JS libraries to calculate technical indicators before passing them to ECharts. This PR introduces a native `echarts:indicator` transform that computes these mathematically in the data pipeline, significantly reducing boilerplate and external dependencies.

### What does the proposed API look like?
The new transform hooks seamlessly into the existing `ExternalDataTransform` interface:
```javascript
dataset: [{
    source: stockData
}, {
    transform: {
        type: 'echarts:indicator',
        config: { 
            indicator: 'macd', // Supports: 'sma', 'ema', 'macd', 'bollinger'
            shortPeriod: 12, 
            longPeriod: 26, 
            signalPeriod: 9, 
            sourceDimension: 'Close' 
        }
    }
}]
