### PR TITLE
fix(line): keep labels above lines. close #15679

### DIFF
--- a/src/chart/line/LineView.ts
+++ b/src/chart/line/LineView.ts
@@ -1044,7 +1044,7 @@ class LineView extends ChartView {
                 points
             },
             segmentIgnoreThreshold: 2,
-            z2: 10
+            z2: 1
         });
 
         this._lineGroup.add(polyline);

--- a/test/ut/spec/series/line.test.ts
+++ b/test/ut/spec/series/line.test.ts
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getGraphicElements } from '../../core/utHelper';
+
+
+describe('line_series', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should render line under labels from mixed series', function () {
+        chart.setOption({
+            animation: false,
+            xAxis: {
+                type: 'category',
+                data: ['A', 'B', 'C']
+            },
+            yAxis: {},
+            series: [
+                {
+                    type: 'bar',
+                    label: {
+                        show: true,
+                        position: 'top'
+                    },
+                    data: [120, 120, 120]
+                },
+                {
+                    type: 'line',
+                    showSymbol: false,
+                    data: [140, 100, 140]
+                }
+            ]
+        });
+
+        const barItem = getGraphicElements(chart, 'series', 0).find(el => el.name === 'item');
+        const barLabel = barItem && barItem.getTextContent();
+        const linePolyline = getGraphicElements(chart, 'series', 1).find(el => el.type === 'ec-polyline');
+
+        expect(barItem).toBeDefined();
+        expect(barLabel).toBeDefined();
+        expect(linePolyline).toBeDefined();
+
+        expect((linePolyline as any).z2).toBeLessThan((barLabel as any).z2);
+    });
+
+});


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Keeps line series paths below labels from mixed series by lowering the default line polyline `z2`.



### Fixed issues

- #15679: Line graph overlaps labels on other series on mixed series.



## Details

### Before: What was the problem?

In mixed charts such as bar + line, the line polyline used a default `z2` of `10`.

That made the line path render above labels attached to other series, so a line series could visually overlap bar labels.



### After: How does it behave after the fixing?

The line polyline default `z2` is lowered to `1`, so it no longer sits above labels from other series.

A regression test was added to verify that a line polyline is rendered below a bar label in a mixed bar + line chart.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/ut/spec/series/line.test.ts`

Validation run:

- `npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/series/line.test.ts`
- `npm run lint`
- `npm run checktype`
- `npx eslint test/ut/spec/series/line.test.ts`
- `git --no-pager diff --check`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

N.A.
