### PR TITLE
fix(dataZoom): keep boundary neighbors for line series so partial segments and null gaps survive

### DIFF
--- a/src/component/dataZoom/AxisProxy.ts
+++ b/src/component/dataZoom/AxisProxy.ts
@@ -450,6 +450,13 @@ class AxisProxy {
                             })
                         );
                     }
+                    else if (shouldKeepLineBoundary(seriesModel)) {
+                        // Line / area series need one neighboring data row on each side
+                        // of the in-window range so partial line segments at the
+                        // boundary are still drawn (#21564) and null gap markers that
+                        // fall outside the window still interrupt the line (#21565).
+                        keepLineBoundary(seriesData, dim, valueWindow);
+                    }
                     else {
                         const range: Dictionary<[number, number]> = {};
                         range[dim] = valueWindow as [number, number];
@@ -497,6 +504,47 @@ class AxisProxy {
             minMaxSpan[minMax + 'ValueSpan' as 'minValueSpan' | 'maxValueSpan'] = valueSpan;
         }, this);
     }
+}
+
+function shouldKeepLineBoundary(seriesModel: SeriesModel): boolean {
+    return seriesModel.subType === 'line';
+}
+
+function keepLineBoundary(
+    seriesData: ReturnType<SeriesModel['getData']>,
+    dim: string,
+    valueWindow: number[]
+): void {
+    const store = seriesData.getStore();
+    const dimIdx = seriesData.getDimensionIndex(dim);
+    const count = store.count();
+    if (!count || dimIdx < 0) {
+        return;
+    }
+
+    const min = valueWindow[0];
+    const max = valueWindow[1];
+    const inWindow = new Uint8Array(count);
+    let allIn = true;
+    for (let i = 0; i < count; i++) {
+        const v = store.get(dimIdx, i) as number;
+        const isIn = ((v >= min && v <= max) || isNaN(v)) ? 1 : 0;
+        inWindow[i] = isIn;
+        if (!isIn) {
+            allIn = false;
+        }
+    }
+    if (allIn) {
+        return;
+    }
+
+    seriesData.filterSelf(function (idx: number) {
+        return !!(
+            inWindow[idx]
+            || (idx > 0 && inWindow[idx - 1])
+            || (idx < count - 1 && inWindow[idx + 1])
+        );
+    });
 }
 
 export default AxisProxy;

--- a/test/line-dataZoom-boundary.html
+++ b/test/line-dataZoom-boundary.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+        <div id="main0"></div>
+        <div id="main1"></div>
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option = {
+                xAxis: {
+                    type: 'category',
+                    data: [
+                        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                        10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+                    ]
+                },
+                dataZoom: [{
+                    type: 'inside',
+                    xAxisIndex: 0,
+                    minValueSpan: 10,
+                    maxValueSpan: 10
+                }],
+                yAxis: {
+                    type: 'value',
+                    min: 3,
+                    max: 7
+                },
+                series: [{
+                    type: 'line',
+                    data: [
+                        [0, 5],
+                        [2, 6],
+                        [8, 5],
+                        [12, 5],
+                        [16, 6]
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    '#21564 Line chart partial segments at dataZoom boundary',
+                    'Pan the chart: line segments crossing the visible edge',
+                    'should still draw their visible portion (not vanish entirely).'
+                ],
+                option: option
+            });
+        });
+        </script>
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option = {
+                xAxis: {
+                    type: 'category',
+                    data: [
+                        0, 1, 2, 3, 4, 5, 6, 7,
+                        8, 9, 10, 11, 12, 13, 14
+                    ]
+                },
+                dataZoom: [{
+                    type: 'inside',
+                    xAxisIndex: 0,
+                    minValueSpan: 10,
+                    maxValueSpan: 10,
+                    startValue: 3
+                }],
+                yAxis: {
+                    type: 'value',
+                    min: 3,
+                    max: 7
+                },
+                series: [{
+                    type: 'line',
+                    data: [
+                        [4, 5],
+                        [7, 5],
+                        [11, 5],
+                        [11, null],
+                        [6, 6],
+                        [9, 6]
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main1', {
+                title: [
+                    '#21565 Line chart null gap preserved across dataZoom',
+                    'Pan the chart: the null between (11,5) and (6,6) must',
+                    'keep interrupting the line (no ghost line connecting them).'
+                ],
+                option: option
+            });
+        });
+        </script>
+    </body>
+</html>

