### PR TITLE
ci: build generated types before type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Lint
         run: npx eslint $(cat ~/tmp/changed_files)
 
+      - name: Build generated types
+        run: npm run build:lib
+
       - name: Check types
         run: npm run checktype
 


### PR DESCRIPTION
## Summary
- build generated library types in the lint job before running `npm run checktype`
- prevents cached `node_modules` from skipping `npm ci` and leaving `types/dist/echarts` missing

## Root Cause
The lint job skips `npm ci` when the `node_modules` cache hits. Since `npm ci` is what normally runs `prepare -> build:lib`, generated type files may be absent before `checktype`.

## Validation
- `npm ci`
- `npm run build:lib && npm run checktype`
- commit hook: `npm run lint` and `npm run checktype`