### PR TITLE
fix(radar): respect axisName width and overflow

### DIFF
--- a/src/component/axis/AxisBuilder.ts
+++ b/src/component/axis/AxisBuilder.ts
@@ -908,6 +908,8 @@ const builders: Record<AxisBuilderAxisPartName, AxisElementsBuilder> = {
         const maxWidth = retrieve(
             cfg.raw.nameTruncateMaxWidth, truncateOpt.maxWidth, axisNameAvailableWidth
         );
+        const textOverflow = retrieve2(textStyleModel.get('overflow'), 'truncate');
+        const textWidth = retrieve2(textStyleModel.get('width'), maxWidth) as number;
 
         const nameMarginLevel = extraParams.nameMarginLevel || 0;
 
@@ -919,8 +921,8 @@ const builders: Record<AxisBuilderAxisPartName, AxisElementsBuilder> = {
             style: createTextStyle(textStyleModel, {
                 text: name,
                 font: textFont,
-                overflow: 'truncate',
-                width: maxWidth,
+                overflow: textOverflow,
+                width: textWidth,
                 ellipsis,
                 fill: textStyleModel.getTextColor()
                     || axisModel.get(['axisLine', 'lineStyle', 'color']) as ColorString,

--- a/test/radar-axis.html
+++ b/test/radar-axis.html
@@ -40,6 +40,9 @@ under the License.
         <div id="main0"></div>
 
 
+        <div id="main1"></div>
+
+
         <script>
         require(['echarts'], function (echarts) {
             var option;
@@ -106,6 +109,43 @@ under the License.
             });
         });
         </script>
+
+
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = {
+                radar: {
+                    radius: 100,
+                    axisName: {
+                        width: 50,
+                        overflow: 'break',
+                        color: '#333'
+                    },
+                    indicator: [
+                        { name: 'Very long radar indicator label', max: 100 },
+                        { name: 'Second very long radar indicator label', max: 100 },
+                        { name: 'Third very long radar indicator label', max: 100 }
+                    ]
+                },
+                series: [{
+                    type: 'radar',
+                    data: [{
+                        value: [50, 60, 70]
+                    }]
+                }]
+            };
+
+            testHelper.create(echarts, 'main1', {
+                title: [
+                    'Radar axisName width and overflow',
+                    'Long radar indicator names should wrap within 50px'
+                ],
+                option: option
+            });
+        });
+        </script>
+
 
 
     </body>


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Allow radar indicator axis names to respect configured `axisName.width` and `axisName.overflow` instead of always using the internal truncate fallback.



### Fixed issues

- #14449: Radar indicator name `width` and `overflow` settings were not taking effect.


## Details

### Before: What was the problem?

Radar indicator names are rendered through the shared axis-name builder. That builder always passed `overflow: 'truncate'` and `width: maxWidth` as fixed style values for axis names, so user-provided radar `axisName` text style options such as:

```js
radar: {
    axisName: {
        width: 50,
        overflow: 'break'
    }
}
```

were overwritten before reaching the ZRender text element. In an SSR reproduction, long radar indicator labels remained a single SVG `<text>` element even with `width: 50` and `overflow: 'break'`.



### After: How does it behave after the fixing?

Axis-name rendering now uses `nameTextStyle` / radar `axisName` `overflow` and `width` when they are provided, while preserving the existing truncate fallback when they are not. With `width: 50` and `overflow: 'break'`, the SSR output now emits multiple text lines for long radar indicator labels.

A focused visual case was added to `test/radar-axis.html` to cover long radar indicator names wrapping within `50px`.


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/radar-axis.html`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

- `npx eslint src/component/axis/AxisBuilder.ts`
- `npm run checktype`
- `git diff --check`
- `npm run build:lib && npm run build`

`npm run build:lib && npm run build` generated build outputs locally for validation only; generated files were reverted and are not included in this PR.