--- a/test/ut/spec/component/dataZoom/lineBoundary.test.ts
+++ b/test/ut/spec/component/dataZoom/lineBoundary.test.ts
@@ -1,0 +1,177 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getECModel } from '../../../core/utHelper';
+
+function getRawIndices(chart: EChartsType, seriesIndex = 0): number[] {
+    const data = getECModel(chart).getSeries()[seriesIndex].getData();
+    const out: number[] = [];
+    for (let i = 0; i < data.count(); i++) {
+        out.push(data.getRawIndex(i));
+    }
+    return out;
+}
+
+describe('dataZoom/lineBoundary', function () {
+
+    let chart: EChartsType;
+    beforeEach(function () {
+        chart = createChart();
+    });
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    // https://github.com/apache/echarts/issues/21564
+    it('keeps one neighbor on each side so partial line segments still draw', function () {
+        chart.setOption({
+            xAxis: {
+                type: 'category',
+                data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+            },
+            yAxis: { type: 'value' },
+            dataZoom: [{
+                type: 'inside',
+                xAxisIndex: 0,
+                startValue: 3,
+                endValue: 13
+            }],
+            series: [{
+                type: 'line',
+                data: [
+                    [0, 5],
+                    [2, 6],
+                    [8, 5],
+                    [12, 5],
+                    [16, 6]
+                ]
+            }]
+        });
+
+        // Window covers categories [3, 13]. Raw rows in window: 2 (x=8), 3 (x=12).
+        // The fix also keeps row 1 (x=2, predecessor of first in-window row)
+        // and row 4 (x=16, successor of last in-window row), so the line view
+        // can render the partial segments crossing the window boundary.
+        expect(getRawIndices(chart)).toEqual([1, 2, 3, 4]);
+    });
+
+    // https://github.com/apache/echarts/issues/21565
+    it('keeps a null gap row whose neighbor in raw order is in the window', function () {
+        chart.setOption({
+            xAxis: {
+                type: 'category',
+                data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+            },
+            yAxis: { type: 'value' },
+            dataZoom: [{
+                type: 'inside',
+                xAxisIndex: 0,
+                startValue: 3,
+                endValue: 10
+            }],
+            series: [{
+                type: 'line',
+                data: [
+                    [4, 5],
+                    [7, 5],
+                    [11, 5],
+                    [11, null],
+                    [6, 6],
+                    [9, 6]
+                ]
+            }]
+        });
+
+        // Window covers categories [3, 10]. Raw rows whose x is in window:
+        // 0 (x=4), 1 (x=7), 4 (x=6), 5 (x=9). Without the fix, row 3 (x=11,
+        // y=null) would be dropped and the line would jump from row 1 (7,5)
+        // to row 4 (6,6), producing a ghost line. The fix keeps row 3 because
+        // its raw-order successor (row 4) is in the window, and also keeps
+        // row 2 (x=11) because its predecessor (row 1) is in the window.
+        expect(getRawIndices(chart)).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+
+    it('does not affect bar series (boundary keeping is line-only)', function () {
+        chart.setOption({
+            xAxis: { type: 'category', data: [0, 1, 2, 3, 4] },
+            yAxis: { type: 'value' },
+            dataZoom: [{
+                type: 'inside',
+                xAxisIndex: 0,
+                startValue: 1,
+                endValue: 3
+            }],
+            series: [{
+                type: 'bar',
+                data: [
+                    [0, 5],
+                    [1, 5],
+                    [2, 5],
+                    [3, 5],
+                    [4, 5]
+                ]
+            }]
+        });
+
+        expect(getRawIndices(chart)).toEqual([1, 2, 3]);
+    });
+
+    it('does not change behavior when filterMode is not "filter"', function () {
+        chart.setOption({
+            xAxis: { type: 'category', data: [0, 1, 2, 3, 4, 5, 6] },
+            yAxis: { type: 'value' },
+            dataZoom: [{
+                type: 'inside',
+                xAxisIndex: 0,
+                startValue: 2,
+                endValue: 4,
+                filterMode: 'none'
+            }],
+            series: [{
+                type: 'line',
+                data: [
+                    [0, 5], [1, 5], [2, 5], [3, 5], [4, 5], [5, 5], [6, 5]
+                ]
+            }]
+        });
+
+        // filterMode 'none' keeps every row.
+        expect(getRawIndices(chart)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    });
+
+    it('keeps no extra neighbors when every row is in the window', function () {
+        chart.setOption({
+            xAxis: { type: 'category', data: [0, 1, 2, 3, 4] },
+            yAxis: { type: 'value' },
+            dataZoom: [{
+                type: 'inside',
+                xAxisIndex: 0,
+                startValue: 0,
+                endValue: 4
+            }],
+            series: [{
+                type: 'line',
+                data: [[0, 5], [1, 5], [2, 5], [3, 5], [4, 5]]
+            }]
+        });
+
+        expect(getRawIndices(chart)).toEqual([0, 1, 2, 3, 4]);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

When `dataZoom` filters a line series with the default `filterMode: 'filter'`, keep one neighboring data row on each side of the in-window range so partial line segments at the boundary can still be drawn and `null` gap markers outside the window still interrupt the line.

### Fixed issues

- close #21564
- close #21565

## Details

### Before: What was the problem?

Both bugs share one root cause. `AxisProxy.filterData()` calls `seriesData.selectRange()`, which physically drops every row whose value falls outside the data zoom window. For line / area series this corrupts the rendering in two ways:

**#21564 — partial line segments vanish at the boundary.**
When a segment connects an in-window point with an out-of-window point, the out-of-window endpoint is removed and the line view loses the entire segment instead of clipping it. The result is that any line crossing the visible edge disappears completely.

**#21565 — null gap markers stop interrupting the line.**
When a `null` row's value sits outside the window, the row is dropped from the filtered store and the line view never sees the gap marker. With non-monotonic data, the line view then connects two rows that should remain interrupted, drawing a "ghost line".

### After: How does it behave after the fixing?

For line / area series only (`subType === 'line'`) and only when `filterMode === 'filter'`, swap `selectRange()` for a boundary-aware filter:

> Keep row `i` if row `i`, row `i-1` or row `i+1` is in the window.

A single `Uint8Array` pre-scan computes inWindow status; `filterSelf` then applies the keep predicate in one pass. Other series types (bar, scatter, ...) and other filter modes (`none`, `empty`, `weakFilter`) are completely untouched, so the fast `selectRange` path remains the default for everything that does not need this.

With the fix:

- The boundary points just outside the window are retained, so segments crossing the edge still draw their visible portion (clip path takes care of the cropping).
- A `null` row whose raw-order neighbor is in the window is retained, so it still breaks the line and prevents ghost connections.

The visible-y extent on auto-fit Y axes may extend slightly to include the boundary points' Y values; this is *necessary* because the partial segment's clipping line can reach those Y values, and without the wider extent the segment would be clipped along the Y dimension as well.

### Tests

`test/ut/spec/component/dataZoom/lineBoundary.test.ts` adds five unit tests covering:

- `#21564`: window `[3, 13]` against `[(0,5), (2,6), (8,5), (12,5), (16,6)]` → kept raw indices `[1, 2, 3, 4]` (the two boundary neighbors are now retained).
- `#21565`: window `[3, 10]` against `[(4,5), (7,5), (11,5), (11,null), (6,6), (9,6)]` → all six rows retained, so the null still breaks the line.
- `bar` series: behavior unchanged (no boundary keeping).
- `filterMode: 'none'`: behavior unchanged.
- All-in-window: short-circuited, no extra work.

`test/line-dataZoom-boundary.html` is a visual reproducer for both issues so reviewers can pan the chart and verify the rendering directly.

Full unit suite: 26 suites, 197 tests, all green.

## Document Info

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/ut/spec/component/dataZoom/lineBoundary.test.ts` — unit tests
- `test/line-dataZoom-boundary.html` — visual reproducer

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

A few related rendering features were not exhaustively visually verified and are worth a reviewer's eye:

- `endLabel` on a line series with dataZoom: with the fix, the last filtered row may be a boundary point sitting just outside the window. The label would either be clipped or rendered just past the chart edge depending on how `endLabel` is positioned. If this turns out to need adjusting, it can be a follow-up.
- `markPoint` with `type: 'max'` / `'min'`: same caveat — these may now match a boundary point.

For the bugs as reported, both reproductions render correctly with the fix applied.
