### PR TITLE
fix(core): reset process flag on option error. close #15037

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -774,7 +774,15 @@ class ECharts extends Eventful<ECEventDefinition> {
             ecModel.init(null, null, null, theme, this._locale, optionManager);
         }
 
-        this._model.setOption(option as ECBasicOption, { replaceMerge }, optionPreprocessorFuncs);
+        try {
+            this._model.setOption(option as ECBasicOption, { replaceMerge }, optionPreprocessorFuncs);
+        }
+        catch (e) {
+            this[PENDING_UPDATE] = null;
+            this[IN_EC_CYCLE_KEY] = false;
+
+            throw e;
+        }
 
         const updateParams = {
             seriesTransition: transitionOpt,

--- a/test/ut/spec/api/setOption.test.ts
+++ b/test/ut/spec/api/setOption.test.ts
@@ -1,0 +1,143 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '../../../../src/echarts';
+import { createChart, removeChart } from '../../core/utHelper';
+
+const QUOTE = String.fromCharCode(96);
+const MAIN_PROCESS_ERROR = '[ECharts] ' + QUOTE + 'setOption' + QUOTE
+    + ' should not be called during main process.';
+
+describe('api/setOption', function () {
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        removeChart(chart);
+    });
+
+    it('recovers from an invalid calendar option error', function () {
+        const oldConsoleErr = console.error;
+        console.error = jest.fn();
+
+        try {
+            expect(function () {
+                chart.setOption({
+                    calendar: {
+                        range: '999'
+                    },
+                    visualMap: {
+                        show: false,
+                        min: 0,
+                        max: 10
+                    },
+                    series: {
+                        type: 'heatmap',
+                        coordinateSystem: 'calendar',
+                        data: []
+                    }
+                });
+            }).toThrow();
+        }
+        finally {
+            console.error = oldConsoleErr;
+        }
+
+        const consoleErr = jest.fn();
+        console.error = consoleErr;
+
+        try {
+            expect(function () {
+                chart.setOption({
+                    calendar: {
+                        range: '2020'
+                    },
+                    visualMap: {
+                        show: false,
+                        min: 0,
+                        max: 10
+                    },
+                    series: {
+                        type: 'heatmap',
+                        coordinateSystem: 'calendar',
+                        data: []
+                    }
+                });
+            }).not.toThrow();
+        }
+        finally {
+            console.error = oldConsoleErr;
+        }
+
+        expect(consoleErr).not.toHaveBeenCalledWith(MAIN_PROCESS_ERROR);
+        expect((chart.getOption().calendar as any[])[0].range).toEqual('2020');
+    });
+
+    it('resets the main process state when option merge throws', function () {
+        expect(function () {
+            chart.setOption({
+                xAxis: {
+                    data: ['a']
+                },
+                yAxis: {},
+                series: [
+                    {
+                        id: 'duplicate',
+                        type: 'line',
+                        data: [1]
+                    },
+                    {
+                        id: 'duplicate',
+                        type: 'line',
+                        data: [2]
+                    }
+                ]
+            });
+        }).toThrowError(/duplicate/);
+
+        const oldConsoleErr = console.error;
+        const consoleErr = jest.fn();
+        console.error = consoleErr;
+
+        try {
+            chart.setOption({
+                xAxis: {
+                    data: ['a']
+                },
+                yAxis: {},
+                series: [
+                    {
+                        id: 'valid',
+                        type: 'line',
+                        data: [1]
+                    }
+                ]
+            });
+        }
+        finally {
+            console.error = oldConsoleErr;
+        }
+
+        expect(consoleErr).not.toHaveBeenCalledWith(MAIN_PROCESS_ERROR);
+        expect((chart.getOption().series as any[])[0].id).toEqual('valid');
+    });
+});


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Reset the ECharts main-process state when `setOption` fails during option merge so the same chart instance can recover on later valid `setOption` calls.



### Fixed issues

- #15037: Invalid calendar options could leave the chart instance stuck in the main process state.



## Details

### Before: What was the problem?

If `setOption` threw while merging options, ECharts had already entered the main process state but did not reset that state before rethrowing.

After that, later valid `setOption` calls on the same chart instance could be blocked with:

```text
[ECharts] `setOption` should not be called during main process.
```

This affected the reported calendar case where an invalid intermediate `calendar.range` value could poison the chart instance and prevent recovery.



### After: How does it behave after the fixing?

`setOption` now resets the pending update and main-process flags when option merge throws, then rethrows the original error.

This keeps the original error behavior for invalid options, but allows the same chart instance to accept a later valid `setOption`.

Regression tests were added for:

- recovery after an invalid calendar option;
- recovery after an option merge error caused by duplicate component ids.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/api/setOption.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/api/setOption.test.ts
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/model/Global.test.ts
npm run checktype
npm run lint
git diff --check
```