### PR TITLE
fix(heatmap): prevent crash with missing coordinate system

### DIFF
--- a/src/chart/heatmap/HeatmapView.ts
+++ b/src/chart/heatmap/HeatmapView.ts
@@ -121,6 +121,13 @@ class HeatmapView extends ChartView {
         this.group.removeAll();
 
         const coordSys = seriesModel.coordinateSystem;
+        // The coordinate system may be unresolved, e.g. a heatmap that
+        // references a `calendar`/`geo`/`bmap` coordinate system whose component
+        // is missing. Skip rendering instead of throwing on `coordSys.type`
+        // (`incrementalRender` already guards this the same way). See #19060.
+        if (!coordSys) {
+            return;
+        }
         if (coordSys.type === 'cartesian2d'
             || coordSys.type === 'calendar'
             || coordSys.type === 'matrix'

--- a/test/ut/spec/series/heatmap.test.ts
+++ b/test/ut/spec/series/heatmap.test.ts
@@ -1,0 +1,57 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart } from '../../core/utHelper';
+import { EChartsType } from '../../../../src/echarts';
+
+describe('series/heatmap', function () {
+
+    let chart: EChartsType;
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    // Regression test for #19060: a heatmap whose coordinate system cannot be
+    // resolved (e.g. `coordinateSystem: 'calendar'` without a calendar
+    // component) used to throw "Cannot read properties of undefined (reading
+    // 'type')" in HeatmapView.render, aborting the whole chart render.
+    it('does not throw when the heatmap coordinate system is missing (#19060)', function () {
+        function setMisconfiguredHeatmap() {
+            chart.setOption({
+                visualMap: {
+                    min: 0,
+                    max: 10,
+                    calculable: true
+                },
+                series: [{
+                    type: 'heatmap',
+                    coordinateSystem: 'calendar',
+                    data: [['2023-01-01', 5]]
+                }]
+            });
+        }
+
+        expect(setMisconfiguredHeatmap).not.toThrow();
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Prevents `HeatmapView.render` from throwing when a heatmap's coordinate system cannot be resolved.

### Fixed issues

- close #19060

## Details

### Before: What was the problem?

`HeatmapView.render` read `seriesModel.coordinateSystem.type` without checking that the coordinate system existed. When a heatmap references a coordinate system whose component is missing (e.g. `coordinateSystem: 'calendar'` or `'bmap'` not registered), `coordinateSystem` is `undefined`, so `coordSys.type` threw `Cannot read properties of undefined (reading 'type')`, aborting the entire render. `incrementalRender` already guarded this case with `if (coordSys)`, but `render` did not.

### After: How does it behave after the fixing?

`render` now returns early when the coordinate system is missing (same guard as `incrementalRender`), so the misconfiguration is skipped gracefully — ECharts still emits its usual "coordinate system cannot be found" warning — instead of throwing. Added a regression unit test (`test/ut/spec/series/heatmap.test.ts`).

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes.

### Merging options

- [x] Please squash the commits into a single one when merging.