### PR TITLE
fix(roam): proper touch pinch support for zoom & pan

### DIFF
--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -136,7 +136,9 @@ class RoamController extends Eventful<RoamEventDefinition> {
 
     private _pinchY: number;
 
-    private _pinchPanEnabled: boolean;
+    private _moveEnabled: boolean;
+
+    private _zoomEnabled: boolean;
 
     private _controlType: RoamOptionMixin['roam'];
 
@@ -193,7 +195,8 @@ class RoamController extends Eventful<RoamEventDefinition> {
             if (controlType == null) {
                 controlType = true;
             }
-            const pinchPanEnabled = controlType === true || (controlType === 'move' || controlType === 'pan');
+            const moveEnabled = controlType === true || (controlType === 'move' || controlType === 'pan');
+            const zoomEnabled = controlType === true || (controlType === 'scale' || controlType === 'zoom');
 
             // A quick optimization for repeatedly calling `enable` during roaming.
             // Assert `disable` is only affected by `controlType`.
@@ -202,17 +205,20 @@ class RoamController extends Eventful<RoamEventDefinition> {
                 this.disable();
 
                 this._enabled = true;
-                if (controlType === true || (controlType === 'move' || controlType === 'pan')) {
+                if (moveEnabled) {
                     addRoamZrListener(zr, 'mousedown', mousedownHandler, zInfoParsed);
                     addRoamZrListener(zr, 'mousemove', mousemoveHandler, zInfoParsed);
                     addRoamZrListener(zr, 'mouseup', mouseupHandler, zInfoParsed);
                 }
-                if (controlType === true || (controlType === 'scale' || controlType === 'zoom')) {
+                if (zoomEnabled) {
                     addRoamZrListener(zr, 'mousewheel', mousewheelHandler, zInfoParsed);
+                }
+                if (moveEnabled || zoomEnabled) {
                     addRoamZrListener(zr, 'pinch', pinchHandler, zInfoParsed);
                 }
             }
-            this._pinchPanEnabled = pinchPanEnabled;
+            this._moveEnabled = moveEnabled;
+            this._zoomEnabled = zoomEnabled;
         };
 
         this.disable = function () {
@@ -223,7 +229,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
                 removeRoamZrListener(zr, 'mouseup', mouseupHandler);
                 removeRoamZrListener(zr, 'mousewheel', mousewheelHandler);
                 removeRoamZrListener(zr, 'pinch', pinchHandler);
-                this._pinchPanEnabled = false;
+                this._moveEnabled = this._zoomEnabled = false;
             }
         };
     }
@@ -431,6 +437,10 @@ class RoamController extends Eventful<RoamEventDefinition> {
         const originX = e.pinchX;
         const originY = e.pinchY;
 
+        // Gate only the beginning of a pinch capture.
+        // Once captured, keep handling movement outside the roam area.
+        // Requiring a native touchstart for a new capture also
+        //  prevents another RoamController from picking up an already-moving pinch.
         const isTouchStart = e.event.type === 'touchstart';
         const isPinchStart = !this._pinching || isTouchStart;
         if (isPinchStart) {
@@ -442,14 +452,15 @@ class RoamController extends Eventful<RoamEventDefinition> {
         eventTool.stop(e.event);
         (e as RoamControllerZREventExtend).__ecRoamConsumed = true;
 
+        this._pinching = true;
+
         const oldX = this._pinchX;
         const oldY = this._pinchY;
-        this._pinching = true;
         this._pinchX = originX;
         this._pinchY = originY;
 
         if (!isPinchStart
-            && this._pinchPanEnabled
+            && this._moveEnabled
             && (originX !== oldX || originY !== oldY)
         ) {
             trigger(this, 'pan', null, e, {
@@ -464,7 +475,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
         }
 
         const scale = e.pinchScale;
-        if (scale !== 1) {
+        if (this._zoomEnabled && scale !== 1) {
             trigger(this, 'zoom', null, e, {
                 scale: scale, originX: originX, originY: originY, isAvailableBehavior: null
             });

--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -229,7 +229,8 @@ class RoamController extends Eventful<RoamEventDefinition> {
                 removeRoamZrListener(zr, 'mouseup', mouseupHandler);
                 removeRoamZrListener(zr, 'mousewheel', mousewheelHandler);
                 removeRoamZrListener(zr, 'pinch', pinchHandler);
-                this._moveEnabled = this._zoomEnabled = false;
+                this._moveEnabled = false;
+                this._zoomEnabled = false;
             }
         };
     }

--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -418,7 +418,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
         ) {
             return;
         }
-        const scale = e.pinchScale > 1 ? 1.1 : 1 / 1.1;
+        const scale = e.pinchScale;
         this._checkTriggerMoveZoom(this, 'zoom', null, e, {
             scale: scale, originX: e.pinchX, originY: e.pinchY, isAvailableBehavior: null
         });

--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -106,12 +106,12 @@ export type RoamEventDefinition = {
 type RoamPointerChecker = (e: ZRElementEvent, x: number, y: number) => boolean;
 
 /**
- * An manager of zoom and pan(darg) hehavior.
+ * A manager of zoom and pan(drag) behavior.
  * But it is not responsible for updating the view, since view updates vary and can
  * not be handled in a uniform way.
  *
  * Note: regarding view updates:
- *  - Transformabe views typically use `coord/View` (e.g., geo and series.graph roaming).
+ *  - Transformable views typically use `coord/View` (e.g., geo and series.graph roaming).
  *    Some commonly used view update logic has been organized into `roamHelper.ts`.
  *  - Non-transformable views handle updates themselves, possibly involving re-layout,
  *    (e.g., treemap).
@@ -131,6 +131,12 @@ class RoamController extends Eventful<RoamEventDefinition> {
     private _x: number;
 
     private _y: number;
+
+    private _pinchX: number;
+
+    private _pinchY: number;
+
+    private _pinchPanEnabled: boolean;
 
     private _controlType: RoamOptionMixin['roam'];
 
@@ -187,6 +193,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
             if (controlType == null) {
                 controlType = true;
             }
+            const pinchPanEnabled = controlType === true || (controlType === 'move' || controlType === 'pan');
 
             // A quick optimization for repeatedly calling `enable` during roaming.
             // Assert `disable` is only affected by `controlType`.
@@ -205,6 +212,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
                     addRoamZrListener(zr, 'pinch', pinchHandler, zInfoParsed);
                 }
             }
+            this._pinchPanEnabled = pinchPanEnabled;
         };
 
         this.disable = function () {
@@ -215,6 +223,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
                 removeRoamZrListener(zr, 'mouseup', mouseupHandler);
                 removeRoamZrListener(zr, 'mousewheel', mousewheelHandler);
                 removeRoamZrListener(zr, 'pinch', pinchHandler);
+                this._pinchPanEnabled = false;
             }
         };
     }
@@ -355,6 +364,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
         const zr = this._zr;
         if (!eventTool.isMiddleOrRightButtonOnMouseUpDown(e)) {
             this._dragging = false;
+            this._pinching = false;
 
             const cursorStyle = this._decideCursorStyle(e, e.offsetX, e.offsetY, true);
             if (cursorStyle) {
@@ -418,10 +428,47 @@ class RoamController extends Eventful<RoamEventDefinition> {
         ) {
             return;
         }
+        const originX = e.pinchX;
+        const originY = e.pinchY;
+
+        const isTouchStart = e.event.type === 'touchstart';
+        const isPinchStart = !this._pinching || isTouchStart;
+        if (isPinchStart) {
+            if (!isTouchStart || !this._checkPointer(e, originX, originY)) {
+                return;
+            }
+        }
+
+        eventTool.stop(e.event);
+        (e as RoamControllerZREventExtend).__ecRoamConsumed = true;
+
+        const oldX = this._pinchX;
+        const oldY = this._pinchY;
+        this._pinching = true;
+        this._pinchX = originX;
+        this._pinchY = originY;
+
+        if (!isPinchStart
+            && this._pinchPanEnabled
+            && (originX !== oldX || originY !== oldY)
+        ) {
+            trigger(this, 'pan', null, e, {
+                dx: originX - oldX,
+                dy: originY - oldY,
+                oldX: oldX,
+                oldY: oldY,
+                newX: originX,
+                newY: originY,
+                isAvailableBehavior: null
+            });
+        }
+
         const scale = e.pinchScale;
-        this._checkTriggerMoveZoom(this, 'zoom', null, e, {
-            scale: scale, originX: e.pinchX, originY: e.pinchY, isAvailableBehavior: null
-        });
+        if (scale !== 1) {
+            trigger(this, 'zoom', null, e, {
+                scale: scale, originX: originX, originY: originY, isAvailableBehavior: null
+            });
+        }
     }
 
     private _checkTriggerMoveZoom<T extends 'scrollMove' | 'zoom'>(


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Improve `RoamController` pinch handling by using the real touch pinch scale, supporting two-finger pan, and capturing pinch gestures consistently.

### Fixed issues

Fixes https://github.com/apache/echarts/issues/18949
Fixes https://github.com/apache/echarts/issues/18113
Related #21417
Related #20939

## Details

### Before: What was the problem?

Touch pinch zoom used a fixed zoom step:

```ts
e.pinchScale > 1 ? 1.1 : 1 / 1.1
```

This made small frame-to-frame pinch changes to zoom exponentially instead of according to the pinch distance.

Pinch also emitted only zoom events. When the pinch center moved, roamable views did not pan with the fingers. Additionally, pinch hit-testing was repeated on every frame, so an active pinch could stop when moving outside the roam area, or be picked up mid-gesture by another overlapping `RoamController`.

### After: How does it behave after the fixing?

`RoamController` now uses the actual `e.pinchScale` reported by ZRender.

Pinch is treated as a two-finger roam gesture:

- `roam: true`: pinch can pan and zoom.
- `roam: 'move'` / `'pan'`: pinch can pan without zooming.
- `roam: 'scale'` / `'zoom'`: pinch can zoom without panning.

A pinch is captured only when it starts from a native `touchstart` inside the valid roam area. Once captured, it continues outside the area like mouse drag, and another `RoamController` cannot pick up the already-moving pinch.

## Document Info

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Manual examples:
- `test/dataZoom-timeAxis.html`
- `dataZoom-rainfall-inside.html`
- `test/geo-map-roam.html`
- `test/graph-layout-roam.html`
- `test/tree-roam.html`
- `test/sankey-roam.html`
- `test/treemap-simple.html`
- `test/treemap-scaleLimit.html`
- `test/graph-thumbnail.html`

I've tested the changes in all the mentioned test examples on an Android phone in Chrome.

### Merging options

- [x] Please squash the commits into a single one when merging.


### Before & After videos

https://github.com/user-attachments/assets/d5159506-e8cb-46eb-b6aa-77a8c56f7e1b

https://github.com/user-attachments/assets/64dfd4c9-fe7f-43ed-8d7e-fb55c5c2242c

https://github.com/user-attachments/assets/8afcd01c-7e56-4c24-b376-a996aa581ab0

https://github.com/user-attachments/assets/f16ad354-a88a-4be4-a194-742614a57005