### PR TITLE
fix(geo): tolerate singular view transform when chart size is zero

### DIFF
--- a/src/coord/View.ts
+++ b/src/coord/View.ts
@@ -564,11 +564,12 @@ function legacyCopyOverallTrans(
     if (target) {
         copyTransform(target, overallTrans);
         matrixCopy(target.transform || (target.transform = []), mtOverall);
+        const invTransform = target.invTransform || (target.invTransform = matrixCreate());
         if (mtOverallInv) {
             // `matrixInvert` returns null if the overall transform is singular (e.g., a
-            // zero-sized view rect when the chart container is hidden or sized 0x0).
-            // Keep the last inverse in that case (as before v6.1.0) rather than crash.
-            matrixCopy(target.invTransform || (target.invTransform = []), mtOverallInv);
+            // zero-sized view rect when the chart container is hidden or sized 0x0);
+            // keep the last inverse in that case rather than crash.
+            matrixCopy(invTransform, mtOverallInv);
         }
     }
 }

--- a/src/coord/View.ts
+++ b/src/coord/View.ts
@@ -559,12 +559,17 @@ function legacyCopyOverallTrans(
     target: Transformable | NullUndefined,
     overallTrans: Transformable,
     mtOverall: MatrixArray,
-    mtOverallInv: MatrixArray
+    mtOverallInv: MatrixArray | NullUndefined
 ): void {
     if (target) {
         copyTransform(target, overallTrans);
         matrixCopy(target.transform || (target.transform = []), mtOverall);
-        matrixCopy(target.invTransform || (target.invTransform = []), mtOverallInv);
+        if (mtOverallInv) {
+            // `matrixInvert` returns null if the overall transform is singular (e.g., a
+            // zero-sized view rect when the chart container is hidden or sized 0x0).
+            // Keep the last inverse in that case (as before v6.1.0) rather than crash.
+            matrixCopy(target.invTransform || (target.invTransform = []), mtOverallInv);
+        }
     }
 }
 

--- a/test/ut/spec/component/geo/geo.test.ts
+++ b/test/ut/spec/component/geo/geo.test.ts
@@ -1,0 +1,75 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType, registerMap } from '../../../../../src/echarts';
+import { GeoJSON } from '../../../../../src/coord/geo/geoTypes';
+import { createChart } from '../../../core/utHelper';
+
+describe('geo', function () {
+
+    const testGeoJson: GeoJSON = {
+        'type': 'FeatureCollection',
+        'features': [
+            {
+                'type': 'Feature',
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [
+                        [
+                            [0, 0],
+                            [10, 0],
+                            [10, 10],
+                            [0, 10]
+                        ]
+                    ]
+                },
+                'properties': {
+                    'name': 'A',
+                    'childNum': 1
+                }
+            }
+        ]
+    };
+    registerMap('geo_test_zero_size', testGeoJson);
+
+    let chart: EChartsType;
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('should not throw when the chart size is zero', function () {
+        // A hidden (display:none) container makes the chart 0x0. The geo view
+        // transform is singular then and must not crash. See #21706.
+        chart = createChart({ opts: { width: 0, height: 0 } });
+        expect(function () {
+            chart.setOption({
+                geo: {
+                    map: 'geo_test_zero_size'
+                },
+                series: [
+                    {
+                        type: 'scatter',
+                        coordinateSystem: 'geo',
+                        data: [{ name: 'x', value: [5, 5, 1] }]
+                    }
+                ]
+            });
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes the `TypeError: Cannot read properties of null (reading '0')` thrown by every geo/map chart whose size is 0×0 (e.g. a container hidden with `display: none`) — a regression introduced in 6.1.0.

### Fixed issues

- #21706: [Bug] Geo/map chart crashes with "Cannot read properties of null (reading '0')" when chart size is 0×0 (regression in 6.1.0)


## Details

### Before: What was the problem?

With a zero-sized view rect the overall view transform has zero scale, so its determinant is 0 and zrender's `matrix.invert()` returns `null` without writing `out`. `viewCoordSysUpdateOverallTrans` passed that return value to `legacyCopyOverallTrans` unguarded, where `matrixCopy(target.invTransform, null)` dereferences `null[0]`.

Before 6.1.0, the equivalent code (`View.prototype._updateTransform`) ignored `invert()`'s return value — `invTransform` simply kept its previous contents — so zero-sized geo charts were tolerated. Since the failure happens inside the update pipeline, in real apps it re-throws on every animation frame until the chart is disposed.

### After: How does it behave after the fixing?

`legacyCopyOverallTrans` skips the inverse copy when `matrixInvert` returned `null`, keeping the last inverse — the same semantics as before 6.1.0 (and the same as the existing `matrixInvert(viewInner.mtRawInv, mtRaw)` call in this file, whose return value is likewise ignored). Zero-sized geo/map charts render without throwing; a regression unit test is included (fails before the fix, passes after).


## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
