### PR TITLE
fix(core): preserve event query context. close #21584

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -1357,14 +1357,22 @@ class ECharts extends Eventful<ECEventDefinition> {
                     params.event = e;
                     params.type = eveName;
 
-                    (this._$eventProcessor as ECEventProcessor).eventInfo = {
+                    const eventProcessor = this._$eventProcessor as ECEventProcessor;
+                    // A user handler may synchronously trigger another ECharts event.
+                    const previousEventInfo = eventProcessor.eventInfo;
+                    eventProcessor.eventInfo = {
                         targetEl: el,
                         packedEvent: params,
                         model: model,
                         view: view
                     };
 
-                    this.trigger(eveName, params);
+                    try {
+                        this.trigger(eveName, params);
+                    }
+                    finally {
+                        eventProcessor.eventInfo = previousEventInfo;
+                    }
                 }
             };
             // Consider that some component (like tooltip, brush, ...)

--- a/src/util/ECEventProcessor.ts
+++ b/src/util/ECEventProcessor.ts
@@ -144,8 +144,4 @@ export class ECEventProcessor implements EventProcessor {
         }
     }
 
-    afterTrigger() {
-        // Make sure the eventInfo won't be used in next trigger.
-        this.eventInfo = null;
-    }
 };

--- a/test/ut/spec/api/event.test.ts
+++ b/test/ut/spec/api/event.test.ts
@@ -1,0 +1,99 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '../../../../src/echarts';
+import { createChart, getECModel } from '../../core/utHelper';
+
+describe('api/event', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart();
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should preserve the event query context when a handler calls setOption', function () {
+        chart.setOption({
+            xAxis: {
+                type: 'category',
+                data: ['Mon', 'Tue']
+            },
+            yAxis: {
+                type: 'value'
+            },
+            series: [
+                {
+                    id: 'first',
+                    type: 'line',
+                    data: [1, 2]
+                },
+                {
+                    id: 'second',
+                    type: 'line',
+                    data: [2, 3]
+                }
+            ]
+        });
+
+        const triggeredSeries: string[] = [];
+
+        chart.on('click', {seriesId: 'first'}, function () {
+            triggeredSeries.push('first');
+            chart.setOption({
+                series: [{
+                    id: 'first',
+                    data: [3, 4]
+                }]
+            });
+        });
+        chart.on('click', {seriesId: 'second'}, function () {
+            triggeredSeries.push('second');
+        });
+
+        const target = getECModel(chart)
+            .getSeriesByIndex(0)
+            .getData()
+            .getItemGraphicEl(0);
+
+        chart.getZr().trigger('click', {
+            target: target,
+            offsetX: 10,
+            offsetY: 10
+        });
+
+        expect(triggeredSeries).toEqual(['first']);
+
+        const secondTarget = getECModel(chart)
+            .getSeriesByIndex(1)
+            .getData()
+            .getItemGraphicEl(0);
+
+        chart.getZr().trigger('click', {
+            target: secondTarget,
+            offsetX: 10,
+            offsetY: 10
+        });
+
+        expect(triggeredSeries).toEqual(['first', 'second']);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Preserves mouse-event query context across nested ECharts events so handlers remain correctly filtered when an earlier handler calls `setOption`.

### Fixed issues

- #21584: Event handlers filtered by `seriesId` could incorrectly run for another series after a preceding handler called `setOption`.

## Details

### Before: What was the problem?

Mouse-event queries use `ECEventProcessor.eventInfo` to determine the source series or component.

When a matching handler synchronously called `setOption`, ECharts emitted a nested `updated` event. The nested event's `afterTrigger` hook cleared the shared mouse-event context before the original click dispatch had finished.

Consequently, later click handlers found no event context. Since missing context is treated as unfiltered, a handler registered for another series could run incorrectly:

```js
chart.on('click', { seriesId: 'first' }, function () {
    chart.setOption(...);
});

chart.on('click', { seriesId: 'second' }, function () {
    // This could incorrectly run after clicking "first".
});
```

### After: How does it behave after the fixing?

The mouse-event handler now scopes `eventInfo` to its dispatch:

1. Save the previous event context.
2. Set the current mouse-event context.
3. Trigger the event handlers.
4. Restore the previous context in a `finally` block.

The unconditional `afterTrigger` cleanup was removed because it could clear an outer event's context during a nested trigger.

As a result, synchronous nested events no longer bypass the remaining event-query filters. The context is also restored safely if an event handler throws.

A regression test verifies that:

- clicking the first series only invokes its matching handler, even when that handler calls `setOption`;
- a later click on the second series is still routed to the correct handler.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/ut/spec/api/event.test.ts`

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validated with:

```sh
npx jest --config test/ut/jest.config.cjs --coverage=false --runInBand --runTestsByPath test/ut/spec/api/event.test.ts
TZ=UTC npm test -- --runInBand
npm run checktype
npm run lint
npx eslint src/core/echarts.ts src/util/ECEventProcessor.ts test/ut/spec/api/event.test.ts
git diff --check
```

The complete unit suite passed with 26 test suites and 193 tests.