### PR TITLE
fix(dataZoom): allow wheel zoom-out to expand a collapsed inside dataZoom range

### DIFF
--- a/src/component/dataZoom/InsideZoomView.ts
+++ b/src/component/dataZoom/InsideZoomView.ts
@@ -88,7 +88,7 @@ interface DataZoomGetRangeHandler<
     ): [number, number]
 }
 
-const getRangeHandlers: {
+export const getRangeHandlers: {
     pan: DataZoomGetRangeHandler<RoamEventParams['pan']>
     zoom: DataZoomGetRangeHandler<RoamEventParams['zoom']>
     scrollMove: DataZoomGetRangeHandler<RoamEventParams['scrollMove']>
@@ -114,6 +114,17 @@ const getRangeHandlers: {
             ) / directionInfo.pixelLength * (range[1] - range[0]) + range[0];
 
         const scale = Math.max(1 / e.scale, 0);
+
+        // When the current range is collapsed to a single point (e.g. the toolbox
+        // dataZoom brushed exactly one category), multiplicative zoom cannot expand
+        // a zero-width window. Seed it with a small percent around the wheel anchor
+        // so wheel-out becomes responsive again. See #21541.
+        const SEED_HALF_PERCENT = 2.5;
+        if (range[1] - range[0] < 1e-6 && scale > 1) {
+            range[0] = percentPoint - SEED_HALF_PERCENT;
+            range[1] = percentPoint + SEED_HALF_PERCENT;
+        }
+
         range[0] = (range[0] - percentPoint) * scale + percentPoint;
         range[1] = (range[1] - percentPoint) * scale + percentPoint;
 

--- a/test/dataZoom-wheel-zoom-out-collapsed.html
+++ b/test/dataZoom-wheel-zoom-out-collapsed.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+        <div id="main0"></div>
+
+
+        <script>
+        require([
+            'echarts',
+        ], function (echarts) {
+            var option = {
+                dataZoom: [
+                    { filterMode: 'filter', type: 'inside', xAxisIndex: [0] },
+                    { filterMode: 'filter', type: 'inside', yAxisIndex: [0] }
+                ],
+                toolbox: {
+                    show: true,
+                    feature: {
+                        dataZoom: { type: 'inside' },
+                        restore: {}
+                    }
+                },
+                xAxis: { type: 'category', data: ['Mon', 'Tue', 'Wed', 'Thu'] },
+                yAxis: { type: 'value' },
+                visualMap: {
+                    type: 'continuous',
+                    min: 0,
+                    max: 6,
+                    left: 10,
+                    inRange: {
+                        color: ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
+                    }
+                },
+                series: [{
+                    symbolSize: 20,
+                    type: 'scatter',
+                    data: [
+                        ['Mon', 1], ['Tue', 2], ['Mon', 3], ['Tue', 4],
+                        ['Mon', 5], ['Tue', 6], ['Wed', 1], ['Thu', 2],
+                        ['Wed', 3], ['Thu', 4], ['Wed', 5], ['Thu', 6]
+                    ]
+                }]
+            };
+
+            var chart = testHelper.create(echarts, 'main0', {
+                title: [
+                    '#21541 Wheel zoom-out from a single-category dataZoom window',
+                    'Steps: (1) toolbox dataZoom → drag to brush ONE category only',
+                    '(2) scroll mouse wheel up to zoom out',
+                    'Expected: window expands and reveals adjacent categories.'
+                ],
+                option: option
+            });
+        });
+        </script>
+    </body>
+</html>

--- a/test/ut/spec/component/dataZoom/insideZoomViewWheel.test.ts
+++ b/test/ut/spec/component/dataZoom/insideZoomViewWheel.test.ts
@@ -1,0 +1,105 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { getRangeHandlers } from '@/src/component/dataZoom/InsideZoomView';
+
+interface ZoomCtx {
+    range: [number, number];
+    dataZoomModel: {
+        findRepresentativeAxisProxy: () => { getMinMaxSpan: () => Record<string, number> };
+    };
+}
+
+function makeCtx(range: [number, number]): ZoomCtx {
+    return {
+        range,
+        dataZoomModel: {
+            findRepresentativeAxisProxy: () => ({ getMinMaxSpan: () => ({}) })
+        }
+    };
+}
+
+const coordSysInfo = {
+    model: {
+        coordinateSystem: {
+            getRect: () => ({ x: 0, y: 0, width: 400, height: 300 })
+        }
+    },
+    axisModels: [{ axis: { dim: 'x', inverse: false } }]
+};
+
+function callZoom(
+    ctx: ZoomCtx,
+    eScale: number,
+    originX = 200
+): [number, number] | void {
+    return (getRangeHandlers.zoom as any).call(
+        ctx,
+        coordSysInfo,
+        'grid',
+        null,
+        { scale: eScale, originX, originY: 150, isAvailableBehavior: null }
+    );
+}
+
+describe('dataZoom/InsideZoomView wheel zoom', function () {
+
+    // https://github.com/apache/echarts/issues/21541
+    it('expands a collapsed range when wheel-zooming out', function () {
+        const ctx = makeCtx([33.33, 33.33]);
+
+        // Wheel-out: e.scale < 1 → handler scale = 1 / e.scale > 1.
+        const result = callZoom(ctx, 1 / 1.1) as [number, number];
+
+        expect(result).toBeDefined();
+        expect(result[1] - result[0]).toBeGreaterThan(0);
+        // The seed expansion is anchored on the wheel position (centered here).
+        expect((result[0] + result[1]) / 2).toBeCloseTo(33.33, 5);
+    });
+
+    it('does not expand a collapsed range when wheel-zooming in', function () {
+        const ctx = makeCtx([33.33, 33.33]);
+        const result = callZoom(ctx, 1.1);
+        // Range did not change, so the handler returns undefined.
+        expect(result).toBeUndefined();
+        expect(ctx.range[0]).toBeCloseTo(33.33, 6);
+        expect(ctx.range[1]).toBeCloseTo(33.33, 6);
+    });
+
+    it('keeps the existing multiplicative behavior on a non-degenerate range', function () {
+        const ctx = makeCtx([25, 75]);
+        const before = ctx.range[1] - ctx.range[0];
+        const result = callZoom(ctx, 1 / 1.1) as [number, number];
+        const after = result[1] - result[0];
+
+        expect(after).toBeGreaterThan(before);
+        // Roughly the wheel factor (1.1×).
+        expect(after / before).toBeCloseTo(1.1, 1);
+    });
+
+    it('clamps the seeded range to [0, 100] without crashing near the edge', function () {
+        const ctx = makeCtx([99.5, 99.5]);
+        const result = callZoom(ctx, 1 / 1.1, 400) as [number, number];
+
+        expect(result).toBeDefined();
+        expect(result[1] - result[0]).toBeGreaterThan(0);
+        expect(result[0]).toBeGreaterThanOrEqual(0);
+        expect(result[1]).toBeLessThanOrEqual(100);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Make `dataZoom inside` wheel zoom-out work after the toolbox has collapsed the range to a single category, so users can zoom back out and see all categories again.

### Fixed issues

- close #21541

## Details

### Before: What was the problem?

When the toolbox dataZoom feature brushes a single category on a category axis, it dispatches `startValue === endValue` and `AxisProxy` collapses the percent window to a zero-width range (for example `[33.33, 33.33]` for category index `1` of `4`).

`InsideZoomView.zoom` expands the window multiplicatively around the wheel anchor:

```ts
range[i] = (range[i] - percentPoint) * scale + percentPoint
```

For a collapsed range every term is zero, so wheel-out leaves the range unchanged and the user is stuck looking at the single category they brushed. The bug was confirmed by @helgasoft and tracked in #20392.

Reproducer (from the issue):

1. Toolbox dataZoom → brush exactly one category.
2. Scroll the mouse wheel up to zoom out.
3. The window stays collapsed; wheel does nothing.

### After: How does it behave after the fixing?

Detect the collapsed-range case in the zoom handler. When the user is wheel-zooming out (`scale > 1`), seed the range with a small percent (currently 5%) centered on the wheel anchor before applying the multiplicative expansion:

```ts
const SEED_HALF_PERCENT = 2.5;
if (range[1] - range[0] < 1e-6 && scale > 1) {
    range[0] = percentPoint - SEED_HALF_PERCENT;
    range[1] = percentPoint + SEED_HALF_PERCENT;
}

range[0] = (range[0] - percentPoint) * scale + percentPoint;
range[1] = (range[1] - percentPoint) * scale + percentPoint;
```

After the seed, subsequent wheel ticks scale multiplicatively as before, so the user reaches the full range in roughly 30 ticks (default factor 1.1). The seed is anchored on the wheel position, then the existing `sliderMove` clamp ensures the range stays within `[0, 100]` even when the wheel anchor sits near the edge.

Wheel-in on a collapsed range is intentionally left as a no-op — it cannot collapse the range further, and the existing math already handles that correctly.

### Tests

`test/ut/spec/component/dataZoom/insideZoomViewWheel.test.ts` adds four unit tests calling the exported `getRangeHandlers.zoom` directly with mocked context:

- collapsed-range wheel-out → range expands and stays centered on the wheel anchor.
- collapsed-range wheel-in → handler returns `undefined` (no change).
- non-degenerate range wheel-out → existing multiplicative behavior preserved (≈1.1× factor).
- collapsed range near `100%` → seed gets clamped to `[0, 100]` without crashing.

`test/dataZoom-wheel-zoom-out-collapsed.html` is a visual reproducer matching the issue's steps so reviewers can brush a single category in the toolbox and verify the wheel now expands the window.

`InsideZoomView.ts` exports `getRangeHandlers` so the unit tests can drive the handler in isolation; the type alias `DataZoomGetRangeHandlers` was already exported, so this is purely a value export.

Full unit suite: 26 suites, 196 tests, all green.

## Document Info

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/ut/spec/component/dataZoom/insideZoomViewWheel.test.ts` — unit tests
- `test/dataZoom-wheel-zoom-out-collapsed.html` — visual reproducer

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

The seed half-width (2.5% per side, 5% width on first tick) is empirical: small enough not to feel jumpy on the first tick, large enough that the user feels progress and reaches the full range in a reasonable number of ticks. Happy to tune this if reviewers prefer a different value.
