### PR TITLE
fix(bar): draw bars stacked over out-of-log-domain values from the axis start

### DIFF
--- a/src/layout/barGrid.ts
+++ b/src/layout/barGrid.ts
@@ -446,7 +446,12 @@ export function createProgressiveLayout(seriesType: string): StageHandler {
                         if (isValueAxisH) {
                             const coord = cartesian.dataToPoint([value, baseValue]);
                             if (stacked) {
-                                baseCoord = cartesian.dataToPoint([stackStartValue, baseValue])[0];
+                                const stackStartCoord = cartesian.dataToPoint([stackStartValue, baseValue])[0];
+                                // On a log axis, a `stackStartValue` that is out of the log domain
+                                // (e.g., 0, resulting from stacking over a null value) maps to a
+                                // non-finite coordinate. Draw the bar from the axis start in that
+                                // case, as if it were the first bar in the stack.
+                                baseCoord = isFinite(stackStartCoord) ? stackStartCoord : valueAxisStart;
                             }
                             x = baseCoord;
                             y = coord[1] + columnOffset;
@@ -460,7 +465,9 @@ export function createProgressiveLayout(seriesType: string): StageHandler {
                         else {
                             const coord = cartesian.dataToPoint([baseValue, value]);
                             if (stacked) {
-                                baseCoord = cartesian.dataToPoint([baseValue, stackStartValue])[1];
+                                const stackStartCoord = cartesian.dataToPoint([baseValue, stackStartValue])[1];
+                                // See the comment in the horizontal case above.
+                                baseCoord = isFinite(stackStartCoord) ? stackStartCoord : valueAxisStart;
                             }
                             x = coord[0] + columnOffset;
                             y = baseCoord;

--- a/test/bar-log.html
+++ b/test/bar-log.html
@@ -40,6 +40,7 @@ under the License.
 
 
         <div id="main0"></div>
+        <div id="main1"></div>
 
         <script>
 
@@ -72,6 +73,42 @@ under the License.
 
                 chart = myChart = testHelper.create(echarts, 'main0', {
                     title: 'bar in log axis',
+                    option: option,
+                    info: option
+                });
+            });
+
+        </script>
+
+        <script>
+
+            // See <https://github.com/apache/echarts/issues/19517>
+
+            require([
+                'echarts'
+            ], function (echarts) {
+                var option = {
+                    animation: false,
+                    yAxis: {
+                        type: 'log'
+                    },
+                    xAxis: {
+                        type: 'category',
+                        data: ['First', 'Second']
+                    },
+                    series: [{
+                        type: 'bar',
+                        data: ['-', 2000],
+                        stack: 'main'
+                    }, {
+                        type: 'bar',
+                        data: [2500, 3000],
+                        stack: 'main'
+                    }]
+                };
+
+                testHelper.create(echarts, 'main1', {
+                    title: 'stacked bars in log axis: there should be three bars (one in "First", two in "Second")',
                     option: option,
                     info: option
                 });

--- a/test/ut/spec/series/barStackLog.test.ts
+++ b/test/ut/spec/series/barStackLog.test.ts
@@ -1,0 +1,135 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts.all';
+import { createChart, getECModel } from '../../core/utHelper';
+import SeriesModel from '@/src/model/Series';
+
+describe('barStackLog', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    function getItemLayout(seriesIndex: number, dataIndex: number) {
+        const seriesModel = getECModel(chart).getSeriesByIndex(seriesIndex) as SeriesModel;
+        return seriesModel.getData().getItemLayout(dataIndex);
+    }
+
+    it('should layout a bar stacked over a null value on a log axis', function () {
+        // https://github.com/apache/echarts/issues/19517
+        chart.setOption({
+            animation: false,
+            yAxis: {
+                type: 'log'
+            },
+            xAxis: {
+                type: 'category',
+                data: ['First', 'Second']
+            },
+            series: [{
+                type: 'bar',
+                data: ['-', 2000],
+                stack: 'main'
+            }, {
+                type: 'bar',
+                data: [2500, 3000],
+                stack: 'main'
+            }]
+        });
+
+        // The bar of the second series at 'First' is stacked over a null
+        // value. Its layout should be finite so that it gets rendered.
+        const layout = getItemLayout(1, 0);
+        expect(isFinite(layout.x)).toEqual(true);
+        expect(isFinite(layout.y)).toEqual(true);
+        expect(isFinite(layout.width)).toEqual(true);
+        expect(isFinite(layout.height)).toEqual(true);
+
+        // It should be drawn from the value axis start, like a bar that is
+        // the first in its stack.
+        const firstInStackLayout = getItemLayout(0, 1);
+        expect(layout.y).toBeCloseTo(firstInStackLayout.y);
+    });
+
+    it('should layout a horizontal bar stacked over a null value on a log axis', function () {
+        chart.setOption({
+            animation: false,
+            xAxis: {
+                type: 'log'
+            },
+            yAxis: {
+                type: 'category',
+                data: ['First', 'Second']
+            },
+            series: [{
+                type: 'bar',
+                data: ['-', 2000],
+                stack: 'main'
+            }, {
+                type: 'bar',
+                data: [2500, 3000],
+                stack: 'main'
+            }]
+        });
+
+        const layout = getItemLayout(1, 0);
+        expect(isFinite(layout.x)).toEqual(true);
+        expect(isFinite(layout.y)).toEqual(true);
+        expect(isFinite(layout.width)).toEqual(true);
+        expect(isFinite(layout.height)).toEqual(true);
+
+        const firstInStackLayout = getItemLayout(0, 1);
+        expect(layout.x).toBeCloseTo(firstInStackLayout.x);
+    });
+
+    it('should not change the layout of stacked bars with all values present', function () {
+        chart.setOption({
+            animation: false,
+            yAxis: {
+                type: 'log'
+            },
+            xAxis: {
+                type: 'category',
+                data: ['First', 'Second']
+            },
+            series: [{
+                type: 'bar',
+                data: [1000, 2000],
+                stack: 'main'
+            }, {
+                type: 'bar',
+                data: [2500, 3000],
+                stack: 'main'
+            }]
+        });
+
+        // The base of the stacked-over bar should be at the coordinate of
+        // the stacked-on value.
+        const bottomLayout = getItemLayout(0, 0);
+        const topLayout = getItemLayout(1, 0);
+        expect(topLayout.y).toBeCloseTo(bottomLayout.y + bottomLayout.height);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Draws a bar that is stacked over an out-of-log-domain value (e.g. stacked over a null value) from the value axis start, instead of silently not rendering it.

### Fixed issues

- #19517

## Details

### Before: What was the problem?

When bars are stacked on a log axis and a lower series has a null (`'-'`) value, the upper bar's stack base is `0`. Since `log(0)` is `-Infinity`, that bar's base coordinate is non-finite and the rect is never drawn, even though the value still shows up in the tooltip. Minimal repro is in #19517 ([live example](https://echarts.apache.org/examples/en/editor.html?code=PYBwLglsB2AEC8sDeAoWsCG0IFsORgC5YAzDAGwGcBTAGjVjGGHMhGKQF970BPAQQAeEShwbowvENWIBycsADmshtwaChIseglSZsWQGN81RcABOvWTx0ATfBmIBtWQDEI5ymGsGAytUMYW1kAXVUbGnMIalFYJ3FkBN1pOQAjDHNrJNgAehzYVIBXRWIwAAtqc2pYSkKQEGAaW0ZgAuryquqqwzAsRXIY2BhGCprDTuhsvNgAeWhyXkYAd1aM6ttzDCXoADps-17nWQBaHwAmAAYrkJsdGt7DAGs5PAhoFTu1O9Q75P1ZdKZW52BzOM4AViutFgAGYrhcbtkvBgni8MG8PjpOAwwpwANxAA)).

Per the analysis in #19517 this seems to have regressed in 5.3.0 with the bar layout changes; earlier versions rendered this case fine.

The second series' bar (2500 in `First`, stacked over the null) is simply missing:

<img width="600" alt="before: only two bars drawn, First is empty" src="https://raw.githubusercontent.com/rusackas/echarts/assets-19517/before.png" />

### After: How does it behave after the fixing?

In the progressive bar layout, a non-finite stacked base coordinate is clamped back to the value axis start, in both orientations. A bar stacked over a null value is drawn from the axis start, using the same baseline as the first bar in a stack. Bars in fully-populated stacks are unaffected.

Same option with this fix, all three bars drawn:

<img width="600" alt="after: all three bars drawn" src="https://raw.githubusercontent.com/rusackas/echarts/assets-19517/after.png" />

Added unit tests in `test/ut/spec/series/barStackLog.test.ts` (vertical, horizontal, and a guard asserting fully-populated stacked layouts are unchanged). The first two fail without the fix. Also added a manual case to `test/bar-log.html`.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

`test/bar-log.html`, second chart.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

I'm aware of the conclusion in #19234 that stacked bars on a log axis can be misleading, and this PR doesn't take a position on that. The proportions concern is about how visible bars are read. This is a different problem: a value that exists in the data and the tooltip silently doesn't render at all, which reads as data loss rather than distortion. The drawn bar's top edge is still truthful against the axis.

#19518 attempted a fix for the same issue but hardcoded the stack base to `1`, which would be wrong whenever the axis min isn't 1. This version clamps the computed pixel coordinate instead, so no data values are changed.

For what it's worth, we hit this downstream in Apache Superset (apache/superset#25829), where stacked bar charts on a log axis drop bars whenever a series has gaps in it.
