### PR TITLE
feat(toolbox): expose toolbox feature extension API

### DIFF
--- a/src/component/toolbox/featureManager.ts
+++ b/src/component/toolbox/featureManager.ts
@@ -102,7 +102,7 @@ export interface UserDefinedToolboxFeature {
     onclick(): void
 }
 
-type ToolboxFeatureCtor = {
+export type ToolboxFeatureCtor = {
     new(): ToolboxFeature
     /**
      * Static defaultOption property

--- a/src/export/core.ts
+++ b/src/export/core.ts
@@ -23,6 +23,18 @@ export * from '../core/echarts';
 export * from './api';
 import { use } from '../extension';
 
+export type {
+    EChartsExtension,
+    EChartsExtensionInstaller,
+    EChartsExtensionInstallRegisters
+} from '../extension';
+export {
+    ToolboxFeature,
+    ToolboxFeatureOption,
+    ToolboxFeatureModel,
+    ToolboxFeatureCtor
+} from '../component/toolbox/featureManager';
+
 // Import label layout by default.
 // TODO will be treeshaked.
 import { installLabelLayout } from '../label/installLabelLayout';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ import { registerImpl } from './core/impl';
 import { registerPainter } from 'zrender/src/zrender';
 import { CustomSeriesRenderItem } from './chart/custom/CustomSeries';
 import { registerCustomSeries } from './chart/custom/customSeriesRegister';
+import { registerFeature as registerToolboxFeature } from './component/toolbox/featureManager';
 
 const extensions: (EChartsExtensionInstaller | EChartsExtension)[] = [];
 
@@ -60,6 +61,7 @@ const extensionRegisters = {
     registerLoading,
     registerMap,
     registerImpl,
+    registerToolboxFeature,
 
     PRIORITY,
 

--- a/test/types/esm/importPartial.ts
+++ b/test/types/esm/importPartial.ts
@@ -17,7 +17,14 @@
 * under the License.
 */
 
-import {init, use, ComposeOption} from 'echarts/core';
+import {
+    init,
+    use,
+    ComposeOption,
+    EChartsExtensionInstaller,
+    ToolboxFeature,
+    ToolboxFeatureOption
+} from 'echarts/core';
 import {
     BarChart,
     BarSeriesOption,
@@ -35,6 +42,23 @@ import {
 } from 'echarts/renderers';
 
 use([BarChart, LineChart, GridComponent, DataZoomComponent, CanvasRenderer]);
+
+interface ExportDataFeatureOption extends ToolboxFeatureOption {
+    filename?: string
+}
+
+class ExportDataFeature extends ToolboxFeature<ExportDataFeatureOption> {
+    onclick(): void {
+        this.api.getOption();
+        this.model.get('filename');
+    }
+}
+
+const installExportData: EChartsExtensionInstaller = function (registers) {
+    registers.registerToolboxFeature('exportData', ExportDataFeature);
+};
+
+use(installExportData);
 
 type Option = ComposeOption<
     GridComponentOption

--- a/test/ut/spec/component/toolbox/featureExtension.test.ts
+++ b/test/ut/spec/component/toolbox/featureExtension.test.ts
@@ -1,0 +1,46 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import {
+    EChartsExtensionInstaller,
+    ToolboxFeature,
+    ToolboxFeatureOption,
+    use
+} from '@/src/export/core';
+import { getFeature } from '@/src/component/toolbox/featureManager';
+
+interface ExportDataFeatureOption extends ToolboxFeatureOption {
+    filename?: string
+}
+
+class ExportDataFeature extends ToolboxFeature<ExportDataFeatureOption> {
+    onclick(): void {}
+}
+
+describe('toolbox feature extension', function () {
+    it('registers a toolbox feature through the extension API', function () {
+        const install: EChartsExtensionInstaller = function (registers) {
+            registers.registerToolboxFeature('exportData', ExportDataFeature);
+        };
+
+        use(install);
+
+        expect(getFeature('exportData')).toBe(ExportDataFeature);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Exposes a stable toolbox-feature registration API for independently packaged ECharts extensions.

### Fixed issues

- #21693: provides the core extension point required by the proposed independent `export-toolbox` package; the exporter package itself remains outside ECharts core.

## Details

### Before: What was the problem?

Toolbox features are stored in an internal registry. ECharts extensions installed with `echarts.use()` cannot access that registry, and the public custom-feature path only recognizes option keys prefixed with `my`. As a result, an independent package cannot register a first-class feature such as `toolbox.feature.exportData` without importing internal modules.

### After: How does it behave after the fixing?

The extension installer now exposes `registerToolboxFeature(name, ctor)`. `ToolboxFeature` and its option/model/constructor types, together with the extension installer types, are exported from `echarts/core`.

An external package can now register a feature through the normal extension lifecycle:

```ts
class ExportDataFeature extends ToolboxFeature<ExportDataFeatureOption> {
    onclick(): void {
        // Delegate to the package's shared programmatic exporter.
    }
}

const install: EChartsExtensionInstaller = (registers) => {
    registers.registerToolboxFeature('exportData', ExportDataFeature);
};

echarts.use(install);
```

The change adds no exporter implementation or third-party dependency to ECharts core. CSV/PDF/XLSX implementations can remain independently packaged and tree-shakeable. Registering an extension only makes the feature available; each chart must explicitly configure it, and the feature's `show` option controls whether its button is displayed.

## Document Info

- [ ] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [x] The document changes have been made in apache/echarts-doc#524

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- Unit coverage verifies registration through `echarts.use()`.
- Public DTS coverage verifies subclassing `ToolboxFeature` and calling `registerToolboxFeature` from `echarts/core`.
- `npm run checktype`
- Targeted Jest and ESLint checks
- DTS tests with TypeScript 4.7 through 5.9
- Physical browser test with a real chart, toolbox click, and downloaded CSV content verification

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

The matching independent exporter prototype uses explicit `table` / `getTable(chart)` data sources and shares one exporter registry between its toolbox and programmatic APIs, as described in #21693.
