### PR TITLE
fix(sunburst): preserve data decal. close #18118

### DIFF
--- a/src/chart/helper/enableAriaDecalForTree.ts
+++ b/src/chart/helper/enableAriaDecalForTree.ts
@@ -1,26 +1,28 @@
-
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+import { extend } from 'zrender/src/core/util';
 import SeriesModel from '../../model/Series';
-import {Dictionary, DecalObject} from '../../util/types';
+import { Dictionary, DecalObject, InnerDecalObject } from '../../util/types';
 import { getDecalFromPalette } from '../../model/mixin/palette';
+
+type TreeDecalObject = DecalObject | 'none';
 
 export default function enableAriaDecalForTree(seriesModel: SeriesModel) {
     const data = seriesModel.getData();
@@ -34,11 +36,30 @@ export default function enableAriaDecalForTree(seriesModel: SeriesModel) {
             current = current.parentNode;
         }
 
-        const decal = getDecalFromPalette(
+        const paletteDecal = getDecalFromPalette(
             seriesModel.ecModel,
             current.name || current.dataIndex + '',
             decalPaletteScope
         );
+        const itemStyleDecal = node.getModel<any>()
+            .getModel('itemStyle')
+            .getShallow('decal') as TreeDecalObject;
+        const specifiedDecal = itemStyleDecal != null
+            ? itemStyleDecal
+            : node.getVisual('decal') as TreeDecalObject;
+        const decal = mergeDecal(specifiedDecal, paletteDecal);
         node.setVisual('decal', decal);
     });
+}
+
+function mergeDecal(specifiedDecal: TreeDecalObject, paletteDecal: DecalObject): TreeDecalObject {
+    if (specifiedDecal === 'none') {
+        return specifiedDecal;
+    }
+
+    const resultDecal = specifiedDecal
+        ? extend(extend({}, paletteDecal), specifiedDecal)
+        : paletteDecal;
+    (resultDecal as InnerDecalObject).dirty = true;
+    return resultDecal;
 }

--- a/test/ut/spec/series/sunburst.test.ts
+++ b/test/ut/spec/series/sunburst.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EChartsType } from '@/src/echarts';
+import type { DecalObject } from '@/src/util/types';
+import { createChart, getECModel } from '../../core/utHelper';
+
+
+describe('sunburst', function () {
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({
+            opts: {
+                renderer: 'svg'
+            }
+        });
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should preserve itemStyle decal overrides when aria decal is enabled', function () {
+        chart.setOption({
+            aria: {
+                enabled: true,
+                decal: {
+                    show: true,
+                    decals: {
+                        symbol: 'circle'
+                    }
+                }
+            },
+            series: {
+                type: 'sunburst',
+                data: [
+                    {
+                        name: 'Parent',
+                        children: [
+                            {
+                                name: 'Base decal',
+                                value: 1
+                            },
+                            {
+                                name: 'Changed decal',
+                                value: 1,
+                                itemStyle: {
+                                    decal: {
+                                        symbol: 'none'
+                                    }
+                                }
+                            },
+                            {
+                                name: 'Disabled decal',
+                                value: 1,
+                                itemStyle: {
+                                    decal: 'none'
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        const data = getECModel(chart).getSeries()[0].getData();
+        const baseIdx = data.indexOfName('Base decal');
+        const changedIdx = data.indexOfName('Changed decal');
+        const disabledIdx = data.indexOfName('Disabled decal');
+
+        expect(baseIdx).not.toBe(-1);
+        expect(changedIdx).not.toBe(-1);
+        expect(disabledIdx).not.toBe(-1);
+
+        const baseDecal = data.getItemVisual(baseIdx, 'decal') as DecalObject;
+        const changedDecal = data.getItemVisual(changedIdx, 'decal') as DecalObject;
+
+        expect(baseDecal.symbol).toBe('circle');
+        expect(changedDecal.symbol).toBe('none');
+        expect(data.getItemVisual(disabledIdx, 'decal')).toBe('none');
+        expect(data.getItemVisual(disabledIdx, 'style').decal).toBeNull();
+    });
+});


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Preserve sunburst data item decal overrides when ARIA decal generation is enabled.



### Fixed issues

- #18118: `series-sunburst.data.itemStyle.decal` was overwritten by `aria.decal.decals`.



## Details

### Before: What was the problem?

When `aria.decal.show` was enabled for a sunburst series, the tree-specific ARIA decal helper assigned palette decals directly to each tree node.

Because sunburst ignores generic data item style processing, `series.data[].itemStyle.decal` was not preserved before ARIA decal assignment. As a result, a data item such as:

```js
{
    name: 'Changed decal',
    value: 1,
    itemStyle: {
        decal: {
            symbol: 'none'
        }
    }
}
```

still rendered with the global ARIA decal, for example `symbol: 'circle'`.



### After: How does it behave after the fixing?

The tree ARIA decal helper now reads a node's `itemStyle.decal`, merges it over the palette decal, and preserves explicit `decal: 'none'`.

This allows sunburst data items to override or disable the ARIA decal while keeping palette decals for items without an override.

A regression test was added for the sunburst + ARIA decal case.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/series/sunburst.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Validation run locally:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/series/aria-columns-exclude.test.ts test/ut/spec/series/sunburst.test.ts
npx eslint src/chart/helper/enableAriaDecalForTree.ts test/ut/spec/series/sunburst.test.ts
npm run checktype
git diff --check
```
