### PR TITLE
fix(line): respect disabled emphasis in hover. close #21634

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -942,8 +942,13 @@ class LineView extends ChartView {
     ) {
         const data = seriesModel.getData();
         const dataIndex = modelUtil.queryDataIndex(data, payload);
+        const emphasisDisabled = seriesModel.getModel('emphasis').get('disabled');
 
         this._changePolyState('emphasis');
+
+        if (emphasisDisabled) {
+            return;
+        }
 
         if (!(dataIndex instanceof Array) && dataIndex != null && dataIndex >= 0) {
             const points = data.getLayout('points');
@@ -1001,6 +1006,7 @@ class LineView extends ChartView {
     ) {
         const data = seriesModel.getData();
         const dataIndex = modelUtil.queryDataIndex(data, payload) as number;
+        const emphasisDisabled = seriesModel.getModel('emphasis').get('disabled');
 
         this._changePolyState('normal');
 
@@ -1011,12 +1017,12 @@ class LineView extends ChartView {
                     data.setItemGraphicEl(dataIndex, null);
                     this.group.remove(symbol);
                 }
-                else {
+                else if (!emphasisDisabled) {
                     symbol.downplay();
                 }
             }
         }
-        else {
+        else if (!emphasisDisabled) {
             // FIXME
             // can not downplay completely.
             // Downplay whole series


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Respect disabled emphasis for line-series tooltip hover symbols.

### Fixed issues

- #21634: Fix dirty-rect repaint corruption for dense canvas line series with tooltip axis-pointer hover.

## Details

### Before: What was the problem?

For dense canvas line series with `showSymbol: false`, `useDirtyRect: true`,
tooltip axis-pointer hover, and `emphasis: { disabled: true }`,
`LineView.highlight()` could still create a temporary hover symbol.

That temporary symbol was later removed during downplay. The add/remove
lifecycle could leave stale or corrupted line pixels when dirty-rect repainting
was enabled.

This reproduced with the issue's ECharts 6.1.0 canvas scenario:

- dense line series
- `showSymbol: false`
- `progressive`
- piecewise `visualMap`
- tooltip `trigger: 'axis'`
- tooltip axis pointer
- `useDirtyRect: true`
- `emphasis: { disabled: true }`

### After: How does it behave after the fixing?

When line-series emphasis is disabled, `LineView.highlight()` no longer creates
or highlights a temporary hover symbol, and `downplay()` avoids symbol/whole
series downplay work for disabled emphasis.

The existing polyline state transition is kept so dirty-rect invalidation still
clears tooltip axis-pointer updates correctly.

Verified with a pixel-diff harness comparing a dirty-rect chart against a
full-repaint control:

- native mouse hover: 0 mismatches
- `showTip` action: 0 mismatches
- settled after `hideTip`: 0 mismatches

Also passed:

```sh
npm run lint
npm run checktype

```


Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This fix was investigated together with ecomfe/zrender#1159. The ZRender
dirty-rect changes improved related behavior but did not fully resolve this
ECharts-side temp-symbol path. The final fix here is independent of ZRender
changes.