### PR TITLE
fix(candlestick): apply canvas-level clipPath in normal rendering mode

### DIFF
--- a/src/chart/candlestick/CandlestickView.ts
+++ b/src/chart/candlestick/CandlestickView.ts
@@ -48,8 +48,6 @@ class CandlestickView extends ChartView {
     private _progressiveEls: Element[];
 
     render(seriesModel: CandlestickSeriesModel, ecModel: GlobalModel, api: ExtensionAPI) {
-        // If there is clipPath created in large mode. Remove it.
-        this.group.removeClipPath();
         // Clear previously rendered progressive elements.
         this._progressiveEls = null;
 
@@ -164,6 +162,16 @@ class CandlestickView extends ChartView {
             .execute();
 
         this._data = data;
+
+        if (needsClip) {
+            const clipPath = createClipPath(coord, false, seriesModel);
+            if (clipPath) {
+                group.setClipPath(clipPath);
+            }
+        }
+        else {
+            group.removeClipPath();
+        }
     }
 
     _renderLarge(seriesModel: CandlestickSeriesModel) {


### PR DESCRIPTION
## Summary

- Apply `group.setClipPath()` in candlestick normal rendering mode when `clip: true`, consistent with how `LineView` handles clipping.
- Previously, `CandlestickView.render()` unconditionally removed the clip path and relied solely on a per-item `isNormalBoxClipped()` visibility check, which allowed partially-visible candlestick wicks to render outside the grid boundary.
- The per-item `isNormalBoxClipped` check is kept as an optimization to skip items entirely outside the clip area.

Fixes #21627

## Changes

**`src/chart/candlestick/CandlestickView.ts`**

1. **Removed** the unconditional `group.removeClipPath()` call from `render()` (previously line 52) — clip path lifecycle is now managed by `_renderNormal` and `_renderLarge` individually.
2. **Added** canvas-level clip path in `_renderNormal()`: when `clip: true`, applies `group.setClipPath(createClipPath(coord, false, seriesModel))`; otherwise calls `group.removeClipPath()`.

## Before / After

| Before (v5.5.0) | After (this PR) |
|---|---|
| Candlestick wicks bleed into adjacent grid | Wicks clipped at grid boundary |

Live reproducer: https://wplong11.github.io/echarts-candlestick-clip-bug/

## Test plan

- [ ] Open the [reproducer](https://wplong11.github.io/echarts-candlestick-clip-bug/) with patched build — wicks should be clipped at Grid 1 boundary
- [ ] Toggle filterMode between `'none'` and `'empty'` — both should show no bleed
- [ ] Toggle y-axis zoom off — full range should render normally
- [ ] Verify candlestick rendering in single-grid layout is unaffected
- [ ] Verify large mode rendering is unaffected (large mode already applies `setClipPath`)