### PR TITLE
fix(geo): remove unsafe and unnecessary `new Function` when parsing GeoJSON input

### DIFF
--- a/src/coord/geo/GeoJSONResource.ts
+++ b/src/coord/geo/GeoJSONResource.ts
@@ -115,7 +115,7 @@ export class GeoJSONResource implements GeoResource {
             fixTextCoord(mapName, region);
             fixDiaoyuIsland(mapName, region);
 
-            // Some area like Alaska in USA map needs to be tansformed
+            // Some area like Alaska in USA map needs to be transformed
             // to look better
             const specialArea = this._specialAreas && this._specialAreas[regionName];
             if (specialArea) {
@@ -141,7 +141,7 @@ export class GeoJSONResource implements GeoResource {
         return {
             // For backward compatibility, use geoJson
             // PENDING: it has been returning them without clone.
-            // do we need to avoid outsite modification?
+            // do we need to avoid outside modification?
             geoJson: this._geoJSON,
             geoJSON: this._geoJSON,
             specialAreas: this._specialAreas

--- a/src/coord/geo/GeoJSONResource.ts
+++ b/src/coord/geo/GeoJSONResource.ts
@@ -161,9 +161,5 @@ function calculateBoundingRect(regions: GeoJSONRegion[]): BoundingRect {
 }
 
 function parseInput(source: GeoJSONSourceInput): GeoJSON | GeoJSONCompressed {
-    return !isString(source)
-        ? source
-        : (typeof JSON !== 'undefined' && JSON.parse)
-        ? JSON.parse(source)
-        : (new Function('return (' + source + ');'))();
+    return !isString(source) ? source : JSON.parse(source);
 }


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

As we discussed in the group, remove unsafe and unnecessary `new Function` when parsing GeoJSON input.

### Fixed issues

This issue was also reported as a security risk in closed #21626.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx