### PR TITLE
fix(graph): edge endpoints follow symbol shape. close #10563

### DIFF
--- a/src/chart/graph/adjustEdge.ts
+++ b/src/chart/graph/adjustEdge.ts
@@ -19,15 +19,62 @@
 
 import * as curveTool from 'zrender/src/core/curve';
 import * as vec2 from 'zrender/src/core/vector';
-import {getSymbolSize} from './graphHelper';
-import Graph from '../../data/Graph';
+import { normalizeSymbolSize, normalizeSymbolOffset } from '../../util/symbol';
+import {
+    getSymbolBoundaryDistance,
+    getSymbolContainChecker,
+    symbolRotateToRad
+} from './nodeShapeHelper';
+import Graph, { GraphNode } from '../../data/Graph';
+
+const quadraticAt = curveTool.quadraticAt;
+const v2DistSquare = vec2.distSquare;
+const mathAbs = Math.abs;
+
+// Curve sampling resolution used to locate where a quadratic edge crosses a node outline.
+const CURVE_SAMPLES = 20;
+const CURVE_BISECT_ITERATIONS = 12;
+
+interface NodeShapeParams {
+    symbolType: string
+    // Half already folded into scale by nodeShapeHelper; these are full sizes/offsets in px,
+    // pre-multiplied by the node global scale.
+    size: number[]
+    rotateRad: number
+    keepAspect: boolean
+    offset: number[]
+}
+
+/**
+ * Collect the node's symbol geometry (already scaled by the graph global scale) needed to probe
+ * its outline. All of these visuals are populated by `visual/symbol` before the view renders.
+ */
+function getNodeShapeParams(node: GraphNode, globalScale: number): NodeShapeParams {
+    const rawSize = normalizeSymbolSize(node.getVisual('symbolSize'));
+    const rawOffset = normalizeSymbolOffset(node.getVisual('symbolOffset'), rawSize);
+    return {
+        symbolType: node.getVisual('symbol') || 'circle',
+        size: [rawSize[0] * globalScale, rawSize[1] * globalScale],
+        rotateRad: symbolRotateToRad(node.getVisual('symbolRotate')),
+        keepAspect: node.getVisual('symbolKeepAspect'),
+        offset: rawOffset ? [rawOffset[0] * globalScale, rawOffset[1] * globalScale] : null
+    };
+}
+
+function getNodeBoundaryDistance(
+    node: GraphNode, globalScale: number, dirX: number, dirY: number
+): number {
+    const p = getNodeShapeParams(node, globalScale);
+    return getSymbolBoundaryDistance(p.symbolType, p.size, p.rotateRad, p.keepAspect, p.offset, dirX, dirY);
+}
 
 const v1: number[] = [];
 const v2: number[] = [];
 const v3: number[] = [];
