### PR TITLE
Export CallbackDataParams and TopLevelFormatterParams for formatter callbacks

### DIFF
--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -46,6 +46,16 @@ export {
     ToggleAxisBreakPayload,
 } from '../component/axis/axisAction';
 
+// Types of the `params` argument passed to formatter callbacks
+// (for example `tooltip.formatter` and `label.formatter`), so that
+// these callbacks can be typed without importing from internal paths.
+export {
+    CallbackDataParams,
+} from '../util/types';
+export {
+    TopLevelFormatterParams,
+} from '../component/tooltip/TooltipModel';
+
 
 export { LinearGradientObject } from 'zrender/src/graphic/LinearGradient';
 export { RadialGradientObject } from 'zrender/src/graphic/RadialGradient';


### PR DESCRIPTION
### What does this PR do?

This exports the types of the `params` argument that ECharts passes to formatter callbacks, so TypeScript users can type those callbacks without reaching into internal paths.

Two types are now importable from the package entry:

- `CallbackDataParams` - the per-item params object passed to `label.formatter`, and to each element of the array a series-grouped `tooltip.formatter` receives.
- `TopLevelFormatterParams` - the exact type of the `params` argument of `tooltip.formatter` (`CallbackDataParams | CallbackDataParams[]`).

### Why?

Today people either type `params` as `any` and lose all checking, copy the interface by hand, or import from an internal path such as `echarts/types/dist/shared.js`. All of those break as soon as the internals move. With this change the supported usage is:

```ts
import type { CallbackDataParams, TopLevelFormatterParams } from 'echarts';

const formatter = (params: TopLevelFormatterParams) => {
  const list = Array.isArray(params) ? params : [params];
  return list.map(p => p.seriesName).join(', ');
};
```

The aliases `DefaultLabelFormatterCallbackParams` and `TooltipComponentFormatterCallbackParams` already existed on the ESM types entry, but the base names were not exported and neither name reached the CJS types entry. This re-exports the base names from the core export, which feeds both entries, so the types resolve regardless of module resolution mode. The change is type-only, with no runtime output.

Closes #14277
