### PR TITLE
fix: Revert updateTransform to support progressive rendering

### DIFF
--- a/src/chart/effectScatter/EffectScatterView.ts
+++ b/src/chart/effectScatter/EffectScatterView.ts
@@ -29,6 +29,7 @@ import EffectScatterSeriesModel from './EffectScatterSeries';
 import { StageHandlerProgressExecutor } from '../../util/types';
 import { createCoordSysClipAreaSimply } from '../helper/createClipPathFromCoordSys';
 import { SymbolDrawUpdateOpt } from '../helper/baseDraw';
+import { isInProgressiveRendering } from '../../util/model';
 
 class EffectScatterView extends ChartView {
     static readonly type = 'effectScatter';
@@ -48,6 +49,10 @@ class EffectScatterView extends ChartView {
     }
 
     updateTransform(seriesModel: EffectScatterSeriesModel, ecModel: GlobalModel, api: ExtensionAPI) {
+        if (isInProgressiveRendering(seriesModel)) {
+            return {update: true} as const;
+        }
+
         const data = seriesModel.getData();
 
         this.group.dirty();

--- a/src/chart/lines/LinesView.ts
+++ b/src/chart/lines/LinesView.ts
@@ -35,7 +35,7 @@ import SeriesData from '../../data/SeriesData';
 import type Polar from '../../coord/polar/Polar';
 import type Cartesian2D from '../../coord/cartesian/Cartesian2D';
 import Element from 'zrender/src/Element';
-import { getIncrementalId } from '../../util/model';
+import { getIncrementalId, isInProgressiveRendering } from '../../util/model';
 import { getCurrentCanvasPainter } from '../../util/graphic';
 import { ILineDraw } from '../helper/baseDraw';
 
@@ -134,7 +134,8 @@ class LinesView extends ChartView {
         const data = seriesModel.getData();
         const lineDraw = this._lineDraw;
 
-        if (!this._finished
+        if (isInProgressiveRendering(seriesModel)
+            || !this._finished
             || !lineDraw
             // TODO Don't have to do update in large mode. Only do it when there are millions of data.
             || !lineDraw.updateLayout

--- a/src/chart/scatter/ScatterView.ts
+++ b/src/chart/scatter/ScatterView.ts
@@ -28,7 +28,7 @@ import SeriesData from '../../data/SeriesData';
 import { TaskProgressParams } from '../../core/task';
 import type { StageHandlerProgressExecutor } from '../../util/types';
 import Element from 'zrender/src/Element';
-import { getIncrementalId } from '../../util/model';
+import { getIncrementalId, isInProgressiveRendering } from '../../util/model';
 import { createCoordSysClipAreaSimply } from '../helper/createClipPathFromCoordSys';
 import { ISymbolDraw, SymbolDrawUpdateOpt } from '../helper/baseDraw';
 
@@ -78,7 +78,9 @@ class ScatterView extends ChartView {
         // PENDING
         this.group.dirty();
 
-        if (!this._finished) { // FIXME: _finished checking is unnecessary?
+        if (isInProgressiveRendering(seriesModel)
+            || !this._finished
+        ) { // FIXME: _finished checking is unnecessary?
             return {update: true} as const;
         }
         else {

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1973,13 +1973,7 @@ class ECharts extends Eventful<ECEventDefinition> {
                 const seriesDirtyMap = createHashMap();
                 ecModel.eachSeries(function (seriesModel) {
                     const chartView = ecIns._chartsMap[seriesModel.__viewId];
-                    const pipelineContext = seriesModel.pipelineContext;
-                    if (chartView.updateTransform
-                        // Use the progressive pass if enabled, where each frame renders only a small amount.
-                        // And `ISymbolDraw['updateLayout']` and `ILineDraw['updateLayout']` do not support
-                        // progressive case.
-                        && !pipelineContext.progressiveRender
-                    ) {
+                    if (chartView.updateTransform) {
                         const result = chartView.updateTransform(seriesModel, ecModel, api, payload);
                         result && result.update && seriesDirtyMap.set(seriesModel.uid, 1);
                     }

--- a/src/util/model.ts
+++ b/src/util/model.ts
@@ -1442,3 +1442,7 @@ export function createSimpleOverallStageHandler2(
         overallReset: overallReset
     };
 }
+
+export function isInProgressiveRendering(seriesModel: SeriesModel): boolean {
+    return seriesModel.pipelineContext.progressiveRender;
+}

--- a/src/view/Chart.ts
+++ b/src/view/Chart.ts
@@ -71,6 +71,22 @@ interface ChartView {
     /**
      * Update transform directly.
      * Implement it if needed.
+     *
+     * [NOTICE]: It may be called after normal rendering (via `ChartView['render']`)
+     * or progressive rendering (via `ChartView['incrementalPrepareRender']` and
+     * `ChartView['incrementalRender']`).
+     * For example, echarts-gl `linesGL` supports `updateTransform` to run in
+     * progressive rendering.
+     * If a series opts out of supporting `updateTransform` in progressive rendering,
+     * it can fall back to the normal update path using
+     *  ```js
+     *  updateTransform(seriesModel) {
+     *      if (isInProgressiveRendering(seriesModel)) {
+     *          return {update: true} as const;
+     *      }
+     *      // ...
+     *  }
+     *  ```
      */
     updateTransform(
         seriesModel: SeriesModel,

--- a/test/scatter-gps.html
+++ b/test/scatter-gps.html
@@ -70,7 +70,7 @@ under the License.
                 }
                 // var dataURL = `../../echarts-gl/test/data/gps/gps_${idx}.bin`;
                 // var dataURL = `../../data-online/gps/gps_${idx}.bin`;
-                var dataURL = `../../echarts-examples/public/data/asset/data/gps2/gps_${idx}.bin`;
+                var dataURL = `../../echarts-examples/public/data/asset/data/gps/gps_${idx}.bin`;
                 var xhr = new XMLHttpRequest();
                 xhr.open('GET', dataURL, true);
                 xhr.responseType = 'arraybuffer';


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [ ] new feature
- [x] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

Revert `updateTransform` to support progressive rendering (e.g. for 'linesGL' in echarts-gl). It is incorrectly broken by v6.1.0.

test cases: 
+ echarts-gl/test/linesGL.html
+ echarts-examples: http://127.0.0.1:3002/en/editor.html?c=linesGL-ny&gl=1&local=1
