### PR TITLE
feat(axisPointer): keep pointer on connected charts without data

### DIFF
--- a/src/component/axisPointer/AxisPointerModel.ts
+++ b/src/component/axisPointer/AxisPointerModel.ts
@@ -90,6 +90,8 @@ class AxisPointerModel extends ComponentModel<AxisPointerOption> {
         snap: false,
         triggerTooltip: true,
         triggerEmphasis: true,
+        triggerOnNoData: false,
+        findPointOnConnectedCharts: true,
 
         value: null,
         status: null, // Init value depends on whether handle is used.

--- a/src/component/axisPointer/axisTrigger.ts
+++ b/src/component/axisPointer/axisTrigger.ts
@@ -115,12 +115,12 @@ export default function axisTrigger(
     ecModel: GlobalModel,
     api: ExtensionAPI
 ) {
+    const axisPointerComponent = ecModel.getComponent('axisPointer') as AxisPointerModel;
     const currTrigger = payload.currTrigger;
     let point = [payload.x, payload.y];
     const finder = payload;
     const dispatchAction = payload.dispatchAction || bind(api.dispatchAction, api);
-    const coordSysAxesInfo = (ecModel.getComponent('axisPointer') as AxisPointerModel)
-        .coordSysAxesInfo as CollectedCoordInfo;
+    const coordSysAxesInfo = axisPointerComponent.coordSysAxesInfo as CollectedCoordInfo;
 
     // Pending
     // See #6121. But we are not able to reproduce it yet.
@@ -128,7 +128,10 @@ export default function axisTrigger(
         return;
     }
 
-    if (illegalPoint(point)) {
+    // Chart-wide option. See `CommonAxisPointerOption.findPointOnConnectedCharts`.
+    const findPointOnConnectedCharts = axisPointerComponent.get('findPointOnConnectedCharts');
+
+    if (illegalPoint(point) && findPointOnConnectedCharts) {
         // Used in the default behavior of `connection`: use the sample seriesIndex
         // and dataIndex. And also used in the tooltipView trigger.
         point = findPointFromSeries({
@@ -168,8 +171,13 @@ export default function axisTrigger(
         each(coordSysAxesInfo.coordSysAxesInfo[coordSysKey], function (axisInfo, key) {
             const axis = axisInfo.axis;
             const inputAxisInfo = findInputAxisInfo(inputAxesInfo, axisInfo);
+            // When `triggerOnNoData` is enabled, still trigger this axis even if the point
+            // is illegal (e.g. on a connected chart with no data at the hovered location),
+            // as long as a value is available from the input (the linked value). This is
+            // not applied on `leave`, so the pointer is still hidden when the cursor leaves.
+            const triggerOnNoData = axisInfo.triggerOnNoData && currTrigger !== 'leave' && !!inputAxisInfo;
             // If no inputAxesInfo, no axis is restricted.
-            if (!shouldHide && coordSysContainsPoint && (!inputAxesInfo || inputAxisInfo)) {
+            if ((!shouldHide || triggerOnNoData) && coordSysContainsPoint && (!inputAxesInfo || inputAxisInfo)) {
                 let val = inputAxisInfo && inputAxisInfo.value;
                 if (val == null && !isIllegalPoint) {
                     val = axis.pointToData(point);

--- a/src/component/axisPointer/modelHelper.ts
+++ b/src/component/axisPointer/modelHelper.ts
@@ -50,6 +50,7 @@ interface AxisInfo {
     axisPointerModel: Model<CommonAxisPointerOption>
     triggerTooltip: boolean
     triggerEmphasis: boolean
+    triggerOnNoData: boolean
     involveSeries: boolean
     snap: boolean
     useHandle: boolean
@@ -89,6 +90,7 @@ export function collect(ecModel: GlobalModel, api: ExtensionAPI) {
          *      axisPointerModel,
          *      triggerTooltip,
          *      triggerEmphasis,
+         *      triggerOnNoData,
          *      involveSeries,
          *      snap,
          *      seriesModels,
@@ -197,6 +199,7 @@ function collectAxesInfo(result: CollectionResult, ecModel: GlobalModel, api: Ex
 
             const snap = axisPointerModel.get('snap');
             const triggerEmphasis = axisPointerModel.get('triggerEmphasis');
+            const triggerOnNoData = axisPointerModel.get('triggerOnNoData');
             const axisKey = makeKey(axis.model);
             const involveSeries = triggerTooltip || snap || axis.type === 'category';
 
@@ -208,6 +211,7 @@ function collectAxesInfo(result: CollectionResult, ecModel: GlobalModel, api: Ex
                 axisPointerModel: axisPointerModel,
                 triggerTooltip: triggerTooltip,
                 triggerEmphasis: triggerEmphasis,
+                triggerOnNoData: triggerOnNoData,
                 involveSeries: involveSeries,
                 snap: snap,
                 useHandle: isHandleTrigger(axisPointerModel),

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1783,6 +1783,33 @@ export interface CommonAxisPointerOption {
     triggerEmphasis?: boolean
 
     /**
+     * By default the axisPointer is only displayed when the triggered point maps to
+     * an actual value (i.e. there is data at that location). When set to `true`, the
+     * axisPointer is still displayed even if there is no data at the location, as long
+     * as an axis value is available (e.g. the value linked from a connected chart).
+     *
+     * This is mainly useful for `echarts.connect`-ed charts that have different data:
+     * hovering over one chart at a position where another chart has no data will still
+     * show the axisPointer on the other chart at the linked value.
+     *
+     * Configured per axis (e.g. `xAxis.axisPointer.triggerOnNoData`). Default `false`.
+     */
+    triggerOnNoData?: boolean
+
+    /**
+     * Used by the default behavior of `echarts.connect`. When an action is replayed on
+     * a connected chart, the original pixel point is meaningless on that chart, so by
+     * default a sample point is looked up from the chart's own series (using the sample
+     * `seriesIndex`/`dataIndex`) to position the axisPointer/tooltip.
+     *
+     * Set to `false` to skip this lookup, so the axisPointer is positioned solely by the
+     * linked axis value (see {@link triggerOnNoData}) rather than snapped to a sample data
+     * point. This is a chart-wide option; configure it on the top-level `axisPointer`
+     * component. Default `true` (keeps the legacy behavior).
+     */
+    findPointOnConnectedCharts?: boolean
+
+    /**
      * current value. When using axisPointer.handle, value can be set to define the initial position of axisPointer.
      */
     value?: ScaleDataValue

--- a/test/axisPointer-triggerOnNoData.html
+++ b/test/axisPointer-triggerOnNoData.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            html,
+            body,
+            #main {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+            #chart1,
+            #chart2 {
+                width: 100%;
+                height: 45%;
+            }
+        </style>
+
+        <div id="chart1"></div>
+        <div id="chart2"></div>
+
+        <script>
+            require(["echarts"], function (echarts) {
+                var data1 = [];
+                var data2 = [];
+
+                var timeBase = +new Date();
+                var hour = 1000 * 60 * 60;
+
+                for (var i = 0; i < 100; i++) {
+                    data1.push([timeBase, Math.random() * 4]);
+                    // chart2 only has data for the first 40 points, the rest is null.
+                    data2.push([timeBase, i < 40 ? Math.random() * 14 : null]);
+                    timeBase += hour;
+                }
+
+                function makeOption(data) {
+                    return {
+                        // Chart-wide: do not snap the axisPointer to a sample data
+                        // point on the connected chart. Position it solely by the
+                        // linked axis value instead.
+                        axisPointer: {
+                            findPointOnConnectedCharts: false,
+                        },
+                        tooltip: {
+                            trigger: "axis",
+                            formatter: "{c}",
+                        },
+                        grid: {
+                            top: "8%",
+                            bottom: "12%",
+                        },
+                        xAxis: {
+                            type: "time",
+                            max: timeBase,
+                            axisPointer: {
+                                snap: true,
+                                // Show the axisPointer even where this chart has no data.
+                                triggerOnNoData: true,
+                            },
+                        },
+                        yAxis: {
+                            type: "value",
+                        },
+                        dataZoom: {
+                            type: "inside",
+                        },
+                        series: [
+                            {
+                                type: "scatter",
+                                data: data,
+                                emphasis: {
+                                    disabled: true,
+                                },
+                            },
+                        ],
+                    };
+                }
+
+                var chart1 = testHelper.create(echarts, "chart1", {
+                    title: [
+                        "CONNECTED CHARTS - axisPointer.triggerOnNoData",
+                        "Chart1 has data everywhere. Chart2 only has data in the LEFT ~40%.",
+                        "Hover over chart1 in the region where chart2 has NO data.",
+                        "EXPECTED: the axisPointer line still shows on BOTH charts at the same x position.",
+                    ],
+                    option: makeOption(data1),
+                });
+                var chart2 = testHelper.create(echarts, "chart2", {
+                    title: [
+                        "Chart2 (no data on the right side).",
+                        "With triggerOnNoData:true the axisPointer follows the linked value",
+                        "instead of disappearing when there is no data here.",
+                    ],
+                    option: makeOption(data2),
+                });
+
+                echarts.connect([chart1, chart2]);
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Adds `axisPointer.triggerOnNoData` so connected charts keep showing the axisPointer at the linked axis value even where they have no data, instead of hiding it.

## Details

### Before: What was the problem?

With `echarts.connect`, hovering over one chart replays the action on the others. On a connected chart, the original pixel point is meaningless, so the point is treated as illegal. When that chart also has no data at the sample location, the point stays illegal, `shouldHide` becomes true, and the axisPointer is hidden, even though the hovered axis value is known and the chart has a valid axis range. The pointer disappears on the chart with no data, which is confusing for synced time-series dashboards.

### After: How does it behave after the fixing?

Two opt-in options on `axisPointer` (both default to current behavior):

- `triggerOnNoData` (default `false`): when `true`, the axis is still processed for an illegal point (e.g. on a connected chart) as long as a value is available from the input `axesInfo` (the linked value) and it is not a `leave` event. The pointer is positioned by the axis value, independent of series data. The `leave` guard and the input-axis restriction are preserved, so hide-on-leave and `dispatchAction` axis targeting are unchanged.
- `findPointOnConnectedCharts` (default `true`): chart-wide option to skip looking up a sample series point when the incoming point is illegal, so the pointer follows the linked value instead of snapping to a sample data point.

## Document Info

One of the following should be checked.

- [ ] This PR doesn't relate to document changes
- [x] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#520

(New options `axisPointer.triggerOnNoData` and `axisPointer.findPointOnConnectedCharts` need entries in apache/echarts-doc.)

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/axisPointer-triggerOnNoData.html

### Merging options

- [x] Please squash the commits into a single one when merging.