### PR TITLE
fix(heatmap): bound truncated labels to cell. close #17644

### DIFF
--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -322,7 +322,9 @@ class HeatmapView extends ChartView {
                     labelFetcher: seriesModel,
                     labelDataIndex: idx,
                     defaultOpacity: style.opacity,
-                    defaultText: defaultText
+                    defaultText: defaultText,
+                    autoOverflowArea: true,
+                    layoutRect: zrUtil.clone(rect.shape)
                 }
             );
 

--- a/test/ut/spec/series/heatmap.test.ts
+++ b/test/ut/spec/series/heatmap.test.ts
@@ -1,0 +1,100 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import { createChart, getGraphicElements } from '../../core/utHelper';
+
+
+describe('heatmap', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({width: 240, height: 200});
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    function getFirstHeatmapCell() {
+        const cell = getGraphicElements(chart, 'series', 0).filter(function (el) {
+            return el.type === 'rect' && !!el.getTextContent();
+        })[0] as any;
+
+        expect(cell).toBeTruthy();
+        return cell;
+    }
+
+    it('should use cell size as dynamic label overflow area', function () {
+        chart.setOption({
+            animation: false,
+            grid: {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0
+            },
+            xAxis: {
+                type: 'category',
+                data: ['a', 'b']
+            },
+            yAxis: {
+                type: 'category',
+                data: ['x']
+            },
+            visualMap: {
+                show: false,
+                min: 0,
+                max: 100
+            },
+            series: [{
+                type: 'heatmap',
+                data: [[0, 0, 123456], [1, 0, 789012]],
+                label: {
+                    show: true,
+                    overflow: 'truncate'
+                }
+            }]
+        });
+
+        const cell = getFirstHeatmapCell();
+        const textConfig = cell.textConfig;
+        const textStyle = cell.getTextContent().style;
+
+        expect(textStyle.overflow).toBe('truncate');
+        expect(textStyle.width).toBeUndefined();
+        expect(textConfig.autoOverflowArea).toBe(true);
+        expect(textConfig.layoutRect.width).toBe(cell.shape.width);
+        expect(textConfig.layoutRect.height).toBe(cell.shape.height);
+
+        const width = cell.shape.width;
+
+        chart.resize({width: 480, height: 200});
+
+        const resizedCell = getFirstHeatmapCell();
+        const resizedTextConfig = resizedCell.textConfig;
+
+        expect(resizedCell.shape.width).toBeGreaterThan(width);
+        expect(resizedTextConfig.autoOverflowArea).toBe(true);
+        expect(resizedTextConfig.layoutRect.width).toBe(resizedCell.shape.width);
+        expect(resizedTextConfig.layoutRect.height).toBe(resizedCell.shape.height);
+    });
+
+});


### PR DESCRIPTION

<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Make heatmap label truncation use the actual heatmap cell size as its overflow area.



### Fixed issues

- Fix #17644: Heatmap labels with `overflow: 'truncate'` required a fixed `label.width`, so truncation did not adapt when cell size changed.


## Details

### Before: What was the problem?

Heatmap labels using `overflow: 'truncate'` had no dynamic overflow area tied to the rendered cell rectangle.

Users had to set a fixed `series.label.width`, but that fixed width became incorrect when the chart or heatmap cell size changed. This could make labels truncate even when there was enough cell space, or fail to truncate appropriately when cells became smaller.



### After: How does it behave after the fixing?

Heatmap cells now pass their rendered rectangle as the label overflow area via `autoOverflowArea` and `layoutRect`.

This lets labels with `overflow: 'truncate'` adapt to the actual heatmap cell width/height without requiring a fixed `label.width`.

A regression test was added to verify that heatmap label overflow bounds match the cell size and update after chart resize.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/ut/spec/series/heatmap.test.ts`

Validation run:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/series/heatmap.test.ts
npx eslint src/chart/heatmap/HeatmapView.ts test/ut/spec/series/heatmap.test.ts
npm run checktype
git diff --check
```

Commit hook also passed:

```sh
npm run lint
npm run checktype
```

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

N.A.
