### PR TITLE
fix(axis): respect custom axis tick interval. close #17967

### DIFF
--- a/src/coord/Axis.ts
+++ b/src/coord/Axis.ts
@@ -189,6 +189,7 @@ class Axis {
             this,
             preTicksCoords,
             alignWithLabel,
+            result.tickCategoryInterval,
         );
 
         return map(preTicksCoords, function (item) {
@@ -318,6 +319,7 @@ function fixOnBandTicksCoords(
         tick: ScaleTick
     }[],
     alignWithLabel: boolean,
+    tickCategoryInterval: number | NullUndefined,
     // return: whether coords are modified according to `onBand`.
 ): boolean {
     const ticksLen = preTicksCoords.length;
@@ -340,15 +342,17 @@ function fixOnBandTicksCoords(
         ticksItem.coord -= bandWidth / 2;
     });
 
-    const dataExtent = axis.scale.getExtent();
-    const oldLast = preTicksCoords[ticksLen - 1];
-    if (oldLast.tick.offInterval) {
-        preTicksCoords.pop();
+    if (tickCategoryInterval != null) {
+        const dataExtent = axis.scale.getExtent();
+        const oldLast = preTicksCoords[ticksLen - 1];
+        if (oldLast.tick.offInterval) {
+            preTicksCoords.pop();
+        }
+        preTicksCoords.push({
+            coord: oldLast.coord + bandWidth,
+            tick: {value: dataExtent[1] + 1},
+        });
     }
-    preTicksCoords.push({
-        coord: oldLast.coord + bandWidth,
-        tick: {value: dataExtent[1] + 1},
-    });
 
     return true;
 }

--- a/src/coord/axisTickLabelBuilder.ts
+++ b/src/coord/axisTickLabelBuilder.ts
@@ -501,9 +501,10 @@ function makeTicksLabelsByCategoryIntervalNumOrCb(
                 // It is time consuming for large category data.
                 const isOnInterval = !!categoryInterval(tickObj.value, tickLabel);
                 tickObj.offInterval = !isOnInterval;
-                // axis extent min max labels should be always included and the display strategy
-                // is adopted uniformly later in `AxisBuilder`.
-                if (!isOnInterval && !isExtentBoundary) {
+                // Axis extent min max labels should be always included and the display strategy
+                // is adopted uniformly later in `AxisBuilder`. For ticks, keep strictly to the
+                // callback result.
+                if (!isOnInterval && (onlyTick || !isExtentBoundary)) {
                     return;
                 }
             }

--- a/test/ut/spec/scale/interval.test.ts
+++ b/test/ut/spec/scale/interval.test.ts
@@ -115,6 +115,57 @@ describe('scale_interval', function () {
     });
 
 
+    describe('categoryAxisTickInterval', function () {
+        it('should respect custom axisTick interval callback exactly', function () {
+            const categoryData = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+            chart.setOption({
+                xAxis: {
+                    type: 'category',
+                    data: categoryData,
+                    axisTick: {
+                        interval: function (categoryIndex: number, value: string) {
+                            return value === 'Mon';
+                        }
+                    }
+                },
+                yAxis: {},
+                series: [{
+                    type: 'bar',
+                    data: [1, 2, 3, 4, 5, 6, 7]
+                }]
+            });
+
+            const xAxis = getECModel(chart).getComponent('xAxis', 0) as CartesianAxisModel;
+            expect(xAxis.axis.getTicksCoords().map(tick => tick.tickValue)).toEqual([2]);
+        });
+
+        it('should not append an end tick for custom axisTick interval callback', function () {
+            const categoryData = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+            chart.setOption({
+                xAxis: {
+                    type: 'category',
+                    data: categoryData,
+                    axisTick: {
+                        interval: function (categoryIndex: number) {
+                            return categoryIndex === 2 || categoryIndex === 5;
+                        }
+                    }
+                },
+                yAxis: {},
+                series: [{
+                    type: 'bar',
+                    data: [1, 2, 3, 4, 5, 6, 7]
+                }]
+            });
+
+            const xAxis = getECModel(chart).getComponent('xAxis', 0) as CartesianAxisModel;
+            expect(xAxis.axis.getTicksCoords().map(tick => tick.tickValue)).toEqual([2, 5]);
+        });
+    });
+
+
     describe('ticks', function () {
 
         function randomNumber(quantity: number): number {


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fix category axis ticks so `axisTick.interval` callback results are respected exactly.



### Fixed issues

- #17967: Category axis ticks added boundary ticks even when a custom `axisTick.interval` callback did not select them.


## Details

### Before: What was the problem?

When `xAxis.axisTick.interval` was a callback on a category axis, ECharts still kept extent-boundary ticks internally.

That caused two incorrect cases:

- if the callback matched only one category, an extra tick appeared before the first bar;
- if the callback matched multiple categories, an extra tick appeared after the last bar.



### After: How does it behave after the fixing?

Function-based `axisTick.interval` now keeps ticks strictly according to the callback result.

The min/max boundary preservation remains for axis labels, where the existing label display strategy needs it, but custom axis tick callbacks no longer receive forced boundary ticks.

Validation:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/scale/interval.test.ts
npm run checktype
npm run lint
git --no-pager diff --check
```



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Added regression coverage in `test/ut/spec/scale/interval.test.ts`.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

N.A.
