### PR TITLE
fix(treemap): align rich bottom labels. close #17591

### DIFF
--- a/src/chart/treemap/TreemapView.ts
+++ b/src/chart/treemap/TreemapView.ts
@@ -1004,6 +1004,14 @@ function renderNode(
         }
         const textStyle = textEl.style;
         const textPadding = normalizeCssArray(textStyle.padding || 0);
+        const textPosition = normalLabelModel.getShallow('position');
+        // An explicit rich text height becomes the block height, leaving its tokens
+        // at the top of the block even when that block is aligned to the bottom.
+        const isRichTextBottomPosition = textStyle.rich && (
+            textPosition === 'insideBottom'
+            || textPosition === 'insideBottomLeft'
+            || textPosition === 'insideBottomRight'
+        );
 
         if (upperLabelRect) {
             rectEl.setTextConfig({
@@ -1015,9 +1023,12 @@ function renderNode(
             const width = Math.max(
                 (upperLabelRect ? upperLabelRect.width : rectEl.shape.width) - textPadding[1] - textPadding[3], 0
             );
-            const height = Math.max(
-                (upperLabelRect ? upperLabelRect.height : rectEl.shape.height) - textPadding[0] - textPadding[2], 0
-            );
+            const height = isRichTextBottomPosition
+                ? null
+                : Math.max(
+                    (upperLabelRect ? upperLabelRect.height : rectEl.shape.height)
+                        - textPadding[0] - textPadding[2], 0
+                );
             if (textStyle.width !== width || textStyle.height !== height) {
                 textEl.setStyle({
                     width,

--- a/test/treemap-label-position-rich.html
+++ b/test/treemap-label-position-rich.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css">
+</head>
+<body>
+    <div id="main"></div>
+
+    <script>
+        require(['echarts'], function (echarts) {
+            var positions = [
+                'insideTopLeft',
+                'inside',
+                'insideBottomLeft',
+                'insideBottom',
+                'insideBottomRight'
+            ];
+            var colors = ['#5470c6', '#91cc75', '#fac858', '#ee6666', '#73c0de'];
+            var series = [];
+
+            positions.forEach(function (position, rowIndex) {
+                [false, true].forEach(function (rich, columnIndex) {
+                    var labelText = (rich ? 'Rich: ' : 'Plain: ') + position;
+                    series.push({
+                        type: 'treemap',
+                        animation: false,
+                        breadcrumb: {show: false},
+                        nodeClick: false,
+                        roam: false,
+                        left: columnIndex === 0 ? '3%' : '52%',
+                        top: (rowIndex * 19 + 2) + '%',
+                        width: '45%',
+                        height: '16%',
+                        itemStyle: {
+                            borderColor: '#fff',
+                            borderWidth: 2
+                        },
+                        label: {
+                            show: true,
+                            position: position,
+                            color: '#fff',
+                            fontSize: 16,
+                            formatter: rich ? '{label|' + labelText + '}\nsecond line' : labelText + '\nsecond line',
+                            rich: rich ? {
+                                label: {
+                                    color: '#fff',
+                                    fontSize: 16,
+                                    fontWeight: 'bold'
+                                }
+                            } : undefined
+                        },
+                        data: [{
+                            name: labelText,
+                            value: 1,
+                            itemStyle: {color: colors[rowIndex]}
+                        }]
+                    });
+                });
+            });
+
+            testHelper.create(echarts, 'main', {
+                title: [
+                    '#17591: bottom-aligned rich treemap labels',
+                    'Plain labels are on the left; equivalent rich labels are on the right.',
+                    'The three bottom rows should align; top and center are compatibility controls.'
+                ],
+                option: {series: series},
+                height: 900
+            });
+        });
+    </script>
+</body>
+</html>

--- a/test/ut/spec/series/treemap.test.ts
+++ b/test/ut/spec/series/treemap.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EChartsType } from '@/src/echarts';
+import { TreemapSeriesOption } from '@/src/chart/treemap/TreemapSeries';
+import Text, { TextStyleProps } from 'zrender/src/graphic/Text';
+import TSpan from 'zrender/src/graphic/TSpan';
+import { createChart, getGraphicElements } from '../../core/utHelper';
+
+type TreemapLabelPosition = NonNullable<TreemapSeriesOption['label']>['position'];
+
+interface RenderedLabel {
+    height: number | null
+    x: number
+    y: number
+}
+
+function getTreemapText(chart: EChartsType): Text {
+    const elements = getGraphicElements(chart, 'series', 0);
+    for (let i = 0; i < elements.length; i++) {
+        const text = elements[i].getTextContent();
+        if (text) {
+            return text;
+        }
+    }
+    throw new Error('Treemap label was not rendered.');
+}
+
+function renderLabel(position: TreemapLabelPosition, rich: boolean): RenderedLabel {
+    const chart = createChart({width: 400, height: 300});
+
+    try {
+        chart.setOption({
+            animation: false,
+            series: [{
+                type: 'treemap',
+                breadcrumb: {show: false},
+                nodeClick: false,
+                roam: false,
+                left: 0,
+                top: 0,
+                width: 400,
+                height: 300,
+                data: [{name: 'foo', value: 100}],
+                label: {
+                    show: true,
+                    position,
+                    fontSize: 18,
+                    formatter: rich ? '{label|foo}\nbar' : 'foo\nbar',
+                    rich: rich ? {label: {fontSize: 18}} : undefined
+                }
+            }]
+        });
+        chart.getZr().refreshImmediately();
+
+        const text = getTreemapText(chart);
+        const textSpan = text.childrenRef().filter(child => child instanceof TSpan)[0] as TSpan;
+        if (!textSpan) {
+            throw new Error('Treemap label text span was not rendered.');
+        }
+
+        return {
+            height: (text.style as TextStyleProps & {height: number | null}).height,
+            x: textSpan.style.x,
+            y: textSpan.style.y
+        };
+    }
+    finally {
+        chart.dispose();
+    }
+}
+
+describe('treemap label', function () {
+    it.each([
+        'insideBottom',
+        'insideBottomLeft',
+        'insideBottomRight'
+    ] as const)('aligns rich text at %s like plain text', function (position) {
+        const plainLabel = renderLabel(position, false);
+        const richLabel = renderLabel(position, true);
+
+        expect(richLabel.height).toBeNull();
+        expect(richLabel.x).toBeCloseTo(plainLabel.x);
+        expect(richLabel.y).toBeCloseTo(plainLabel.y);
+    });
+
+    it.each([
+        'insideTopLeft',
+        'inside'
+    ] as const)('retains the rich text height constraint at %s', function (position) {
+        const plainLabel = renderLabel(position, false);
+        const richLabel = renderLabel(position, true);
+
+        expect(richLabel.height).toBe(plainLabel.height);
+        expect(richLabel.height).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Corrects the alignment of rich treemap labels using `insideBottom`, `insideBottomLeft`, or `insideBottomRight`.

### Fixed issues

- #17591: Rich treemap labels configured with `insideBottomLeft` were displayed at the top of their cells.

## Details

### Before: What was the problem?

Treemap labels were always assigned the full available cell height. ZRender interprets an explicit height as the height of the entire rich-text block, so bottom-aligned rich labels kept their text tokens at the top of that block and appeared at the top of the treemap cell.

Plain-text labels were not affected in the same way.

### After: How does it behave after the fixing?

Rich labels configured with `insideBottom`, `insideBottomLeft`, or `insideBottomRight` now use their natural content height and align correctly at the bottom of the treemap cell.

The change is intentionally limited to these three positions. Plain labels and rich labels at top or center positions retain their existing height constraints, minimizing unrelated visual changes.

Unit tests cover multiline labels with mixed rich and plain content, all three bottom positions, and compatibility controls for unaffected positions. A focused visual test case was also added.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/treemap-label-position-rich.html`
- `test/ut/spec/series/treemap.test.ts`

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information

Validated with:

- Focused Jest tests: 5 tests passed
- `npm run lint`
- `npm run checktype`
- Local bundle build
- SVG renderer validation confirming zero position difference between equivalent plain and rich bottom-aligned labels