### PR TITLE
fix(line): keep step corners when adjacent points are visually close

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -869,7 +869,8 @@ class LineView extends ChartView {
         polyline.setShape({
             smooth,
             smoothMonotone,
-            connectNulls
+            connectNulls,
+            step: !!step
         });
 
         if (polygon) {
@@ -894,7 +895,8 @@ class LineView extends ChartView {
                 smooth,
                 stackedOnSmooth,
                 smoothMonotone,
-                connectNulls
+                connectNulls,
+                step: !!step
             });
 
             setStatesStylesFromModel(polygon, seriesModel, 'areaStyle');

--- a/src/chart/line/poly.ts
+++ b/src/chart/line/poly.ts
@@ -45,7 +45,8 @@ function drawSegment(
     dir: number,
     smooth: number,
     smoothMonotone: 'x' | 'y' | 'none',
-    connectNulls: boolean
+    connectNulls: boolean,
+    step?: boolean
 ) {
     let prevX: number;
     let prevY: number;
@@ -81,7 +82,14 @@ function drawSegment(
             let dy = y - prevY;
 
             // Ignore tiny segment.
-            if ((dx * dx + dy * dy) < 0.5) {
+            // In step mode, keep every corner; only drop strict duplicates. See #21614.
+            if (step) {
+                if (dx === 0 && dy === 0) {
+                    idx += dir;
+                    continue;
+                }
+            }
+            else if ((dx * dx + dy * dy) < 0.5) {
                 idx += dir;
                 continue;
             }
@@ -218,6 +226,8 @@ class ECPolylineShape {
     smoothConstraint = true;
     smoothMonotone: 'x' | 'y' | 'none';
     connectNulls: boolean;
+    // True when `points` are step-expanded; keep every corner. See #21614.
+    step: boolean;
 }
 
 interface ECPolylineProps extends PathProps {
@@ -271,7 +281,8 @@ export class ECPolyline extends Path<ECPolylineProps> {
                 ctx, points, i, len, len,
                 1,
                 shape.smooth,
-                shape.smoothMonotone, shape.connectNulls
+                shape.smoothMonotone, shape.connectNulls,
+                shape.step
             ) + 1;
         }
     }
@@ -395,13 +406,15 @@ export class ECPolygon extends Path {
                 ctx, points, i, len, len,
                 1,
                 shape.smooth,
-                smoothMonotone, shape.connectNulls
+                smoothMonotone, shape.connectNulls,
+                shape.step
             );
             drawSegment(
                 ctx, stackedOnPoints, i + k - 1, k, len,
                 -1,
                 shape.stackedOnSmooth,
-                smoothMonotone, shape.connectNulls
+                smoothMonotone, shape.connectNulls,
+                shape.step
             );
             i += k + 1;
 

--- a/test/ut/spec/series/line-step-poly.test.ts
+++ b/test/ut/spec/series/line-step-poly.test.ts
@@ -1,0 +1,103 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { ECPolyline } from '../../../../src/chart/line/poly';
+
+type Cmd = ['M' | 'L', number, number] | ['C', number, number, number, number, number, number];
+
+function recordCommands(polyline: ECPolyline): Cmd[] {
+    const cmds: Cmd[] = [];
+    const mockCtx = {
+        moveTo(x: number, y: number) { cmds.push(['M', x, y]); },
+        lineTo(x: number, y: number) { cmds.push(['L', x, y]); },
+        bezierCurveTo(x: number, y: number, x2: number, y2: number, x3: number, y3: number) {
+            cmds.push(['C', x, y, x2, y2, x3, y3]);
+        },
+        closePath() { /* noop */ }
+    };
+    polyline.buildPath(mockCtx as any, polyline.shape);
+    return cmds;
+}
+
+describe('chart/line/poly', function () {
+
+    // https://github.com/apache/echarts/issues/21614
+    it('step mode keeps every corner even when points are visually close', function () {
+        // Step-expanded points for data (0,1),(0.3,1),(0.3,0) with step:'end'.
+        // Adjacent corners fall within the legacy `< 0.5` tiny-segment threshold,
+        // which previously collapsed the L-shape into a slope.
+        const points = [
+            0, 1,
+            0.3, 1,
+            0.3, 1,
+            0.3, 1,
+            0.3, 0
+        ];
+
+        const polyline = new ECPolyline({
+            shape: { points, smooth: 0, connectNulls: false, step: true }
+        });
+
+        const cmds = recordCommands(polyline);
+        const lineTos = cmds.filter(c => c[0] === 'L');
+
+        expect(cmds[0]).toEqual(['M', 0, 1]);
+
+        const cornerIdx = lineTos.findIndex(c => c[1] === 0.3 && c[2] === 1);
+        const tailIdx = lineTos.findIndex(c => c[1] === 0.3 && c[2] === 0);
+        expect(cornerIdx).toBeGreaterThanOrEqual(0);
+        expect(tailIdx).toBeGreaterThanOrEqual(0);
+        expect(cornerIdx).toBeLessThan(tailIdx);
+    });
+
+    it('step mode still drops strictly duplicated points', function () {
+        const points = [
+            0, 0,
+            0, 0,
+            0, 0,
+            5, 5
+        ];
+
+        const polyline = new ECPolyline({
+            shape: { points, smooth: 0, connectNulls: false, step: true }
+        });
+
+        const cmds = recordCommands(polyline);
+        const lineTos = cmds.filter(c => c[0] === 'L');
+
+        expect(cmds[0]).toEqual(['M', 0, 0]);
+        expect(lineTos).toEqual([['L', 5, 5]]);
+    });
+
+    it('non-step mode preserves the tiny-segment optimization', function () {
+        const points = [
+            0, 0,
+            0.3, 0,
+            10, 0
+        ];
+
+        const polyline = new ECPolyline({
+            shape: { points, smooth: 0, connectNulls: false, step: false }
+        });
+
+        const lineTos = recordCommands(polyline).filter(c => c[0] === 'L');
+        expect(lineTos).toEqual([['L', 10, 0]]);
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Stop the line renderer from collapsing step (stair-case) lines into diagonal slopes when adjacent data points are very close on the base axis.



### Fixed issues

- #21614 : [Bug] Line chart tiny segments skipped, becoming a slope


## Details

### Before: What was the problem?

`drawSegment` in `src/chart/line/poly.ts` drops any segment whose squared pixel distance is `< 0.5` as a render-time optimization:

```ts
// Ignore tiny segment.
if ((dx * dx + dy * dy) < 0.5) {
    idx += dir;
    continue;
}
```

For plain polylines this is harmless. For step lines, however, `turnPointsIntoStep` expands each data segment into an L-shape by inserting an auxiliary corner point. Those corner points encode the stair-case and must all be visited.

When two consecutive data points are very close on the base axis (e.g. `[08:59:30, 1]` and `[09:00:00, 1]` reported in #21614), both the corner and one or more intermediate auxiliary points fall under the `< 0.5` threshold. They all get skipped, so the renderer goes straight from the previous point to the next far point, drawing a diagonal slope instead of a vertical step.

Reproduction from the issue (CodeSandbox): https://codesandbox.io/p/sandbox/pdh82y?file=%2Findex.js

The reporter also already pinpointed the offending line: `src/chart/line/poly.ts:83`.



### After: How does it behave after the fixing?

A `step` flag is propagated from `LineView` through `ECPolyline`/`ECPolygon` shapes into `drawSegment`. In step mode the function now only drops strictly duplicate points (`dx === 0 && dy === 0`) and keeps every other corner intact:

```ts
// Ignore tiny segment.
// In step mode, keep every corner; only drop strict duplicates. See #21614.
if (step) {
    if (dx === 0 && dy === 0) {
        idx += dir;
        continue;
    }
}
else if ((dx * dx + dy * dy) < 0.5) {
    idx += dir;
    continue;
}
```

Non-step rendering is byte-for-byte identical.

Added a unit test `test/ut/spec/series/line-step-poly.test.ts` that records the path commands emitted for a step-expanded point set matching the #21614 reproduction and asserts:

1. Step mode visits the corner before the tail (regression for #21614).
2. Step mode still collapses strictly duplicated points so the path stays clean.
3. Non-step mode still applies the `< 0.5` tiny-segment optimization.

Verification:
- Without the fix, the corner-visit assertion fails with the exact bug behavior (corner is missing, only the tail `lineTo` is emitted).
- With the fix, the new tests pass.
- Full unit test suite: `Test Suites: 25 passed, 25 total; Tests: 188 passed, 188 total`.
- `npm run lint` and `tsc --noEmit` both pass (also enforced by the project's pre-commit hook).



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
