### PR TITLE
fix(dataset): detect dimensions across sparse object-row datasets

### DIFF
--- a/src/data/Source.ts
+++ b/src/data/Source.ts
@@ -401,12 +401,23 @@ function determineSourceDimensions(
 }
 
 function objectRowsCollectDimensions(data: OptionSourceDataObjectRows): DimensionDefinitionLoose[] {
-    let firstIndex = 0;
-    let obj;
-    while (firstIndex < data.length && !(obj = data[firstIndex++])) {} // jshint ignore: line
-    if (obj) {
-        return keys(obj);
+    const dimensionNameMap = createHashMap<true, DimensionName>();
+    const dimensionsDefine: DimensionDefinitionLoose[] = [];
+
+    for (let i = 0; i < data.length; i++) {
+        const obj = data[i];
+        if (!obj) {
+            continue;
+        }
+        each(keys(obj), function (name) {
+            if (!dimensionNameMap.get(name)) {
+                dimensionNameMap.set(name, true);
+                dimensionsDefine.push(name);
+            }
+        });
     }
+
+    return dimensionsDefine.length ? dimensionsDefine : void 0;
 }
 
 // Consider dimensions defined like ['A', 'price', 'B', 'price', 'C', 'price'],

--- a/src/data/Source.ts
+++ b/src/data/Source.ts
@@ -19,7 +19,7 @@
 
 import {
     isTypedArray, HashMap, clone, createHashMap, isArray, isObject, isArrayLike,
-    hasOwn, assert, each, map, isNumber, isString, keys
+    hasOwn, assert, each, map, isNumber, isString
 } from 'zrender/src/core/util';
 import {
     SourceFormat, SeriesLayoutBy, DimensionDefinition,
@@ -409,12 +409,12 @@ function objectRowsCollectDimensions(data: OptionSourceDataObjectRows): Dimensio
         if (!obj) {
             continue;
         }
-        each(keys(obj), function (name) {
-            if (!dimensionNameMap.get(name)) {
+        for (const name in obj) {
+            if (hasOwn(obj, name) && !dimensionNameMap.get(name)) {
                 dimensionNameMap.set(name, true);
                 dimensionsDefine.push(name);
             }
-        });
+        }
     }
 
     return dimensionsDefine.length ? dimensionsDefine : void 0;

--- a/test/ut/spec/data/SeriesData.test.ts
+++ b/test/ut/spec/data/SeriesData.test.ts
@@ -25,6 +25,7 @@ import { createSourceFromSeriesDataOption, Source, createSource } from '@/src/da
 import { OptionDataItemObject,
     OptionDataValue,
     SOURCE_FORMAT_ARRAY_ROWS,
+    SOURCE_FORMAT_OBJECT_ROWS,
     SOURCE_FORMAT_ORIGINAL } from '@/src/util/types';
 import SeriesDimensionDefine from '@/src/data/SeriesDimensionDefine';
 import OrdinalMeta from '@/src/data/OrdinalMeta';
@@ -204,6 +205,19 @@ describe('SeriesData', function () {
                 sourceHeader: false
             }, SOURCE_FORMAT_ORIGINAL);
             expect(source.dimensionsDefine[0].type).toEqual('ordinal');
+        });
+
+        it('should collect dimensions across all object rows', function () {
+            const source = createSource([
+                { timestamp: 1568191020000, ECM: 26311.466666666667 },
+                { timestamp: 1568191140000, ECM: 1666775.3333333333, GSWY: 1332.5333333333333 }
+            ], {
+                dimensions: null,
+                seriesLayoutBy: null,
+                sourceHeader: false
+            }, SOURCE_FORMAT_OBJECT_ROWS);
+
+            expect(source.dimensionsDefine.map(dim => dim.name)).toEqual(['timestamp', 'ECM', 'GSWY']);
         });
 
         function createStore() {

--- a/test/ut/spec/series/bar.test.ts
+++ b/test/ut/spec/series/bar.test.ts
@@ -1,0 +1,65 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart } from '../../core/utHelper';
+
+
+describe('bar', function () {
+
+    it('should respect encoded object-row dimensions missing from earlier rows', function () {
+        const chart = createChart({width: 400, height: 300});
+
+        try {
+            chart.setOption({
+                animation: false,
+                dataset: {
+                    source: [
+                        { timestamp: 1568191020000, ECM: 26311.466666666667 },
+                        { timestamp: 1568191140000, ECM: 1666775.3333333333, GSWY: 1332.5333333333333 }
+                    ]
+                },
+                xAxis: { type: 'time' },
+                yAxis: { type: 'value' },
+                series: [{
+                    type: 'bar',
+                    name: 'ECM',
+                    encode: { x: 'timestamp', y: 'ECM' },
+                    stack: 'one'
+                }, {
+                    type: 'bar',
+                    name: 'GSWY',
+                    encode: { x: 'timestamp', y: 'GSWY' },
+                    stack: 'one'
+                }]
+            });
+
+            const series = (chart as any).getModel().getSeriesByIndex(1);
+            const data = series.getData();
+            const yDim = data.mapDimension('y');
+
+            expect(yDim).toBe('GSWY');
+            expect(isNaN(data.get(yDim, 0))).toBe(true);
+            expect(data.get(yDim, 1)).toBe(1332.5333333333333);
+        }
+        finally {
+            chart.dispose();
+        }
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Collects dimensions from all object-row dataset entries so sparse fields referenced by `series.encode` map to the correct data.

### Fixed issues

- Fix #11322: Bar charts can use the wrong dataset dimension when a property is absent from the first object row.

## Details

### Before: What was the problem?

ECharts detected object-row dataset dimensions using only the first non-empty object.

For data such as:

```js
dataset: {
    source: [
        { timestamp: 1568191020000, ECM: 26311.466666666667 },
        {
            timestamp: 1568191140000,
            ECM: 1666775.3333333333,
            GSWY: 1332.5333333333333
        }
    ]
}
```

the `GSWY` dimension was not detected because it was absent from the first row.

Consequently, a bar series configured with:

```js
encode: {
    x: 'timestamp',
    y: 'GSWY'
}
```

could silently map its y-axis data to another detected dimension, such as `ECM`, and render incorrect values.

### After: How does it behave after the fixing?

Object-row dimension detection now collects each unique property across all rows while preserving first-seen order.

As a result, `GSWY` is registered as a dataset dimension even when it is absent from earlier rows. The corresponding series correctly maps its y-axis data to `GSWY`; rows without that property remain empty instead of using values from another dimension.

Regression tests cover both source dimension detection and the stacked bar chart behavior from the issue.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Regression coverage was added in:

- `test/ut/spec/data/SeriesData.test.ts`
- `test/ut/spec/series/bar.test.ts`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validated with:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/data/SeriesData.test.ts test/ut/spec/series/bar.test.ts
npx eslint src/data/Source.ts test/ut/spec/data/SeriesData.test.ts test/ut/spec/series/bar.test.ts
npm run checktype
npm run lint
git diff --check
```