### PR TITLE
fix(dataZoom): guard data shadow for single-point time axis

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -400,7 +400,8 @@ class SliderZoomView extends DataZoomView {
             const areaPoints = [[size[0], 0], [0, 0]];
             const linePoints: number[][] = [];
             const step = thisShadowExtent[1] / (Math.max(1, data.count() - 1));
-            const normalizationConstant = size[0] / (thisDataExtent[1] - thisDataExtent[0]);
+            const thisDataExtentSpan = thisDataExtent[1] - thisDataExtent[0];
+            const normalizationConstant = thisDataExtentSpan ? size[0] / thisDataExtentSpan : 0;
             const isTimeAxis = info.thisAxis.type === 'time';
             let thisCoord = -step;
 

--- a/test/dataZoom-single-datapoint.html
+++ b/test/dataZoom-single-datapoint.html
@@ -38,13 +38,16 @@ under the License.
                    causing visual test failures. Some clients may not support fractional px. */
                 line-height: 18px;
             }
-            #main0 {
+            #main0, #main1, #main2, #main3 {
                 width: 800px;
                 margin: 0 auto;
             }
         </style>
 
         <div id="main0"></div>
+        <div id="main1"></div>
+        <div id="main2"></div>
+        <div id="main3"></div>
 
         <script>
             require(['echarts'], function (echarts /*, data */) {
@@ -86,6 +89,95 @@ under the License.
                         'Position of dataZoom when there is only one data point',
                     ],
                     option: option,
+                });
+
+                function makeDataShadowOption(axisType, data) {
+                    return {
+                        animation: false,
+                        grid: {
+                            left: 60,
+                            right: 30,
+                            top: 25,
+                            bottom: 65
+                        },
+                        xAxis: {
+                            type: axisType
+                        },
+                        yAxis: {
+                            type: 'value',
+                            min: 0,
+                            max: 100
+                        },
+                        dataZoom: [{
+                            type: 'slider',
+                            showDataShadow: true,
+                            showDetail: false,
+                            start: 0,
+                            end: 100,
+                            height: 30,
+                            bottom: 15,
+                            dataBackground: {
+                                lineStyle: {
+                                    color: '#c23531',
+                                    width: 2
+                                },
+                                areaStyle: {
+                                    color: '#c23531',
+                                    opacity: 0.4
+                                }
+                            },
+                            selectedDataBackground: {
+                                lineStyle: {
+                                    color: '#c23531',
+                                    width: 2
+                                },
+                                areaStyle: {
+                                    color: '#c23531',
+                                    opacity: 0.4
+                                }
+                            }
+                        }],
+                        series: [{
+                            type: 'line',
+                            symbolSize: 8,
+                            data: data
+                        }]
+                    };
+                }
+
+                testHelper.create(echarts, 'main1', {
+                    title: [
+                        'Single-point series on a time axis with showDataShadow',
+                        'The slider shadow must render at the left edge (no blank/NaN shadow).'
+                    ],
+                    height: 220,
+                    option: makeDataShadowOption('time', [
+                        [+new Date('2024-01-01'), 42]
+                    ])
+                });
+
+                testHelper.create(echarts, 'main2', {
+                    title: [
+                        'Multi-point series on a time axis with showDataShadow',
+                        'The slider shadow should still render across the slider.'
+                    ],
+                    height: 220,
+                    option: makeDataShadowOption('time', [
+                        [+new Date('2024-01-01'), 30],
+                        [+new Date('2024-01-02'), 70],
+                        [+new Date('2024-01-03'), 45]
+                    ])
+                });
+
+                testHelper.create(echarts, 'main3', {
+                    title: [
+                        'Single-point series on a value axis with showDataShadow',
+                        'The slider shadow should keep rendering at the left edge.'
+                    ],
+                    height: 220,
+                    option: makeDataShadowOption('value', [
+                        [0, 42]
+                    ])
                 });
             });
         </script>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Guard dataZoom slider data-shadow normalization so a single-point time-axis series does not generate NaN shadow geometry.



### Fixed issues

- close #21649


## Details

### Before: What was the problem?

For slider dataZoom with `showDataShadow: true`, `_renderDataShadow` computes a time-axis shadow coordinate with:

```ts
(+thisValue - thisDataExtent[0]) * normalizationConstant
```

`normalizationConstant` was calculated as:

```ts
size[0] / (thisDataExtent[1] - thisDataExtent[0])
```

When the shadow-source series has only one point on a time axis, `thisDataExtent[0] === thisDataExtent[1]`, so the divisor is `0`. This makes `normalizationConstant` become `Infinity`, and the single point computes `0 * Infinity`, producing `NaN`. The NaN coordinate then reaches the shadow polygon/polyline and the slider shadow renders blank/broken.



### After: How does it behave after the fixing?

The normalization divisor is guarded for zero-width extents. In that degenerate single-point case, `normalizationConstant` becomes `0`, so the time-axis shadow coordinate remains finite and maps to the left edge of the slider, consistent with the existing non-time single-point step path.

A visual test was added to `test/dataZoom-single-datapoint.html` covering:

- single-point series on a time axis with `showDataShadow: true`;
- multi-point series on a time axis with `showDataShadow: true`;
- single-point series on a value axis with `showDataShadow: true`.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/dataZoom-single-datapoint.html`

Validation run:

```sh
npm run checktype
npx eslint src/component/dataZoom/SliderZoomView.ts
npm run lint
git diff --check
```

Also verified with a temporary SVG SSR bundle built from the patched `src/` that the added data-shadow cases render finite shadow geometry: single-point time axis, multi-point time axis, and single-point value axis all produce no `NaN` in the SVG output. For the reported single-point time-axis case, the data shadow renders as finite geometry such as `polygon points="710 0 0 0 0 15"` and `polyline points="0 15"`.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

N.A.
