### PR TITLE
fix(marker): respect markLine z2 for labels. close #21650

### DIFF
--- a/src/component/marker/MarkerView.ts
+++ b/src/component/marker/MarkerView.ts
@@ -115,7 +115,7 @@ function updateZ(
 
         if (markerModel && markerDraw && markerDraw.group) {
             const { z, zlevel } = retrieveZInfo(markerModel);
-            traverseUpdateZ(markerDraw.group, z, zlevel);
+            traverseUpdateZ(markerDraw.group, z, zlevel, type === 'markLine' ? 0 : 2);
         }
     });
 }

--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -843,8 +843,9 @@ export function traverseUpdateZ(
     el: Element,
     z: number,
     zlevel: number,
+    labelZ2Lift?: number
 ): void {
-    doUpdateZ(el, z, zlevel, -Infinity);
+    doUpdateZ(el, z, zlevel, -Infinity, labelZ2Lift == null ? 2 : labelZ2Lift);
 }
 
 function doUpdateZ(
@@ -855,6 +856,7 @@ function doUpdateZ(
     //  e.g. in graph, edge labels should be above node elements.
     //  Currently impl does not guarantee that.
     maxZ2: number,
+    labelZ2Lift: number
 ): number {
     // `ignoreModelZ` is used to intentionally lift elements to cover other elements,
     // where maxZ2 (for label.z2) should also not be counted for its parents.
@@ -876,7 +878,8 @@ function doUpdateZ(
                     children[i],
                     z,
                     zlevel,
-                    maxZ2
+                    maxZ2,
+                    labelZ2Lift
                 ),
                 maxZ2
             );
@@ -899,7 +902,7 @@ function doUpdateZ(
         label.zlevel = zlevel;
         // lift z2 of text content
         // TODO if el.emphasis.z2 is spcefied, what about textContent.
-        isFinite(maxZ2) && (label.z2 = maxZ2 + 2);
+        isFinite(maxZ2) && (label.z2 = maxZ2 + labelZ2Lift);
     }
     if (labelLine) {
         const textGuideLineConfig = el.textGuideLineConfig;

--- a/test/marker-z-z2.html
+++ b/test/marker-z-z2.html
@@ -33,6 +33,7 @@ under the License.
     <div id="main1"></div>
     <div id="main2"></div>
     <div id="main3"></div>
+    <div id="main4"></div>
 
     <script>
         require(["echarts"], function (echarts) {
@@ -582,6 +583,78 @@ under the License.
             console.log(chart)
         });
     </script>
+
+    <script>
+        require(["echarts"], function (echarts) {
+            var option = {
+                animation: false,
+                grid: {
+                    left: 80,
+                    right: 80,
+                    top: 60,
+                    bottom: 80
+                },
+                xAxis: {
+                    type: "category",
+                    data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+                },
+                yAxis: {
+                    type: "value"
+                },
+                series: [
+                    {
+                        type: "line",
+                        data: [10, 20, 30, 40, 50, 60, 70],
+                        markLine: {
+                            symbol: "none",
+                            label: {
+                                show: true,
+                                formatter: "{b}",
+                                position: "middle",
+                                fontSize: 30
+                            },
+                            lineStyle: {
+                                width: 16,
+                                opacity: 0.9
+                            },
+                            data: [
+                                {
+                                    name: "red z2:1",
+                                    yAxis: 35,
+                                    z2: 1,
+                                    lineStyle: {
+                                        color: "red"
+                                    },
+                                    label: {
+                                        color: "red"
+                                    }
+                                },
+                                {
+                                    name: "blue z2:2",
+                                    yAxis: 35,
+                                    z2: 2,
+                                    lineStyle: {
+                                        color: "blue"
+                                    },
+                                    label: {
+                                        color: "blue"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            };
+            testHelper.create(echarts, "main4", {
+                option: option,
+                title: [
+                    "MarkLine item z2 should also order labels",
+                    "Blue line and blue label (z2:2) should be above the red label (z2:1)."
+                ]
+            });
+        });
+    </script>
+
 </body>
 
 </html>


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Makes `markLine` labels follow the same item `z2` ordering as their corresponding markLine graphic.



### Fixed issues

- #21650: `markLine.data[].z2` affected the line but not the label, so labels could render above higher-`z2` markLines.



## Details

### Before: What was the problem?

`markLine` item `z2` was applied to the line path, but the attached label received the default text-content z2 lift from `traverseUpdateZ`.

That meant a lower-`z2` markLine label could still be rendered above a higher-`z2` markLine. In the reported case, two markLines with different `z2` values ordered their lines correctly, but their labels did not follow the same ordering.



### After: How does it behave after the fixing?

`traverseUpdateZ` now supports a configurable label z2 lift while preserving the existing default behavior.

`MarkerView` uses a zero label lift for `markLine`, so the label keeps the same z2 ordering as the markLine item. `markPoint` and `markArea` keep the previous default label lift behavior.

A visual case was added to `test/marker-z-z2.html` where two overlapping markLines use `z2: 1` and `z2: 2`; the blue `z2: 2` line and label should render above the red `z2: 1` label.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/marker-z-z2.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

- `npm run checktype`
- `npm run build`
- `npx eslint src/util/graphic.ts src/component/marker/MarkerView.ts`
- `git diff --check`

No `dist/` files are included in this PR.
