### PR TITLE
fix(option): avoid incorrectly requiring TimelineComponent when media is used without timeline

### DIFF
--- a/src/model/OptionManager.ts
+++ b/src/model/OptionManager.ts
@@ -314,7 +314,7 @@ function parseRawOption(
     if (declaredBaseOption) {
         baseOption = declaredBaseOption;
         // For merge option.
-        if (!baseOption.timeline) {
+        if (!baseOption.timeline && timelineOnRoot) {
             baseOption.timeline = timelineOnRoot;
         }
     }


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

It fixes a bug where `TimelineComponent` is incorrectly required when responsive `media` options are specified, even if no timeline is actually used in the chart configuration. This happens because `baseOption.timeline` was being assigned `timelineOnRoot` even when it was `undefined`, causing the core component loader to falsely detect timeline usage.



### Fixed issues

<!--
- #21686
-->


## Details

### Before: What was the problem?

When developers used modular imports (without importing the `TimelineComponent`) alongside responsive `media` queries, ECharts threw the following error:
`Error: Component timeline is used but not imported.`

This issue occurred in `OptionManager.ts`. The code was assigning the value of `timelineOnRoot` to `baseOption.timeline` even when `timelineOnRoot` was `undefined`. In JavaScript, explicitly assigning `undefined` to an object property still registers the key on that object. Consequently, when the core component loader performed a property existence check (using `in` or `hasOwnProperty`), it detected the presence of `'timeline'` on the option object and assumed a timeline was in use, resulting in an error because the component hadn't been imported.



### After: How does it behave after the fixing?

With this change, `baseOption.timeline` is only assigned if `timelineOnRoot` is defined. This prevents the `'timeline'` key from being incorrectly registered on the `baseOption` when no timeline is actively configured. As a result, responsive media queries now render successfully without triggering the incorrect `TimelineComponent` dependency error.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

This is a clean logical fix for the bug reported in #21686. It does not introduce any breaking changes or require modifications to the documentation. Thanks to the maintainers for reviewing!