### PR TITLE
fix(scale): handle tiny nice intervals. close #21645

### DIFF
--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -229,8 +229,12 @@ export function round(x: number | string, precision: number, returnStr?: boolean
         // precision utils (such as getAcceptableTickPrecision) may return NaN.
         return returnStr ? '' + x : +x;
     }
-    // Avoid range error
-    precision = mathMin(mathMax(0, precision), TO_FIXED_SUPPORTED_PRECISION_MAX);
+    // Avoid range error. Do not clamp large precision to 20 because it may
+    // over-round tiny values such as 3e-21 to zero.
+    if (precision > TO_FIXED_SUPPORTED_PRECISION_MAX) {
+        return returnStr ? '' + x : +x;
+    }
+    precision = mathMax(0, precision);
     // PENDING: 1.005.toFixed(2) is '1.00' rather than '1.01'
     x = (+x).toFixed(precision);
     return (returnStr ? x : +x);

--- a/test/ut/spec/scale/interval.test.ts
+++ b/test/ut/spec/scale/interval.test.ts
@@ -68,6 +68,29 @@ describe('scale_interval', function () {
             expect(ticks[ticks.length - 1].value).toEqual(max);
         });
 
+        it('ticks_tiny_max', function () {
+            chart.setOption({
+                xAxis: {},
+                yAxis: {
+                    type: 'value',
+                    scale: true,
+                    max: 2.324097633474072e-20
+                },
+                series: [{
+                    type: 'line',
+                    data: [1e-20]
+                }]
+            });
+
+            const yAxis = getECModel(chart).getComponent('yAxis', 0) as CartesianAxisModel;
+            const ticks = yAxis.axis.scale.getTicks();
+
+            expect(ticks.length).toBeGreaterThan(2);
+            ticks.forEach(function (tick) {
+                expect(tick.value).toBeFinite();
+            });
+        });
+
         it('ticks_small_value', function () {
             chart.setOption({
                 tooltip: {},

--- a/test/ut/spec/util/number.test.ts
+++ b/test/ut/spec/util/number.test.ts
@@ -958,6 +958,12 @@ describe('util/number', function () {
             expect(nice(3900000000000000000021)).toEqual(5000000000000000000000);
             expect(nice(0.00000000000000000656939, true)).toEqual(0.000000000000000005);
             expect(nice(0.00000000000000000656939)).toEqual(0.00000000000000001);
+            const niceTiny3 = nice(2.648195266948144e-21, true);
+            const niceTiny5 = nice(4.648195266948144e-21, true);
+            expect(niceTiny3).toBeGreaterThan(0);
+            expect(niceTiny3).toBeLessThan(1e-20);
+            expect(niceTiny5).toBeGreaterThan(0);
+            expect(niceTiny5).toBeLessThan(1e-20);
             expect(nice(0.10000000000000000656939, true)).toEqual(0.1);
             expect(nice(0.10000000000000000656939)).toEqual(0.2);
         });


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix tiny value-axis tick calculation so valid sub-`1e-20` extents do not collapse to zero during rounding.



### Fixed issues

- #21645: `yAxis.max` smaller than about `1e-19` could trigger an assertion error during interval tick calculation.


## Details

### Before: What was the problem?

For very small positive value-axis extents, such as a `yAxis.max` of `2.324097633474072e-20`, the tick interval calculation could request a precision greater than the cross-platform `toFixed(20)` limit.

The shared `round` helper clamped that precision to `20`, which could over-round tiny values such as `3e-21` to `0`. This produced invalid interval/nice extent values and could trigger an assertion error in `IntervalScale.setConfig`, preventing the chart from rendering.



### After: How does it behave after the fixing?

When the requested rounding precision is above the supported `toFixed` limit, `round` now returns the numeric value directly instead of clamping to `20` and over-rounding it.

This keeps tiny positive nice intervals finite and non-zero, so value axes with valid small numeric extents can calculate ticks and render successfully.

Added regression coverage in:

- `test/ut/spec/scale/interval.test.ts`
- `test/ut/spec/util/number.test.ts`



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

- `npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/scale/interval.test.ts test/ut/spec/util/number.test.ts`
- `npm run checktype`
- pre-commit `npm run lint`
- `git diff --check`
