### PR TITLE
fix(dataZoom): skip redundant reset when only the origin snapshot rem…

### DIFF
--- a/src/component/dataZoom/history.ts
+++ b/src/component/dataZoom/history.ts
@@ -72,8 +72,16 @@ export function push(ecModel: GlobalModel, newSnapshot: DataZoomStoreSnapshot) {
 
 export function pop(ecModel: GlobalModel) {
     const storedSnapshots = getStoreSnapshots(ecModel);
+
+    // When only the origin snapshot remains, there is nothing to undo.
+    // Return an empty snapshot so callers do not dispatch a redundant
+    // dataZoom action (see #21660).
+    if (storedSnapshots.length <= 1) {
+        return {};
+    }
+
     const head = storedSnapshots[storedSnapshots.length - 1];
-    storedSnapshots.length > 1 && storedSnapshots.pop();
+    storedSnapshots.pop();
 
     // Find top for all dataZoom.
     const snapshot: DataZoomStoreSnapshot = {};

--- a/test/ut/spec/component/dataZoom/history.test.ts
+++ b/test/ut/spec/component/dataZoom/history.test.ts
@@ -1,0 +1,89 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { push, pop, count, clear } from '../../../../../src/component/dataZoom/history';
+import GlobalModel from '../../../../../src/model/Global';
+
+// `history.push` completes the origin range by querying the related dataZoom
+// model. Return a stub whose `getPercentRange` yields a fixed range so the
+// origin snapshot is populated the same way it is at runtime.
+function createMockECModel(): GlobalModel {
+    return {
+        queryComponents() {
+            return [{
+                getPercentRange() {
+                    return [0, 100];
+                }
+            }];
+        }
+    } as unknown as GlobalModel;
+}
+
+describe('dataZoom/history', function () {
+
+    it('starts with a single origin snapshot', function () {
+        const ecModel = createMockECModel();
+        expect(count(ecModel)).toBe(1);
+    });
+
+    it('pushes and pops snapshots for multiple dataZooms', function () {
+        const ecModel = createMockECModel();
+
+        push(ecModel, { dz0: { dataZoomId: 'dz0', start: 10, end: 90 } });
+        push(ecModel, { dz1: { dataZoomId: 'dz1', start: 20, end: 80 } });
+        expect(count(ecModel)).toBe(3);
+
+        const undoDz1 = pop(ecModel);
+        expect(undoDz1.dz1).toBeTruthy();
+        expect(count(ecModel)).toBe(2);
+
+        const undoDz0 = pop(ecModel);
+        expect(undoDz0.dz0).toBeTruthy();
+        expect(count(ecModel)).toBe(1);
+    });
+
+    // Regression test for #21660: after every zoom has been undone only the
+    // origin snapshot remains, so an extra "back" / zoom-reset must be a no-op
+    // instead of dispatching a redundant dataZoom action that restores the
+    // origin range again.
+    it('returns an empty snapshot once only the origin remains (#21660)', function () {
+        const ecModel = createMockECModel();
+
+        push(ecModel, { dz0: { dataZoomId: 'dz0', start: 10, end: 90 } });
+        push(ecModel, { dz1: { dataZoomId: 'dz1', start: 20, end: 80 } });
+
+        pop(ecModel); // undo the dz1 zoom
+        pop(ecModel); // undo the dz0 zoom
+        expect(count(ecModel)).toBe(1);
+
+        expect(pop(ecModel)).toEqual({});
+        expect(count(ecModel)).toBe(1);
+    });
+
+    it('clears the stored snapshots back to the origin', function () {
+        const ecModel = createMockECModel();
+
+        push(ecModel, { dz0: { dataZoomId: 'dz0', start: 10, end: 90 } });
+        expect(count(ecModel)).toBe(2);
+
+        clear(ecModel);
+        expect(count(ecModel)).toBe(1);
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Stops the toolbox dataZoom "back"/zoom-reset from dispatching a redundant action once the chart is already back at its original range.

### Fixed issues

- close #21660

## Details

### Before: What was the problem?

The dataZoom zoom history keeps the original (un-zoomed) range as the base snapshot, then pushes one snapshot per zoom. `history.pop()` did not stop when only that base snapshot remained — it still returned the origin as a restorable snapshot. So the toolbox "back"/zoom-reset could be triggered one extra time (e.g. 3× after 2 zooms across multiple grids), dispatching a redundant `dataZoom` action that "restores" a range that is already current.

Reproduction (from #21660): open the `grid-multiple` example, zoom the upper chart once and the lower chart once (2 zooms), then click Zoom Reset — it can be triggered 3 times.

### After: How does it behave after the fixing?

`history.pop()` now returns an empty snapshot when only the origin remains (nothing left to undo). Its only caller — the toolbox dataZoom `back` handler — already guards on `batch.length`, so no redundant `dataZoom` action is dispatched. After 2 zooms, reset now triggers exactly 2 times.

Added a unit test (`test/ut/spec/component/dataZoom/history.test.ts`) covering push/pop/count and the regression: popping when only the origin remains returns `{}`.

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Unit test: `test/ut/spec/component/dataZoom/history.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information