### PR TITLE
fix(toolbox): fix updateView and dispose silently no-oping on toolbox features

### DIFF
--- a/src/component/toolbox/ToolboxView.ts
+++ b/src/component/toolbox/ToolboxView.ts
@@ -377,7 +377,9 @@ class ToolboxView extends ComponentView {
         api: ExtensionAPI,
         payload: unknown
     ) {
-        each(this._features, function (feature) {
+        // `_features` is a `HashMap` rather than a plain object, so it has to be
+        // iterated with its own `each` method - `zrUtil.each` cannot traverse it.
+        this._features && this._features.each(function (feature) {
             feature
                 && feature instanceof ToolboxFeature
                 && feature.updateView
@@ -386,7 +388,7 @@ class ToolboxView extends ComponentView {
     }
 
     dispose(ecModel: GlobalModel, api: ExtensionAPI) {
-        each(this._features, function (feature) {
+        this._features && this._features.each(function (feature) {
             feature
                 && feature instanceof ToolboxFeature
                 && feature.dispose


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others


### What does this PR do?

 fix updateView and dispose silently no-oping on toolbox features



### Fixed issues

ToolboxView._features is a zrender HashMap (created via createHashMap()), which stores entries in an internal native Map. zrUtil.each() iterates it as a plain object, so the callbacks in updateView and dispose never received any feature and both methods silently did nothing.

As a result feature dispose was never called, leaking each feature's resources whenever the view was disposed. For the dataZoom feature this leaks its BrushController: the controller's zr mouse handlers stay bound, and each leaked controller paints its own semi-transparent cover on drag-to-zoom, so the selection overlay gets progressively darker after every dispose/render cycle. Feature updateView was likewise never invoked on chart updates.

Iterate with the HashMap's own .each() instead.


## Details

### Before: What was the problem?

ToolboxView._features is a zrender HashMap (created via createHashMap()), which stores entries in an internal native Map. zrUtil.each() iterates it as a plain object, so the callbacks in updateView and dispose never received any feature and both methods silently did nothing.



### After: How does it behave after the fixing?

Iterate with the HashMap's own .each() instead.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
