### PR TITLE
fix(marker): correct markArea on inverse category axis

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -336,8 +336,10 @@ function fixOnBandTicksCoords(
         return false;
     }
 
+    const axisExtent = axis.getExtent();
+    const coordStep = axisExtent[1] >= axisExtent[0] ? bandWidth : -bandWidth;
     each(preTicksCoords, function (ticksItem) {
-        ticksItem.coord -= bandWidth / 2;
+        ticksItem.coord -= coordStep / 2;
     });
 
     const dataExtent = axis.scale.getExtent();
@@ -346,7 +348,7 @@ function fixOnBandTicksCoords(
         preTicksCoords.pop();
     }
     preTicksCoords.push({
-        coord: oldLast.coord + bandWidth,
+        coord: oldLast.coord + coordStep,
         tick: {value: dataExtent[1] + 1},
     });
 

--- a/test/bar-markArea.html
+++ b/test/bar-markArea.html
@@ -43,6 +43,7 @@ under the License.
         <div id="main4"></div>
         <div id="main5"></div>
         <div id="main6"></div>
+        <div id="main7"></div>
 
         <script>
         require([
@@ -493,5 +494,80 @@ under the License.
               });
           });
         </script>
+
+        <script>
+          require([
+              'echarts'
+          ], function (echarts) {
+              var categories = ['San Francisco', 'Houston', 'Washington', 'New York', 'Miami', 'Boston'];
+              var values = [28000, 33000, 30000, 27000, 31000, 39000];
+              function makeBarSeries(xAxisIndex, yAxisIndex) {
+                return {
+                  type: 'bar',
+                  xAxisIndex: xAxisIndex,
+                  yAxisIndex: yAxisIndex,
+                  data: values,
+                  markArea: {
+                    itemStyle: {
+                      color: 'rgba(0, 112, 242, 0.3)'
+                    },
+                    data: [[{ yAxis: 0 }, { yAxis: 0 }]]
+                  },
+                  markLine: {
+                    lineStyle: {
+                      color: 'red',
+                      width: 2,
+                      type: 'solid'
+                    },
+                    symbol: 'none',
+                    data: [{ yAxis: 0 }]
+                  }
+                };
+              }
+
+              var option = {
+                title: [
+                  {
+                    text: 'normal category axis',
+                    left: 12,
+                    top: 55,
+                    textStyle: { fontSize: 12 }
+                  },
+                  {
+                    text: 'inverse category axis',
+                    left: 12,
+                    top: 255,
+                    textStyle: { fontSize: 12 }
+                  }
+                ],
+                grid: [
+                  { left: 150, right: 40, top: 70, height: 130 },
+                  { left: 150, right: 40, top: 270, height: 130 }
+                ],
+                xAxis: [
+                  { type: 'value', gridIndex: 0 },
+                  { type: 'value', gridIndex: 1 }
+                ],
+                yAxis: [
+                  { type: 'category', gridIndex: 0, data: categories },
+                  { type: 'category', gridIndex: 1, data: categories, inverse: true }
+                ],
+                series: [
+                  makeBarSeries(0, 0),
+                  makeBarSeries(1, 1)
+                ]
+              };
+
+              var chart = testHelper.create(echarts, 'main7', {
+                  title: [
+                      'For both panels, the blue markArea and red markLine at **yAxis: 0** should cover **San Francisco**.',
+                      'In the inverse panel, the blue markArea must cover the first/top bar, not Houston. Fix #21652.'
+                  ],
+                  option: option,
+                  height: 480
+              });
+          });
+        </script>
+
     </body>
 </html>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Fixes `markArea` band positioning on inverted category axes.

### Fixed issues

- close #21652: `markArea` on a horizontal bar chart with `yAxis.inverse: true` renders one category band off.

## Details

### Before: What was the problem?

For a horizontal bar chart with an inverted category axis:

```js
yAxis: { type: 'category', inverse: true }
markArea: { data: [[{ yAxis: 0 }, { yAxis: 0 }]] }
```

the `markArea` for the first category rendered on the second category, while `markLine` at the same `{ yAxis: 0 }` value rendered on the correct first category.

The root cause was that `fixOnBandTicksCoords` expanded category tick coordinates to band boundaries using a positive `bandWidth`, assuming coordinates increase as tick values increase. On inverted axes, the coordinate extent is reversed, so the half-band boundary shift moved in the wrong direction.

### After: How does it behave after the fixing?

`markArea` and `markLine` now cover the same category for both normal and inverted category axes.

The fix makes the on-band tick boundary step follow the axis coordinate direction:

- normal extent: use `+bandWidth`
- inverted extent: use `-bandWidth`

Blast radius note: this is unchanged for normal/ascending axis extents because `coordStep === bandWidth` in that case. It is also unchanged for `axisTick.alignWithLabel: true` because `fixOnBandTicksCoords` returns before this code path. Non-category axes are not affected.

A visual regression case was added to `test/bar-markArea.html` with normal and inverted horizontal bar charts. The test overlays a red `markLine` at `{ yAxis: 0 }` so the blue `markArea` can be verified against the same category.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/bar-markArea.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

```sh
npm run checktype
npx eslint src/coord/Axis.ts
git diff --check
```

I also verified the reported repro with SVG SSR before and after the fix:

- before: the inverse-axis `markArea` polygon covered the second band while `markLine` stayed on the first band
- after: the inverse-axis `markArea` polygon covers the first band and aligns with `markLine`