### PR TITLE
fix(toolbox): clear global cursor on restore. close #21644

### DIFF
--- a/src/component/toolbox/feature/Restore.ts
+++ b/src/component/toolbox/feature/Restore.ts
@@ -34,6 +34,9 @@ class RestoreOption extends ToolboxFeature<ToolboxRestoreFeatureOption> {
         history.clear(ecModel);
 
         api.dispatchAction({
+            type: 'takeGlobalCursor'
+        });
+        api.dispatchAction({
             type: 'restore',
             from: this.uid
         });

--- a/test/ut/spec/component/toolbox/DataZoom.test.ts
+++ b/test/ut/spec/component/toolbox/DataZoom.test.ts
@@ -1,0 +1,83 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '../../../../../src/echarts';
+import { createChart, getECModel } from '../../../core/utHelper';
+
+
+describe('toolbox/dataZoom', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('restore exits dataZoom select cursor', function () {
+        chart.setOption({
+            toolbox: {
+                feature: {
+                    dataZoom: {},
+                    restore: {}
+                }
+            },
+            xAxis: {},
+            yAxis: {},
+            series: {
+                type: 'line',
+                data: [1, 2, 3]
+            }
+        });
+
+        chart.dispatchAction({
+            type: 'takeGlobalCursor',
+            key: 'dataZoomSelect',
+            dataZoomSelectActive: true
+        });
+
+        const dataZoomFeature = getDataZoomFeature(chart);
+
+        expect(dataZoomFeature._isZoomActive).toEqual(true);
+        expect(dataZoomFeature._brushController._brushType).toEqual('auto');
+        expect(dataZoomFeature.model.get(['iconStatus', 'zoom'])).toEqual('emphasis');
+
+        const restoreFeature = getToolboxFeature(chart, 'restore');
+        restoreFeature.onclick(restoreFeature.ecModel, restoreFeature.api);
+
+        expect(dataZoomFeature._brushController._brushType).toBeFalsy();
+        expect(dataZoomFeature._isZoomActive).toEqual(false);
+        expect(getDataZoomFeature(chart).model.get(['iconStatus', 'zoom'])).toEqual('normal');
+    });
+
+});
+
+function getDataZoomFeature(chart: EChartsType): any {
+    return getToolboxFeature(chart, 'dataZoom');
+}
+
+function getToolboxFeature(chart: EChartsType, featureName: string): any {
+    const toolboxModel = getECModel(chart).getComponent('toolbox');
+    // @ts-ignore access internal view state for regression verification.
+    const toolboxView = chart._componentsMap[toolboxModel.__viewId] as any;
+    return toolboxView._features.get(featureName);
+}


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Reset the active toolbox dataZoom selection cursor when toolbox restore is clicked.



### Fixed issues

- #21644: Restore feature does not properly reset the toolbox dataZoom cursor state.


## Details

### Before: What was the problem?

After activating toolbox dataZoom selection and then clicking toolbox restore, the chart data range was restored, but the dataZoom selection cursor/brush state could remain active.

This left the chart in the zoom selection interaction mode after restore.



### After: How does it behave after the fixing?

Toolbox restore now releases the global cursor before dispatching the restore action.

This disables the active dataZoom select brush state, restores the toolbox zoom icon to normal, and prevents the stale zoom selection cursor from remaining active after restore.

A unit test was added for the toolbox dataZoom restore path.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/component/toolbox/DataZoom.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Validation run:

- `npx jest --config test/ut/jest.config.cjs --coverage=false test/ut/spec/component/toolbox/DataZoom.test.ts --runInBand`
- `npx eslint src/component/toolbox/feature/Restore.ts test/ut/spec/component/toolbox/DataZoom.test.ts`
- `git diff --check`
- `npm run checktype`
