### PR TITLE
fix(tree): apply selected line style to edges. close #18214

### DIFF
--- a/src/chart/tree/TreeView.ts
+++ b/src/chart/tree/TreeView.ts
@@ -36,7 +36,14 @@ import GlobalModel from '../../model/Global';
 import ExtensionAPI from '../../core/ExtensionAPI';
 import { TreeNode } from '../../data/Tree';
 import SeriesData from '../../data/SeriesData';
-import { setStatesStylesFromModel, setStatesFlag, setDefaultStateProxy, HOVER_STATE_BLUR } from '../../util/states';
+import {
+    setStatesStylesFromModel,
+    setStatesFlag,
+    setDefaultStateProxy,
+    HOVER_STATE_BLUR,
+    enterSelect,
+    leaveSelect
+} from '../../util/states';
 import { AnimationOption, ECElement, RoamPayload } from '../../util/types';
 import tokens from '../../visual/tokens';
 import {
@@ -214,6 +221,8 @@ class TreeView extends ChartView {
             })
             .execute();
 
+        updateTreeEdgeSelection(seriesModel);
+
         this._updateNodeAndLinkScale(seriesModel);
 
         if (seriesModel.get('expandAndCollapse') === true) {
@@ -230,6 +239,18 @@ class TreeView extends ChartView {
         this._data = data;
 
         this._firstRender = false;
+    }
+
+    select(seriesModel: TreeSeriesModel): void {
+        updateTreeEdgeSelection(seriesModel);
+    }
+
+    unselect(seriesModel: TreeSeriesModel): void {
+        updateTreeEdgeSelection(seriesModel);
+    }
+
+    toggleSelect(seriesModel: TreeSeriesModel): void {
+        updateTreeEdgeSelection(seriesModel);
     }
 
     __updateOnOwnRoam(
@@ -323,6 +344,16 @@ function symbolNeedsDraw(data: SeriesData, dataIndex: number) {
         && !isNaN(layout.x) && !isNaN(layout.y);
 }
 
+function updateTreeEdgeSelection(seriesModel: TreeSeriesModel) {
+    const data = seriesModel.getData();
+
+    data.eachItemGraphicEl(function (symbolEl: TreeSymbol, dataIndex) {
+        const edge = symbolEl.__edge;
+        if (edge) {
+            seriesModel.isSelected(dataIndex) ? enterSelect(edge) : leaveSelect(edge);
+        }
+    });
+}
 
 function updateNode(
     data: SeriesData,

--- a/test/ut/spec/series/tree.test.ts
+++ b/test/ut/spec/series/tree.test.ts
@@ -1,0 +1,115 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart, getECModel } from '../../core/utHelper';
+import { EChartsType } from '../../../../src/echarts';
+import Element from 'zrender/src/Element';
+
+
+describe('series/tree', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    function getDataIndex(name: string): number {
+        const data = getECModel(chart).getSeriesByIndex(0).getData();
+        const dataIndex = data.indexOfName(name);
+        expect(dataIndex >= 0).toEqual(true);
+        return dataIndex;
+    }
+
+    function getEdge(dataIndex: number): Element & {
+        selected?: boolean,
+        states?: {
+            select?: {
+                style?: {
+                    stroke?: string
+                }
+            }
+        }
+    } {
+        const seriesModel = getECModel(chart).getSeriesByIndex(0);
+        const symbolEl = seriesModel.getData().getItemGraphicEl(dataIndex) as Element & {
+            __edge: Element
+        };
+        return symbolEl.__edge;
+    }
+
+    it('applies select.lineStyle to selected edges', function () {
+        const selectedColor = '#ff6600';
+
+        chart.setOption({
+            series: [{
+                type: 'tree',
+                selectedMode: 'single',
+                animation: false,
+                select: {
+                    itemStyle: {
+                        color: selectedColor
+                    },
+                    lineStyle: {
+                        color: selectedColor
+                    }
+                },
+                data: [{
+                    name: 'root',
+                    children: [{
+                        name: 'child 1'
+                    }, {
+                        name: 'child 2'
+                    }]
+                }]
+            }]
+        });
+
+        const childDataIndex = getDataIndex('child 1');
+        const siblingDataIndex = getDataIndex('child 2');
+        const childEdge = getEdge(childDataIndex);
+        const siblingEdge = getEdge(siblingDataIndex);
+
+        expect(childEdge.states.select.style.stroke).toEqual(selectedColor);
+        expect(childEdge.selected).toEqual(false);
+
+        chart.dispatchAction({
+            type: 'select',
+            seriesIndex: 0,
+            dataIndex: childDataIndex
+        });
+
+        expect(childEdge.selected).toEqual(true);
+        expect(siblingEdge.selected).toEqual(false);
+
+        chart.dispatchAction({
+            type: 'select',
+            seriesIndex: 0,
+            dataIndex: siblingDataIndex
+        });
+
+        expect(childEdge.selected).toEqual(false);
+        expect(siblingEdge.selected).toEqual(true);
+    });
+
+});


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Applies configured `select.lineStyle` to tree node edges when tree nodes are selected.



### Fixed issues

- #18214: Tree series `select.lineStyle` did not affect the selected node's branch/edge.



## Details

### Before: What was the problem?

Tree node symbols could enter the `select` state correctly, so `select.itemStyle` worked on the selected node.

However, the tree edge/branch is rendered as a sibling element of the node symbol group, not as a child of it. The generic selection update only marks the node symbol group as selected, so the edge never entered the `select` state even though its `select.lineStyle` state style was already configured.



### After: How does it behave after the fixing?

Tree edges now mirror the selection state of their corresponding tree nodes.

The fix updates tree edge selection in `TreeView` by applying `enterSelect` / `leaveSelect` to each node edge based on `seriesModel.isSelected(dataIndex)`. It runs after render and during `select`, `unselect`, and `toggleSelect` actions, so both initial selected state and later selection changes are handled.

A regression unit test was added to verify that:

- `select.lineStyle.color` is stored on the tree edge select state;
- selecting a tree node marks its edge as selected;
- single-select selection clears the previously selected edge and selects the new edge.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/series/tree.test.ts`

Validation run:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/series/tree.test.ts
npm run checktype
npm run lint
npx eslint test/ut/spec/series/tree.test.ts
git --no-pager diff --check
```

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

N.A.