### PR TITLE
fix(tooltip): apply textStyle in richText formatter

### DIFF
--- a/src/component/tooltip/TooltipRichContent.ts
+++ b/src/component/tooltip/TooltipRichContent.ts
@@ -111,11 +111,7 @@ class TooltipRichContent {
         ] as const, propName => {
             (this.el.style as any)[propName] = tooltipModel.get(propName);
         });
-        zrUtil.each([
-            'textShadowBlur', 'textShadowOffsetX', 'textShadowOffsetY'
-        ] as const, propName => {
-            this.el.style[propName] = textStyleModel.get(propName) || 0;
-        });
+        applyRichTextStyle(this.el.style, textStyleModel);
 
         this._zr.add(this.el);
 
@@ -214,6 +210,30 @@ class TooltipRichContent {
 
     dispose() {
         this._zr.remove(this.el);
+    }
+}
+
+function applyRichTextStyle(
+    style: TextStyleProps,
+    textStyleModel: Model<TooltipOption['textStyle']>
+) {
+    zrUtil.each([
+        'fontStyle', 'fontWeight', 'fontSize', 'fontFamily', 'lineHeight',
+        'textShadowBlur', 'textShadowOffsetX', 'textShadowOffsetY'
+    ] as const, propName => {
+        const val = textStyleModel.get(propName);
+        if (val != null) {
+            (style as any)[propName] = val;
+        }
+    });
+
+    const textBorderColor = textStyleModel.get('textBorderColor');
+    if (textBorderColor != null) {
+        style.stroke = textBorderColor;
+    }
+    const textBorderWidth = textStyleModel.get('textBorderWidth');
+    if (textBorderWidth != null) {
+        style.lineWidth = textBorderWidth;
     }
 }
 

--- a/test/tooltip-textStyle.html
+++ b/test/tooltip-textStyle.html
@@ -118,6 +118,11 @@ under the License.
                 tooltip: {
                     textStyle: {
                         fontSize: 20,
+                        fontStyle: 'italic',
+                        fontWeight: 'bold',
+                        fontFamily: 'monospace',
+                        textBorderColor: 'blue',
+                        textBorderWidth: 1,
                         textShadowColor: 'red',
                         textShadowBlur: 10,
                         textShadowOffsetX: 10,
@@ -137,7 +142,7 @@ under the License.
                 title: [
                     'trigger: **"item"**',
                     'renderMode: **"richText"**',
-                    'It should have red text shadow and font size being 20px'
+                    'It should use monospace bold italic text, blue text border, red text shadow, and 20px font size'
                 ],
                 option: option
                 // height: 300,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Apply tooltip `textStyle` font and text-border options to richText tooltip content when a formatter returns plain text.



### Fixed issues

- #18339: `tooltip.textStyle` was not fully applied when `tooltip.renderMode` was `richText` and `formatter` was used.


## Details

### Before: What was the problem?

When a tooltip used `renderMode: 'richText'` with a formatter such as `formatter: 'Data: {c}'`, the formatter output was rendered as the root ZRender text element. `TooltipRichContent` only copied a small subset of `tooltip.textStyle` to that root richText element, so options such as `fontStyle`, `fontWeight`, `fontFamily`, and text border settings were ignored even though the same style intent works in HTML tooltip mode.



### After: How does it behave after the fixing?

The richText tooltip root text style now applies the relevant `tooltip.textStyle` fields directly, including font style, weight, size, family, line height, text shadow offsets/blur, and text border color/width. The existing `test/tooltip-textStyle.html` richText formatter case was extended to cover bold italic monospace text with a text border.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/tooltip-textStyle.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

- `npx eslint src/component/tooltip/TooltipRichContent.ts`
- `npm run checktype`
- `git diff --check`
- `npm run build`

`npm run build` generated `dist/` files locally for validation only; they were reverted and are not included in this PR.
