### PR TITLE
fix(line): handle empty visualMap color stops. close #18066

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -331,7 +331,10 @@ function getVisualGradient(
         colorStops, coordDim === 'x' ? api.getWidth() : api.getHeight()
     );
     const inRangeStopLen = colorStopsInRange.length;
-    if (!inRangeStopLen && stopLen) {
+    if (!inRangeStopLen) {
+        if (!stopLen) {
+            return outerColors[0] || outerColors[1];
+        }
         // All stops are out of range. All will be the same color.
         return colorStops[0].coord < 0
             ? (outerColors[1] ? outerColors[1] : colorStops[stopLen - 1].color)

--- a/test/ut/spec/component/visualMap/nullBound.test.ts
+++ b/test/ut/spec/component/visualMap/nullBound.test.ts
@@ -1,0 +1,47 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart } from '../../../core/utHelper';
+
+
+describe('visualMap_nullBound', function () {
+    it('does not throw when line visualMap piece bound is null', function () {
+        const chart = createChart();
+
+        expect(function () {
+            chart.setOption({
+                xAxis: {},
+                yAxis: {},
+                visualMap: {
+                    type: 'piecewise',
+                    pieces: [{
+                        lte: null as any,
+                        color: '#ff0000'
+                    }]
+                },
+                series: [{
+                    type: 'line',
+                    data: [1, 2, 3, 4]
+                }]
+            });
+        }).not.toThrow();
+
+        chart.dispose();
+    });
+});


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix line series rendering when a piecewise visualMap piece has a null bound and produces no gradient color stops.



### Fixed issues

<!--
- #xxxx: ...
-->

- #18066: Line charts throw when `visualMap.pieces[].lte` is set to `null`.


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->

When a line series uses a piecewise visualMap with a piece like:

```js
pieces: [{
    lte: null,
    color: '#ff0000'
}]
```

the visualMap metadata can contain `outerColors` but no color stops. `LineView` still tried to read `colorStopsInRange[0].coord`, causing:

```text
TypeError: Cannot read properties of undefined (reading 'coord')
```

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->

Line series no longer throws for this visualMap configuration.

When there are no in-range color stops, `LineView` now handles the empty-stop case and returns the available outer color instead of building a gradient from an empty stops array.

A regression test was added for the null-bound piecewise visualMap case.

Validation:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/component/visualMap/nullBound.test.ts
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/component/visualMap/setOption.test.ts test/ut/spec/component/visualMap/nullBound.test.ts
npm run checktype
```

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/component/visualMap/nullBound.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

N.A.
