### PR TITLE
fix(line): avoid crash when visualMap piecewise produces no in-range stops

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -323,7 +323,14 @@ function getVisualGradient(
     const stopLen = colorStops.length;
     const outerColors = visualMeta.outerColors.slice();
 
-    if (stopLen && colorStops[0].coord > colorStops[stopLen - 1].coord) {
+    if (stopLen && (
+        colorStops[0].coord > colorStops[stopLen - 1].coord
+        // When stops collapse to the same coord (e.g. a piecewise visualMap with
+        // a single half-infinite piece produces two boundary stops at the same
+        // value), the coord comparison gives no signal — fall back to the axis
+        // direction so we still flip on an inverted axis. See #18066.
+        || (colorStops[0].coord === colorStops[stopLen - 1].coord && axis.inverse)
+    )) {
         colorStops.reverse();
         outerColors.reverse();
     }
@@ -336,6 +343,13 @@ function getVisualGradient(
         return colorStops[0].coord < 0
             ? (outerColors[1] ? outerColors[1] : colorStops[stopLen - 1].color)
             : (outerColors[0] ? outerColors[0] : colorStops[0].color);
+    }
+    if (!inRangeStopLen) {
+        // No color stops at all (e.g. a visualMap piecewise piece producing
+        // a fully [-Infinity, Infinity] interval, like `pieces: [{ lte: null }]`).
+        // Fall back to a single outer color or transparent so we don't crash
+        // on `colorStopsInRange[0].coord` below. See #18066.
+        return outerColors[0] || outerColors[1] || 'transparent';
     }
 
     const tinyExtent = 10; // Arbitrary value: 10px

--- a/src/component/visualMap/PiecewiseModel.ts
+++ b/src/component/visualMap/PiecewiseModel.ts
@@ -370,11 +370,27 @@ class PiecewiseModel extends VisualMapModel<PiecewiseVisualMapOption> {
                 valueState = visualMapModel.getValueState(representValue);
             }
             const color = getColorVisual(representValue, valueState);
-            if (interval[0] === -Infinity) {
+            const lowInf = interval[0] === -Infinity;
+            const highInf = interval[1] === Infinity;
+            if (lowInf) {
                 outerColors[0] = color;
             }
-            else if (interval[1] === Infinity) {
+            if (highInf) {
                 outerColors[1] = color;
+            }
+            // Emit the finite edge(s) as stops as well, so consumers know where
+            // a half-infinite interval ends (e.g. `pieces: [{lte: 10}]` should
+            // still report a boundary at 10). When the interval is fully infinite
+            // there is no finite edge to record, so only `outerColors` is set.
+            // See #18066.
+            if (lowInf && highInf) {
+                return;
+            }
+            if (lowInf) {
+                stops.push({value: interval[1], color: color});
+            }
+            else if (highInf) {
+                stops.push({value: interval[0], color: color});
             }
             else {
                 stops.push(

--- a/test/ut/spec/component/visualMap/setOption.test.ts
+++ b/test/ut/spec/component/visualMap/setOption.test.ts
@@ -287,4 +287,93 @@ describe('vsiaulMap_setOption', function () {
         done();
     });
 
+    // See https://github.com/apache/echarts/issues/18066
+    it('piecewiseWithNullBoundOnLineSeries', function (done) {
+        // Setting `lte: null` (or omitting both bounds) makes the piece
+        // interval [-Infinity, Infinity], which previously crashed
+        // line series rendering with
+        // "Cannot read properties of undefined (reading 'coord')".
+        expect(function () {
+            chart.setOption({
+                xAxis: {type: 'category', data: ['A', 'B', 'C', 'D']},
+                yAxis: {type: 'value'},
+                visualMap: {
+                    type: 'piecewise',
+                    pieces: [
+                        // lte set to null should be treated as no upper bound.
+                        {lte: null, color: 'red'}
+                    ]
+                },
+                series: [{
+                    type: 'line',
+                    data: [10, 20, 30, 40]
+                }]
+            });
+        }).not.toThrow();
+        done();
+    });
+
+    // See https://github.com/apache/echarts/issues/18066 review feedback.
+    it('piecewiseHalfInfiniteEmitsBoundaryStop', function () {
+        chart.setOption({
+            xAxis: {type: 'category', data: ['A', 'B', 'C', 'D']},
+            yAxis: {type: 'value'},
+            visualMap: {
+                type: 'piecewise',
+                pieces: [
+                    {lte: 10, color: 'red'}
+                ],
+                outOfRange: { color: 'blue' }
+            } as PiecewiseVisualMapOption,
+            series: [{
+                type: 'line',
+                data: [5, 8, 15, 20]
+            }]
+        });
+
+        const visualMapModel = (chart as any).getModel().getComponent('visualMap', 0) as VisualMapModel;
+        const visualMeta = (visualMapModel as any).getVisualMeta(
+            (val: number) => visualMapModel.getValueState(val) === 'inRange' ? 'red' : 'blue'
+        );
+
+        // The half-infinite [-Infinity, 10] piece must record the finite edge
+        // at 10 in `stops` (not just in `outerColors`), so consumers can locate
+        // the boundary.
+        const valuesAtTen = visualMeta.stops.filter((s: any) => s.value === 10);
+        expect(valuesAtTen.length).toBeGreaterThanOrEqual(1);
+        const colorsAtTen = valuesAtTen.map((s: any) => s.color);
+        expect(colorsAtTen).toContain('red');
+        // The implicit out-of-range piece for (10, Infinity) should also emit
+        // its finite left edge.
+        expect(colorsAtTen).toContain('blue');
+    });
+
+    it('piecewiseFullInfiniteStillEmitsNoStops', function () {
+        chart.setOption({
+            xAxis: {type: 'category', data: ['A', 'B', 'C', 'D']},
+            yAxis: {type: 'value'},
+            visualMap: {
+                type: 'piecewise',
+                pieces: [
+                    {lte: null, color: 'red'}
+                ]
+            } as PiecewiseVisualMapOption,
+            series: [{
+                type: 'line',
+                data: [10, 20, 30, 40]
+            }]
+        });
+
+        const visualMapModel = (chart as any).getModel().getComponent('visualMap', 0) as VisualMapModel;
+        const visualMeta = (visualMapModel as any).getVisualMeta(
+            () => 'red'
+        );
+
+        // Truly fully infinite intervals have no finite edge to record, so
+        // `stops` stays empty and the LineView defensive fallback handles it.
+        expect(visualMeta.stops).toEqual([]);
+        expect(visualMeta.outerColors[0]).toBe('red');
+        expect(visualMeta.outerColors[1]).toBe('red');
+    });
+
 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix a crash in line series when a `visualMap` piecewise piece has no upper / lower bound (e.g. `{ lte: null }`), which previously made `colorStopsInRange` empty and caused `Cannot read properties of undefined (reading 'coord')`.



### Fixed issues

- #18066: [Bug] Line Charts do not work when lte is set to null


## Details

### Before: What was the problem?

When a `visualMap` of type `piecewise` has a piece without an upper bound (or both bounds missing), e.g.:

```js
visualMap: {
  type: 'piecewise',
  pieces: [{ lte: null, color: 'red' }]
}
```

`PiecewiseModel` falls back the missing bound to `Infinity` / `-Infinity`, so the piece interval becomes `[-Infinity, Infinity]`. In `PiecewiseModel.getVisualMeta`, the `setStop` helper only fills `outerColors` (never `stops`) when an interval edge is `±Infinity`. As a result the line series renderer receives an empty `colorStopsInRange` array and crashes at `LineView.ts:350`:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'coord')
    at colorStopsInRange[0].coord - tinyExtent
```

Reproduction from the issue:
https://echarts.apache.org/examples/en/editor.html?c=line-simple&code=PYBwLglsB2AEC8sDeAoWsCeBBAHhAzgFywDaa6y5FsYGIApsQOQBuAhgDYCu9TANFVgBfcgF0B6HLgLEy1VNXS0GzAMZsw9AObAAThn6CR6ceQ7b60ACbEFFfAAtgAd2IAzTvnrkhE2Ft0IG2RfcjBgYA5IEFtQ9C9A-iJSQTtqZUZYJg4IaF4_amg2AFtMphBdYDcIMENqY1hTdCsNNi8wWVTBZohS6HwoftkmDHo2XX4siqqapibFfGAuXVVMuUV0NI3MMd1mACYABgBGQ7rt9HLK6triU8OCxTjtrY3R8YOT4_OLq5nb2BHB7dCjPDavRTvPZZI7HfY_bZ_G5MO4AVmBFzBigh1Chn2OAGYERskbNiATDhjtg1qKIjGI_CwCFxOABZNgxSjUEAQeirZLreQg9BaTTEKkbKKZaBcDgcR7UVSRPTMABG3F4IJpjUe4U5p0eel50A6WScgQAXjAwJwEeY3KamKsTfQJn4REIANxAA



### After: How does it behave after the fixing?

In `getVisualGradient` of `src/chart/line/LineView.ts`, add a guard for the case where `colorStopsInRange` is empty (and `stopLen` is also `0`, which the existing `!inRangeStopLen && stopLen` branch does not cover). Fall back to `outerColors[0] || outerColors[1] || 'transparent'` so the chart renders with a single fallback color instead of crashing.

The new branch is only hit when there are no color stops at all, so existing behaviors are unchanged.

Added a regression test `piecewiseWithNullBoundOnLineSeries` in `test/ut/spec/component/visualMap/setOption.test.ts` that reproduces the original report and asserts `setOption` does not throw.

Verification:
- Without the fix, the new test fails with the exact stack from the issue (`LineView.ts:350`).
- With the fix, the new test passes.
- All existing unit tests still pass: `Test Suites: 24 passed, 24 total; Tests: 186 passed, 186 total`.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