-const quadraticAt = curveTool.quadraticAt;
-const v2DistSquare = vec2.distSquare;
-const mathAbs = Math.abs;
+/**
+ * Legacy circle intersection, kept as a fallback for the rare cases where the generic outline
+ * search cannot find a crossing (e.g. an unfillable node symbol or a degenerate offset).
+ */
 function intersectCurveCircle(
     curvePoints: number[][],
     center: number[],
@@ -94,14 +141,75 @@ function intersectCurveCircle(
     return t;
 }
 
-// Adjust edge to avoid
-export default function adjustEdge(graph: Graph, scale: number) {
+/**
+ * Find the parameter `t` where the quadratic `curvePoints` crosses `node`'s transformed outline.
+ * The node sits at one end of the curve (`fromStart` ? `t = 0` : `t = 1`), which is inside the
+ * outline; we walk toward the other end to find the exit crossing, then refine by bisection.
+ * Falls back to the circle intersection if no clean crossing is found.
+ */
+function intersectCurveNode(
+    curvePoints: number[][],
+    node: GraphNode,
+    globalScale: number,
+    fromStart: boolean
+): number {
+    const p0 = curvePoints[0];
+    const p1 = curvePoints[1];
+    const p2 = curvePoints[2];
+    const p = getNodeShapeParams(node, globalScale);
+
+    const cx = fromStart ? p0[0] : p2[0];
+    const cy = fromStart ? p0[1] : p2[1];
+    const contain = getSymbolContainChecker(p.symbolType, p.size, p.rotateRad, p.keepAspect, p.offset);
+
+    function isInside(t: number): boolean {
+        const x = quadraticAt(p0[0], p1[0], p2[0], t);
+        const y = quadraticAt(p0[1], p1[1], p2[1], t);
+        return contain(x - cx, y - cy);
+    }
+
+    // Bracket the outline crossing between an inside `t` and an adjacent outside `t`.
+    let inT = fromStart ? 0 : 1;
+    let outT = -1;
+    if (isInside(inT)) {
+        for (let i = 1; i <= CURVE_SAMPLES; i++) {
+            const t = fromStart ? i / CURVE_SAMPLES : 1 - i / CURVE_SAMPLES;
+            if (!isInside(t)) {
+                outT = t;
+                break;
+            }
+            inT = t;
+        }
+    }
+
+    if (outT < 0) {
+        // Endpoint not inside its own outline, or the whole curve lies inside it.
+        const radius = Math.max(p.size[0], p.size[1]) / 2;
+        return intersectCurveCircle(curvePoints, [cx, cy], radius);
+    }
+
+    let lo = inT;
+    let hi = outT;
+    for (let i = 0; i < CURVE_BISECT_ITERATIONS; i++) {
+        const mid = (lo + hi) / 2;
+        if (isInside(mid)) {
+            lo = mid;
+        }
+        else {
+            hi = mid;
+        }
+    }
+    return (lo + hi) / 2;
+}
+
+// Adjust edge endpoints so an edge's end-symbol sits flush against the node outline instead of
+// being hidden underneath it, accounting for the node symbol's shape and transform.
+export default function adjustEdge(graph: Graph, globalScale: number) {
     const tmp0: number[] = [];
     const quadraticSubdivide = curveTool.quadraticSubdivide;
     const pts: number[][] = [[], [], []];
     const pts2: number[][] = [[], []];
     const v: number[] = [];
-    scale /= 2;
 
     graph.eachEdge(function (edge, idx) {
         const linePoints = edge.getLayout();
@@ -124,9 +232,7 @@ export default function adjustEdge(graph: Graph, scale: number) {
             vec2.copy(pts[1], originalPoints[2]);
             vec2.copy(pts[2], originalPoints[1]);
             if (fromSymbol && fromSymbol !== 'none') {
-                const symbolSize = getSymbolSize(edge.node1);
-
-                const t = intersectCurveCircle(pts, originalPoints[0], symbolSize * scale);
+                const t = intersectCurveNode(pts, edge.node1, globalScale, true);
                 // Subdivide and get the second
                 quadraticSubdivide(pts[0][0], pts[1][0], pts[2][0], t, tmp0);
                 pts[0][0] = tmp0[3];
@@ -136,9 +242,7 @@ export default function adjustEdge(graph: Graph, scale: number) {
                 pts[1][1] = tmp0[4];
             }
             if (toSymbol && toSymbol !== 'none') {
-                const symbolSize = getSymbolSize(edge.node2);
-
-                const t = intersectCurveCircle(pts, originalPoints[1], symbolSize * scale);
+                const t = intersectCurveNode(pts, edge.node2, globalScale, false);
                 // Subdivide and get the first
                 quadraticSubdivide(pts[0][0], pts[1][0], pts[2][0], t, tmp0);
                 pts[1][0] = tmp0[1];
@@ -160,15 +264,14 @@ export default function adjustEdge(graph: Graph, scale: number) {
             vec2.sub(v, pts2[1], pts2[0]);
             vec2.normalize(v, v);
             if (fromSymbol && fromSymbol !== 'none') {
-
-                const symbolSize = getSymbolSize(edge.node1);
-
-                vec2.scaleAndAdd(pts2[0], pts2[0], v, symbolSize * scale);
+                // Approach direction at node1 points toward node2.
+                const dist = getNodeBoundaryDistance(edge.node1, globalScale, v[0], v[1]);
+                vec2.scaleAndAdd(pts2[0], pts2[0], v, dist);
             }
             if (toSymbol && toSymbol !== 'none') {
-                const symbolSize = getSymbolSize(edge.node2);
-
-                vec2.scaleAndAdd(pts2[1], pts2[1], v, -symbolSize * scale);
+                // Approach direction at node2 points toward node1.
+                const dist = getNodeBoundaryDistance(edge.node2, globalScale, -v[0], -v[1]);
+                vec2.scaleAndAdd(pts2[1], pts2[1], v, -dist);
             }
             vec2.copy(linePoints[0], pts2[0]);
             vec2.copy(linePoints[1], pts2[1]);

--- a/src/chart/graph/nodeShapeHelper.ts
+++ b/src/chart/graph/nodeShapeHelper.ts
@@ -1,0 +1,345 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+/**
+ * Shape-aware geometry helpers for graph edge endpoints.
+ *
+ * The graph series offsets an edge's end-symbol away from the node center so it is not hidden
+ * under the node. Historically that offset was a plain circle radius (`symbolSize / 2`), which is
+ * wrong for any non-circular / non-uniformly-scaled / rotated / SVG node: the true distance from
+ * the center to the node outline depends on the approach angle.
+ *
+ * These helpers compute that distance against the node's *actual* transformed outline. Rather than
+ * re-deriving the rotation/scale math by hand, they reuse zrender's own transform pipeline: a
+ * unit-size symbol `Path` (built exactly as `chart/helper/Symbol` builds node symbols) is given
+ * the node's transform and probed with `Path#contain`, so the boundary always matches what is
+ * actually drawn.
+ *
+ * All coordinates here are **relative to the node center** (the ray / probe origin), which makes
+ * the returned boundary distance directly usable by the caller with no back-transform.
+ */
+
+import { createSymbol, ECSymbol } from '../../util/symbol';
+import { applyTransform } from 'zrender/src/core/vector';
+
+type Vec2 = [number, number] | number[];
+
+// Cache one unit-size proxy per distinct geometry. The full `path://` / `image://` string is part
+// of `symbolType`, so distinct SVG/image symbols get distinct cache entries.
+const proxyCache: Record<string, ECSymbol> = {};
+
+const RAD = Math.PI / 180;
+// Coarse ray samples used to locate the outermost inside→outside transition (robust for concave
+// shapes such as `arrow` / `pin` / star SVGs), then refined by bisection.
+const COARSE_SAMPLES = 16;
+const BISECT_ITERATIONS = 12;
+const EXTENT_SAFETY = 1.05;
+
+const _corner: number[] = [];
+
+function isCircleType(symbolType: string): boolean {
+    return symbolType === 'circle';
+}
+
+function hasOffset(offset: Vec2): boolean {
+    return !!offset && !!(offset[0] || offset[1]);
+}
+
+// `emptyCircle`, `emptyRect`, ... share the outline of their non-empty base shape.
+function baseSymbolType(symbolType: string): string {
+    return symbolType.indexOf('empty') === 0
+        ? symbolType.charAt(5).toLowerCase() + symbolType.slice(6)
+        : symbolType;
+}
+
+// Local unit-space vertices of the built-in convex polygon symbols (built at [-1, 1] on each axis).
+const CONVEX_POLY_VERTS: Record<string, number[][]> = {
+    triangle: [[0, -1], [1, 1], [-1, 1]],
+    diamond: [[0, -1], [1, 0], [0, 1], [-1, 0]],
+    rect: [[-1, -1], [1, -1], [1, 1], [-1, 1]],
+    square: [[-1, -1], [1, -1], [1, 1], [-1, 1]]
+};
+
+/**
+ * Ray-exit parameter for a convex polygon whose interior contains the origin: the smallest `t > 0`
+ * at which `t * (ux, uy)` crosses an edge. Returns `Infinity` if no edge is crossed.
+ */
+function convexPolyRayExit(verts: number[][], ux: number, uy: number): number {
+    let best = Infinity;
+    const n = verts.length;
+    for (let i = 0; i < n; i++) {
+        const a = verts[i];
+        const b = verts[(i + 1) % n];
+        const ex = b[0] - a[0];
+        const ey = b[1] - a[1];
+        // Solve t*(ux,uy) = a + s*(ex,ey) for (t, s) via Cramer's rule.
+        const det = ex * uy - ux * ey;
+        if (Math.abs(det) < 1e-12) {
+            continue;
+        }
+        const t = (ex * a[1] - a[0] * ey) / det;
+        const s = (ux * a[1] - uy * a[0]) / det;
+        if (t > 1e-9 && s >= -1e-6 && s <= 1 + 1e-6 && t < best) {
+            best = t;
+        }
+    }
+    return best;
+}
+
+/**
+ * Ray-exit parameter for the unit `roundRect` (box [-1, 1] with corner radius 0.5). Exits on a flat
+ * edge unless the ray heads into a corner, where it meets the quarter-circle arc.
+ */
+function roundRectRayExit(ux: number, uy: number): number {
+    const tBox = 1 / Math.max(Math.abs(ux), Math.abs(uy));
+    const qx = tBox * ux;
+    const qy = tBox * uy;
+    if (Math.abs(qx) <= 0.5 || Math.abs(qy) <= 0.5) {
+        return tBox;
+    }
+    // Farther intersection with the corner arc centered at (+/-0.5, +/-0.5), radius 0.5.
+    const cx = qx > 0 ? 0.5 : -0.5;
+    const cy = qy > 0 ? 0.5 : -0.5;
+    const a = ux * ux + uy * uy;
+    const b = -2 * (ux * cx + uy * cy);
+    const c = cx * cx + cy * cy - 0.25;
+    const disc = b * b - 4 * a * c;
+    if (disc < 0) {
+        return tBox;
+    }
+    return (-b + Math.sqrt(disc)) / (2 * a);
+}
+
+/**
+ * Exact center→outline distance for shapes with a closed-form ray intersection, or `null` when no
+ * analytic formula applies (concave / path / image / line symbols → generic ray-march).
+ *
+ * The rendered transform is `g = R'*S*p` with `S = diag(halfW, halfH)` and
+ * `R' = [[cos, sin], [-sin, cos]]` (see zrender `Transformable.getLocalTransform`). A center ray
+ * `g(t) = t*dir` maps to the local ray `t*u` with `u = S^-1 * R'^-1 * dir`, and since `R'*S*u = dir`
+ * is a unit vector, the global distance equals the local exit parameter `t`.
+ */
+function getAnalyticBoundaryDistance(
+    baseType: string,
+    halfW: number,
+    halfH: number,
+    rotateRad: number,
+    dirX: number,
+    dirY: number
+): number {
+    const ct = Math.cos(rotateRad);
+    const st = Math.sin(rotateRad);
+    // u = S^-1 * R'^-1 * dir
+    const ux = (dirX * ct - dirY * st) / halfW;
+    const uy = (dirX * st + dirY * ct) / halfH;
+
+    switch (baseType) {
+        case 'circle':
+            // Ellipse: |t*u| = 1.
+            return 1 / Math.sqrt(ux * ux + uy * uy);
+        case 'rect':
+        case 'square':
+            // Box: max(|t*ux|, |t*uy|) = 1.
+            return 1 / Math.max(Math.abs(ux), Math.abs(uy));
+        case 'diamond':
+            // |t*ux| + |t*uy| = 1.
+            return 1 / (Math.abs(ux) + Math.abs(uy));
+        case 'triangle':
+            return convexPolyRayExit(CONVEX_POLY_VERTS.triangle, ux, uy);
+        case 'roundRect':
+            return roundRectRayExit(ux, uy);
+        default:
+            // pin / arrow (center is not the geometric center), path / image / line / none.
+            return null;
+    }
+}
+
+function getProxy(symbolType: string, keepAspect: boolean): ECSymbol {
+    const key = symbolType + '|' + (keepAspect ? 1 : 0);
+    let proxy = proxyCache[key];
+    if (!proxy) {
+        // Build at unit size centered on the origin, mirroring `Symbol#_createSymbol`.
+        proxy = createSymbol(symbolType, -1, -1, 2, 2, null, keepAspect);
+        // `Path#contain` tests fill containment, so the proxy must report a fill. `setColor`
+        // is a no-op on images, whose `contain` is a bounding-rect test and needs no fill.
+        proxy.setColor && proxy.setColor('#000');
+        proxyCache[key] = proxy;
+    }
+    return proxy;
+}
+
+/**
+ * (Re)configure the shared proxy for a node's symbol, in center-relative space, and refresh its
+ * transform matrix. `size` and `offset` must already include the node global scale.
+ *
+ * The returned proxy is shared and mutable: use it synchronously and finish before configuring a
+ * proxy of the same symbol type again.
+ */
+function configureSymbolProxy(
+    symbolType: string,
+    size: Vec2,
+    rotateRad: number,
+    keepAspect: boolean,
+    offset: Vec2
+): ECSymbol {
+    const proxy = getProxy(symbolType, keepAspect);
+    proxy.x = offset ? offset[0] : 0;
+    proxy.y = offset ? offset[1] : 0;
+    // Unit symbol spans [-1, 1] on each axis, so half-size is the scale factor.
+    proxy.scaleX = size[0] / 2;
+    proxy.scaleY = size[1] / 2;
+    proxy.rotation = rotateRad || 0;
+    proxy.originX = 0;
+    proxy.originY = 0;
+    proxy.updateTransform();
+    return proxy;
+}
+
+/**
+ * Upper bound for the distance from the center to the outline: the farthest transformed corner of
+ * the proxy's local bounding rect (with a small safety margin).
+ */
+function computeMaxExtent(proxy: ECSymbol, size: Vec2): number {
+    const m = proxy.transform;
+    const rect = proxy.getBoundingRect();
+    if (!m) {
+        // Identity transform (near-unit scale): local ~= global, outline within radius √2.
+        return Math.max(size[0], size[1]) / 2 * Math.SQRT2 * EXTENT_SAFETY + 1;
+    }
+    const x0 = rect.x;
+    const y0 = rect.y;
+    const x1 = rect.x + rect.width;
+    const y1 = rect.y + rect.height;
+    let maxDistSq = 0;
+    for (let i = 0; i < 4; i++) {
+        _corner[0] = i & 1 ? x1 : x0;
+        _corner[1] = i & 2 ? y1 : y0;
+        applyTransform(_corner, _corner, m);
+        const distSq = _corner[0] * _corner[0] + _corner[1] * _corner[1];
+        if (distSq > maxDistSq) {
+            maxDistSq = distSq;
+        }
+    }
+    return Math.sqrt(maxDistSq) * EXTENT_SAFETY;
+}
+
+/**
+ * Distance from the node center to its transformed symbol outline along the unit direction
+ * `(dirX, dirY)`. Placing the endpoint at `center + dist * dir` makes it flush with the node
+ * outline at that approach angle.
+ */
+export function getSymbolBoundaryDistance(
+    symbolType: string,
+    size: Vec2,
+    rotateRad: number,
+    keepAspect: boolean,
+    offset: Vec2,
+    dirX: number,
+    dirY: number
+): number {
+    const halfW = size[0] / 2;
+    const halfH = size[1] / 2;
+    if (!(halfW > 0) || !(halfH > 0)) {
+        return 0;
+    }
+
+    const noOffset = !hasOffset(offset);
+    const baseType = baseSymbolType(symbolType);
+
+    // Fast path: a symmetric circle is angle-independent — covers the default node.
+    if (noOffset && isCircleType(baseType) && halfW === halfH) {
+        return halfW;
+    }
+
+    // Exact analytic outline for shapes with a closed-form ray intersection (no offset).
+    if (noOffset) {
+        const analytic = getAnalyticBoundaryDistance(baseType, halfW, halfH, rotateRad, dirX, dirY);
+        if (analytic != null && isFinite(analytic) && analytic > 0) {
+            return analytic;
+        }
+    }
+
+    // Generic fallback: ray-march the transformed outline. Handles concave / `path://` shapes,
+    // raster and SVG images (bounding box), and offset shapes.
+    const fallback = Math.max(halfW, halfH);
+    const proxy = configureSymbolProxy(symbolType, size, rotateRad, keepAspect, offset);
+    const tMax = computeMaxExtent(proxy, size);
+    if (!(tMax > 0)) {
+        return fallback;
+    }
+
+    const step = tMax / COARSE_SAMPLES;
+    let lastInside = NaN;
+    for (let i = 0; i <= COARSE_SAMPLES; i++) {
+        const t = step * i;
+        if (proxy.contain(t * dirX, t * dirY)) {
+            lastInside = t;
+        }
+    }
+
+    // No sample inside: unfillable (`line` / `none`) or the offset moved the shape off the ray.
+    if (isNaN(lastInside)) {
+        return fallback;
+    }
+    // Outline extends beyond the search bound (should not happen given the safety margin).
+    if (lastInside >= tMax) {
+        return lastInside;
+    }
+
+    // Refine the outermost boundary between the last inside sample and the next (outside) one.
+    let lo = lastInside;
+    let hi = lastInside + step;
+    for (let i = 0; i < BISECT_ITERATIONS; i++) {
+        const mid = (lo + hi) / 2;
+        if (proxy.contain(mid * dirX, mid * dirY)) {
+            lo = mid;
+        }
+        else {
+            hi = mid;
+        }
+    }
+    return (lo + hi) / 2;
+}
+
+/**
+ * Predicate testing whether a point (relative to the node center) lies inside the node's
+ * transformed symbol. Used to clip curved edges to the outline.
+ *
+ * The returned function borrows the shared proxy for its symbol type, so use it synchronously and
+ * finish before requesting another checker for the same symbol type.
+ */
+export function getSymbolContainChecker(
+    symbolType: string,
+    size: Vec2,
+    rotateRad: number,
+    keepAspect: boolean,
+    offset: Vec2
+): (relX: number, relY: number) => boolean {
+    const proxy = configureSymbolProxy(symbolType, size, rotateRad, keepAspect, offset);
+    return function (relX: number, relY: number): boolean {
+        return proxy.contain(relX, relY);
+    };
+}
+
+/**
+ * Convert an option `symbolRotate` (degrees) to radians, matching `chart/helper/Symbol`.
+ */
+export function symbolRotateToRad(symbolRotate: number): number {
+    return (symbolRotate || 0) * RAD || 0;
+}

--- a/test/graph-edge-shape.html
+++ b/test/graph-edge-shape.html
@@ -1,0 +1,164 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html, body { margin: 0; }
+            h1 { font: 14px/1.5 sans-serif; margin: 8px; }
+            .cell { display: inline-block; width: 320px; height: 320px; vertical-align: top; }
+            .cell .title { font: 12px/1.5 sans-serif; text-align: center; }
+            .chart { width: 320px; height: 300px; }
+        </style>
+        <h1>
+            Edge arrowheads should sit flush against each central node's outline at <em>every</em>
+            approach angle — no gap, no overlap. Try roaming/zooming; use the browser to inspect.
+            <br><small>Note: <code>image://</code> nodes (raster or SVG data-URIs) have no vector
+            outline, so endpoints clip to the image's <em>bounding box</em>. Use <code>path://</code>
+            (e.g. the whale) for true outline following.</small>
+        </h1>
+        <div id="root"></div>
+        <script>
+
+            var WHALE = 'path://M36.2145543,24.477144 C35.7759706,24.3133453 35.3249718,24.2446326 34.8840006,24.2649744 C34.9626687,23.9194004 34.9847531,23.5731168 34.9532381,23.2338109 C34.8413837,22.0030139 34.0384674,20.88457 32.7969674,20.4150529 C31.520013,19.9369025 30.1351436,20.2769179 29.2274161,21.1723118 C29.5873317,21.1753867 29.9524998,21.2425619 30.3059692,21.3766759 C31.932573,21.9858653 32.7489786,23.7868239 32.1347943,25.3982016 C31.9073849,25.9918982 31.5167899,26.4761986 31.0341567,26.82331 C30.2043811,27.4136952 29.1014755,27.5962983 28.0764023,27.2101589 C26.4499179,26.6026252 25.6326766,24.800957 26.2475773,23.1886332 C26.3279166,22.9795384 26.4293854,22.7838078 26.5491185,22.598248 L26.5474473,22.598248 C26.5474473,22.598248 26.5474473,22.598248 26.5474473,22.5999037 C27.071026,21.7894251 27.5197567,20.9111799 27.8780011,19.9759303 C30.6587224,12.7019642 26.9601267,4.568439 19.6154603,1.812717 C12.2700776,-0.942059 4.0634043,2.7221845 1.2819668,9.9969784 C0.5214286,11.9820775 0.2459111,14.029503 0.395488,16.0168491 C0.3985918,16.0823686 0.4049186,16.1494256 0.4112455,16.2164826 C1.0048974,22.9703137 5.3971812,29.1250079 12.2228051,31.684881 C19.165894,34.2876848 26.703351,32.4570414 31.6617111,27.6088345 C32.5096318,26.7936252 33.7896899,26.491928 34.9658918,26.9324698 C36.3814406,27.4636035 37.1820887,28.8956896 36.9617225,30.3199702 C37.4915087,29.9502698 37.9206619,29.4254042 38.1694394,28.7771868 C38.8283894,27.0541658 37.9521769,25.1284363 36.2145543,24.477144 Z';
+
+            // An embedded raster image (40x40 RGB gradient with a border), as a base64 PNG data URI.
+            var PNG_URI = 'image://data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAIAAAADnC86AAAM+klEQVR42s3YQQfCCgDA8fdx3rt02qVLl2bssYmNLJIYmShRZDuM1KHEDiVaZqm2spkpa6nETEVlTJZUZFKSvsQ79wXee/zvv/v/jz+Bv/+T/viP4b9mncCsA8w6wVknNOuAsw4866CzDj7rELNOYtYhZx1q1snOOvlZh5512FmnPOvUZh1u1mnOOvysI8460qyjzDr6rDOddRazjjXrbGad/azjzjqnWec66/izzmvW+YUNIWAIgCEEDSFkCKAhwIaAGgJuCIQhJAyBNATKELKGkDcE2hBYQygbQs0QOENoGgJvCKIhSIagGIJuCFNDWBiCZQgbQ9gbgmsIJ0O4GoJvCC9D+IXHYmAsAmMxOBZDYxEci/BYRMciPhaJsZgYi+RYpMZidizmxyI9FtmxWB6LtbHIjcXmWOTHojgWpbGojEV9LE7H4mIsWmNxMxb3Y9Edi6exeB2L/lh8jcVfWOsFtB6g9YJaL6T1QK0Haz1U6+Faj9B6Ca1Haj1K62W1Xl7r0VqP1XplrVfTepzWa2o9XuuJWk/SeorW07XeVOsttJ6l9TZab6/1XK130npXredrvZfW+4WVQUAZAMogqAxCygBUBrAyQJUBrgwIZZBQBqQyoJRBVhnklQGtDFhlUFYGNWXAKYOmMuCVgagMJGWgKANdGUyVwUIZWMpgowz2ysBVBidlcFUGvjJ4KYNfeCgHhjIwlINDOTSUwaEMD2V0KONDmRjKiaFMDmVqKGeHcn4o00OZHcrloVwbytxQbg5lfiiLQ1kayspQ1ofydCgvhrI1lDdDeT+U3aF8GsrXoewP5ddQ/oX7o0B/BPRHwf4o1B+B/RHcH6H9Ed4fEf1Roj8i+yOqP8r2R/n+iO6P2P6o3B/V+iOuP2r2R3x/JPZHUn+k9Ed6fzTtjxb9kdUfbfqjfX/k9ken/ujaH/n90as/+oW7aqCrAl012FVDXRXsqnBXRbsq3lWJrproqmRXpbpqtqvmuyrdVdmuWu6qta7KddVmV+W7qthVpa6qdFW9q0676qKrWl1101X3XdXtqqeueu2qfld9ddVfWNACggYIWlDQQoIGChosaKig4YJGCFpC0EhBowQtK2h5QaMFjRW0sqDVBI0TtKag8YImCpokaIqg6YI2FbSFoFmCthG0vaC5gnYStKug+YL2ErRfuK0H2jrQ1oNtPdTWwbYOt3W0reNtnWjribZOtnWqrWfber6t022dbevltl5r61xbb7Z1vq2LbV1q60pb19v6tK0v2rrV1jdtfd/W3bZ+auvXtu639Vdb/4Vbk0BrArQmwdYk1JqArQncmqCtCd6aEK1JojUhWxOqNcm2JvnWhG5N2Nak3JrUWhOuNWm2JnxrIrYmUmuitCZ6azJtTRatidWabFqTfWvitian1uTamvityas1+YUbRqBhAA0j2DBCDQNsGHDDQBsG3jCIhpFoGGTDoBpGtmHkGwbdMNiGUW4YtYbBNYxmw+AbhtgwpIahNAy9YUwbxqJhWA1j0zD2DcNtGKeGcW0YfsN4NYxfmDMDnAlwZpAzQ5wJcibMmShn4pxJcGaCM0nOpDgzy5l5zqQ5k+XMMmfWOJPjzCZn8pwpcqbEmQpn6pw55cwFZ1qcueHMPWe6nHnizCtn+pz54sxfuD4P1OdAfR6sz0P1OVifw/U5Wp/j9TlRnyfqc7I+p+rzbH2er8/p+pytz8v1ea0+5+rzZn3O1+difS7V50p9rtfn0/p8UZ9b9fmmPt/X5259fqrPr/W5X5+/6vNfuLoMVJdAdRmsLkPVJVhdwtUlWl3i1SVRXSaqS7K6pKrLbHWZry7p6pKtLsvVZa265KrLZnXJV5didSlVl0p1qVeX0+pyUV1a1eWmutxXl251eaour9WlX12+qstfuLIKVFZAZRWsrEKVFVhZwZUVWlnhlRVRWSUqK7KyoiqrbGWVr6zoyoqtrMqVVa2y4iqrZmXFV1ZiZSVVVkplpVdW08pqUVlZldWmstpXVm5ldaqsrpWVX1m9KqtfuGQFShZQsoIlK1SywJIFlyy0ZOEliyhZiZJFliyqZGVLVr5k0SWLLVnlklUrWVzJapYsvmSJJUsqWUrJ0kvWtGQtSpZVsjYla1+y3JJ1KlnXkuWXrFfJ+oVZO8DaAGsHWTvE2iBrw6yNsjbO2gRrJ1ibZG2KtbOsnWdtmrVZ1i6zdo21OdZusjbP2iJrS6ytsLbO2lPWXrC2xdob1t6ztsvaJ9a+srbP2i/W/oWZdYBZA8w6yKxDzBpk1jCzRpk1zqwJZp1g1iSzpph1llnnmTXNrFlmXWbWNWbNMesms+aZtcisJWatMGudWU+Z9YJZW8x6w6z3zNpl1idmfWXWPrN+MetfuLgNFLdAcRssbkPFLVjcwsUtWtzixS1R3CaKW7K4pYrbbHGbL27p4pYtbsvFba245YrbZnHLF7dicSsVt0pxqxe30+J2Udxaxe2muN0Xt25xeypur8WtX9y+ittfuLALFHZAYRcs7EKFHVjYwYUdWtjhhR1R2CUKO7Kwowq7bGGXL+zowo4t7MqFXa2w4wq7ZmHHF3ZiYScVdkphpxd208JuUdhZhd2msNsXdm5hdyrsroWdX9i9CrtfOHcI5A5A7hDMHUK5A5g7wLkDmjvguQOROyRyBzJ3oHKHbO6Qzx3o3IHNHcq5Qy134HKHZu7A5w5i7iDlDkruoOcO09xhkTtYucMmd9jnDm7ucModrrmDnzu8codfOOMEMg6QcYIZJ5RxwIwDZxw04+AZh8g4iYxDZhwq42QzTj7j0BmHzTjljFPLOFzGaWYcPuOIGUfKOErG0TPONOMsMo6VcTYZZ59x3IxzyjjXjONnnFfG+YXTbiDtAmk3mHZDaRdMu3DaRdMunnaJtJtIu2TapdJuNu3m0y6ddtm0W067tbTLpd1m2uXTrph2pbSrpF097U7T7iLtWml3k3b3addNu6e0e027ftp9pd1fOHUMpI5A6hhMHUOpI5g6wqkjmjriqSOROiZSRzJ1pFLHbOqYTx3p1JFNHcupYy115FLHZurIp45i6iiljkrqqKeO09RxkTpaqeMmddynjm7qeEodr6mjnzq+UsdfmPQCpAeQXpD0QqQHkh5Meijp4aRHkF6C9EjSo0gvS3p50qNJjyW9MunVSI8jvSbp8aQnkp5Eegrp6aQ3Jb0F6VmktyG9Pem5pHcivSvp+aT3Ir1fOHkOJM9A8hxMnkPJM5g8w8kzmjzjyTORPCeSZzJ5ppLnbPKcT57p5JlNnsvJcy155pLnZvLMJ89i8iwlz0ryrCfP0+R5kTxbyfMmed4nz27yfEqer8mznzy/kudfOH4JxC9A/BKMX0LxCxi/wPELGr/g8QsRvyTiFzJ+oeKXbPySj1/o+IWNX8rxSy1+4eKXZvzCxy9i/CLFL0r8oscv0/hlEb9Y8csmftnHL278copfrvGLH7+84pdfOHYLxG5A7BaM3UKxGxi7wbEbGrvhsRsRuyViNzJ2o2K3bOyWj93o2I2N3cqxWy1242K3ZuzGx25i7CbFbkrspsdu09htEbtZsdsmdtvHbm7sdordrrGbH7u9YrdfOHoPRO9A9B6M3kPROxi9w9E7Gr3j0TsRvSeidzJ6p6L3bPSej97p6J2N3svRey1656L3ZvTOR+9i9C5F70r0rkfv0+h9Eb1b0fsmet9H7270forer9G7H72/ovdfGPMDmA9gfhDzQ5gPYj6M+Sjm45hPYH4C80nMpzA/i/l5zKcxn8X8MubXMJ/D/Cbm85gvYr6E+Qrm65g/xfwF5luYv8H8Pea7mH/C/Cvm+5j/wvxfOPIIRB5A5BGMPEKRBxh5wJEHGnngkQcReSQiDzLyoCKPbOSRjzzoyIONPMqRRy3y4CKPZuTBRx5i5CFFHkrkoUce08hjEXlYkccm8thHHm7kcYo8rpGHH3m8Io9fGHkGkCeAPIPIM4Q8QeQJI08UeeLIk0CeCeRJIk8KeWaRZx550siTRZ5l5FlDnhzybCJPHnmKyFNCngry1JHnFHkukKeFPDfIc488XeR5Qp5X5Okjzxfy/IXhdwB+A/A7CL9D8BuE3zD8RuE3Dr8J+J2A3yT8puB3Fn7n4TcNv1n4XYbfNfjNwe8m/Obhtwi/JfitwG8dfk/h9wJ+W/B7A7/38NuF3yf4fYXfPvx+we9fGPoEoA8AfYLQJwR9QOgDQx8U+uDQh4A+CehDQh8K+mShTx760NCHhT5l6FODPhz0aUIfHvqI0EeCPgr00aHPFPosoI8FfTbQZw99XOhzgj5X6ONDnxf0+YXD30D4C4S/wfA3FP6C4S8c/qLhLx7+EuFvIvwlw18q/M2Gv/nwlw5/2fC3HP7Wwl8u/G2Gv3z4K4a/UvirhL96+DsNfxfhrxX+bsLfffjrhr+n8Pca/vrh7yv8/X/Ml3+/fwAjo8UYjFQbjwAAAABJRU5ErkJggg==';
+
+            // A complex multi-path SVG (a toothed gear with a radial gradient), inlined as a
+            // urlencoded SVG data-URI image. Rendered as an image => clips to its bounding box.
+            function makeGearSvg() {
+                var cx = 50, cy = 50, teeth = 10, ro = 47, ri = 37, steps = teeth * 2, d = '';
+                for (var i = 0; i <= steps; i++) {
+                    var ang = i / steps * Math.PI * 2;
+                    var r = (i % 2 === 0) ? ro : ri;
+                    d += (i === 0 ? 'M' : 'L')
+                        + (cx + Math.cos(ang) * r).toFixed(2) + ' '
+                        + (cy + Math.sin(ang) * r).toFixed(2) + ' ';
+                }
+                d += 'Z';
+                return '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">'
+                    + '<defs><radialGradient id="g" cx="45%" cy="38%" r="65%">'
+                    + '<stop offset="0%" stop-color="#ffe29a"/>'
+                    + '<stop offset="55%" stop-color="#ff9d6c"/>'
+                    + '<stop offset="100%" stop-color="#b0341f"/></radialGradient></defs>'
+                    + '<path d="' + d + '" fill="url(#g)" stroke="#6f1f13" stroke-width="2"/>'
+                    + '<circle cx="50" cy="50" r="14" fill="#2b1a14"/>'
+                    + '<circle cx="50" cy="50" r="6" fill="#ffd27f"/></svg>';
+            }
+            var GEAR_URI = 'image://data:image/svg+xml,' + encodeURIComponent(makeGearSvg());
+
+            // Each case: a big central node of some shape, ringed by peripheral nodes so edges
+            // approach from all angles, with an arrow at the central end of every edge.
+            var cases = [
+                { title: 'rect', center: { symbol: 'rect', symbolSize: 70 } },
+                { title: 'roundRect', center: { symbol: 'roundRect', symbolSize: 70 } },
+                { title: 'diamond', center: { symbol: 'diamond', symbolSize: 80 } },
+                { title: 'triangle', center: { symbol: 'triangle', symbolSize: 80 } },
+                { title: 'pin', center: { symbol: 'pin', symbolSize: 80 } },
+                { title: 'arrow', center: { symbol: 'arrow', symbolSize: 80 } },
+                { title: 'circle (control)', center: { symbol: 'circle', symbolSize: 70 } },
+                { title: 'ellipse symbolSize [110,44]', center: { symbol: 'circle', symbolSize: [110, 44] } },
+                { title: 'rect [110,44]', center: { symbol: 'rect', symbolSize: [110, 44] } },
+                { title: 'rect rotated 30deg', center: { symbol: 'rect', symbolSize: [110, 44], symbolRotate: 30 } },
+                { title: 'diamond rotated 20deg', center: { symbol: 'diamond', symbolSize: 90, symbolRotate: 20 } },
+                { title: 'SVG whale, path:// (keepAspect)', center: { symbol: WHALE, symbolSize: 120, symbolKeepAspect: true } },
+                { title: 'image:// PNG data-URI (bbox)', center: { symbol: PNG_URI, symbolSize: 80 } },
+                { title: 'image:// PNG [120,60] keepAspect', center: { symbol: PNG_URI, symbolSize: [120, 60], symbolKeepAspect: true } },
+                { title: 'image:// SVG gear data-URI (bbox)', center: { symbol: GEAR_URI, symbolSize: 100 } },
+                { title: 'image:// SVG gear, rotated 25deg', center: { symbol: GEAR_URI, symbolSize: [120, 80], symbolRotate: 25 } },
+                { title: 'curved edges + diamond', center: { symbol: 'diamond', symbolSize: 80 }, curveness: 0.25 },
+                { title: 'curved edges + rect rot', center: { symbol: 'rect', symbolSize: [110, 44], symbolRotate: 25 }, curveness: 0.3 }
+            ];
+
+            function buildOption(cfg) {
+                var cx = 160;
+                var cy = 150;
+                var R = 115;
+                var N = 18;
+                var nodes = [];
+                var links = [];
+
+                nodes.push({
+                    name: 'c',
+                    x: cx,
+                    y: cy,
+                    fixed: true,
+                    symbol: cfg.center.symbol,
+                    symbolSize: cfg.center.symbolSize,
+                    symbolRotate: cfg.center.symbolRotate,
+                    symbolKeepAspect: cfg.center.symbolKeepAspect,
+                    itemStyle: { color: '#8fd0ff', borderColor: '#1f6fb2', borderWidth: 1 }
+                });
+                for (var i = 0; i < N; i++) {
+                    var a = i / N * Math.PI * 2;
+                    nodes.push({
+                        name: 'p' + i,
+                        x: cx + Math.cos(a) * R,
+                        y: cy + Math.sin(a) * R,
+                        fixed: true,
+                        symbol: 'circle',
+                        symbolSize: 8,
+                        itemStyle: { color: '#bbb' }
+                    });
+                    // peripheral -> center, so the arrow (toSymbol) lands on the central node.
+                    links.push({ source: 'p' + i, target: 'c' });
+                }
+
+                return {
+                    series: [{
+                        type: 'graph',
+                        layout: 'none',
+                        coordinateSystem: 'view',
+                        roam: true,
+                        edgeSymbol: ['none', 'arrow'],
+                        edgeSymbolSize: 11,
+                        lineStyle: { color: '#c0392b', width: 1.5, opacity: 1, curveness: cfg.curveness || 0 },
+                        data: nodes,
+                        links: links
+                    }]
+                };
+            }
+
+            require(['echarts'], function (echarts) {
+                var root = document.getElementById('root');
+                cases.forEach(function (cfg) {
+                    var cell = document.createElement('div');
+                    cell.className = 'cell';
+                    var title = document.createElement('div');
+                    title.className = 'title';
+                    title.textContent = cfg.title;
+                    var chartDiv = document.createElement('div');
+                    chartDiv.className = 'chart';
+                    cell.appendChild(title);
+                    cell.appendChild(chartDiv);
+                    root.appendChild(cell);
+
+                    var chart = echarts.init(chartDiv);
+                    chart.setOption(buildOption(cfg));
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/test/ut/spec/series/graph/nodeShapeHelper.test.ts
+++ b/test/ut/spec/series/graph/nodeShapeHelper.test.ts
@@ -1,0 +1,116 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { getSymbolBoundaryDistance } from '@/src/chart/graph/nodeShapeHelper';
+
+// Convenience: distance from center to outline for a symbol probed along a unit direction.
+function dist(
+    symbolType: string,
+    size: number[],
+    rotateDeg: number,
+    dirX: number,
+    dirY: number
+): number {
+    const len = Math.sqrt(dirX * dirX + dirY * dirY);
+    return getSymbolBoundaryDistance(
+        symbolType, size, rotateDeg * Math.PI / 180, false, null, dirX / len, dirY / len
+    );
+}
+
+const SQRT1_2 = Math.SQRT1_2;
+
+describe('chart/graph/nodeShapeHelper', function () {
+
+    describe('getSymbolBoundaryDistance', function () {
+
+        it('circle is angle-independent (fast path)', function () {
+            for (let deg = 0; deg < 360; deg += 23) {
+                const rad = deg * Math.PI / 180;
+                expect(dist('circle', [20, 20], 0, Math.cos(rad), Math.sin(rad))).toBeCloseTo(10, 5);
+            }
+        });
+
+        it('axis-aligned rect uses half-extents on the axes', function () {
+            expect(dist('rect', [40, 20], 0, 1, 0)).toBeCloseTo(20, 1);
+            expect(dist('rect', [40, 20], 0, -1, 0)).toBeCloseTo(20, 1);
+            expect(dist('rect', [40, 20], 0, 0, 1)).toBeCloseTo(10, 1);
+            expect(dist('rect', [40, 20], 0, 0, -1)).toBeCloseTo(10, 1);
+        });
+
+        it('rect diagonal follows the box (min of axis crossings)', function () {
+            // (0.6, 0.8): x-limit 20/0.6 = 33.3, y-limit 10/0.8 = 12.5 -> exits at y = 10.
+            expect(dist('rect', [40, 20], 0, 0.6, 0.8)).toBeCloseTo(12.5, 1);
+            // 45deg on a 40x40 square exits at the corner: sqrt(20^2 + 20^2).
+            expect(dist('rect', [40, 40], 0, SQRT1_2, SQRT1_2)).toBeCloseTo(Math.sqrt(800), 1);
+        });
+
+        it('diamond is smaller on the diagonal than on the axes', function () {
+            // |x| + |y| = 10 scaled shape.
+            expect(dist('diamond', [20, 20], 0, 1, 0)).toBeCloseTo(10, 1);
+            expect(dist('diamond', [20, 20], 0, 0, 1)).toBeCloseTo(10, 1);
+            // Diagonal: t*(|dx| + |dy|) = 10 -> 10 / sqrt(2).
+            expect(dist('diamond', [20, 20], 0, SQRT1_2, SQRT1_2)).toBeCloseTo(10 * SQRT1_2, 1);
+        });
+
+        it('rotation swaps the rect axes (90 degrees)', function () {
+            // Rotating a 40x20 rect by 90deg puts its short axis horizontal.
+            expect(dist('rect', [40, 20], 90, 1, 0)).toBeCloseTo(10, 1);
+            expect(dist('rect', [40, 20], 90, 0, 1)).toBeCloseTo(20, 1);
+        });
+
+        it('non-uniform circle is treated as an ellipse', function () {
+            // Ellipse x^2/20^2 + y^2/10^2 = 1 (fast path skipped: half-extents differ).
+            expect(dist('circle', [40, 20], 0, 1, 0)).toBeCloseTo(20, 1);
+            expect(dist('circle', [40, 20], 0, 0, 1)).toBeCloseTo(10, 1);
+            // Diagonal: t^2/2 * (1/400 + 1/100) = 1 -> t = sqrt(160).
+            expect(dist('circle', [40, 20], 0, SQRT1_2, SQRT1_2)).toBeCloseTo(Math.sqrt(160), 1);
+        });
+
+        it('triangle exits at apex, base and slanted sides', function () {
+            // verts (0,-1),(1,1),(-1,1) scaled by 20.
+            expect(dist('triangle', [40, 40], 0, 0, -1)).toBeCloseTo(20, 3); // apex
+            expect(dist('triangle', [40, 40], 0, 0, 1)).toBeCloseTo(20, 3);  // base
+            expect(dist('triangle', [40, 40], 0, 1, 0)).toBeCloseTo(10, 3);  // right side at y=0
+        });
+
+        it('roundRect exits flat edges and corner arcs', function () {
+            // Half-extent 20, corner radius 10.
+            expect(dist('roundRect', [40, 40], 0, 1, 0)).toBeCloseTo(20, 3);  // flat edge
+            expect(dist('roundRect', [40, 40], 0, 0, 1)).toBeCloseTo(20, 3);  // flat edge
+            // Diagonal meets the corner arc (closer than the sharp corner at sqrt(800) ~ 28.28).
+            expect(dist('roundRect', [40, 40], 0, SQRT1_2, SQRT1_2)).toBeCloseTo(24.142, 2);
+        });
+
+        it('empty variants share the base outline', function () {
+            expect(dist('emptyRect', [40, 20], 0, 1, 0)).toBeCloseTo(20, 1);
+            expect(dist('emptyCircle', [20, 20], 0, 1, 0)).toBeCloseTo(10, 3);
+        });
+
+        it('scales with symbol size', function () {
+            expect(dist('rect', [80, 40], 0, 1, 0)).toBeCloseTo(40, 1);
+            expect(dist('rect', [80, 40], 0, 0, 1)).toBeCloseTo(20, 1);
+        });
+
+        it('degenerate sizes do not throw', function () {
+            expect(dist('rect', [0, 0], 0, 1, 0)).toBe(0);
+        });
+
+    });
+
+});


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

This PR improves the edge adjustment in graph series for different symbol shapes. Previously, the endpoints of edges were positioned on a circle around the actual node symbol. This resulted in edge endpoints sometimes being hidden behind the symbol and sometimes too far away. The new logic uses exact formulas for some symbol types and intersections for more complex paths. For data image symbols the rectangular outline of the symbol is used.



### Fixed issues

- #10563: Issue of the end points of edges in Graph chart



## Details

### Before: What was the problem?

Endpoints of edges were positioned on a circle around the actual node symbol. This resulted in edge endpoints sometimes being hidden behind the symbol and sometimes too far away.

<img width="2340" height="1813" alt="before" src="https://github.com/user-attachments/assets/7bebdbfd-32c2-49d8-bda1-ac75d06f1883" />



### After: How does it behave after the fixing?

The new logic uses exact formulas for some symbol types and intersections for more complex paths. For data image symbols the rectangular outline of the symbol is used.

<img width="2340" height="1813" alt="after" src="https://github.com/user-attachments/assets/012eebb2-0920-47ca-a023-c02938599201" />



## Document Info

One of the following should be checked.

- [X] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Related test cases or examples to use the new APIs

- test/graph-edge-shape.html
- test/ut/spec/series/graph/nodeShapeHelper.test.ts
