### PR TITLE
fix(visualMap): retain string type for raw categories to avoid precision loss (#21714)

### DIFF
--- a/src/visual/visualSolution.ts
+++ b/src/visual/visualSolution.ts
@@ -165,28 +165,36 @@ export function applyVisual<VisualState extends string, Scope>(
     }
 
     function eachItem(valueOrIndex: ParsedValue | number, index?: number) {
-        dataIndex = dimension == null
-            ? valueOrIndex as number    // First argument is index
-            : index;
+    dataIndex = dimension == null
+        ? valueOrIndex as number    // First argument is index
+        : index;
 
-        const rawDataItem = data.getRawDataItem(dataIndex);
-        // Consider performance
-        // @ts-ignore
-        if (rawDataItem && rawDataItem.visualMap === false) {
-            return;
-        }
+    const rawDataItem = data.getRawDataItem(dataIndex);
+    // Consider performance
+    // @ts-ignore
+    if (rawDataItem && rawDataItem.visualMap === false) {
+        return;
+    }
 
-        const valueState = getValueState.call(scope, valueOrIndex);
-        const mappings = visualMappings[valueState];
-        const visualTypes = visualTypesMap[valueState];
-
-        for (let i = 0, len = visualTypes.length; i < len; i++) {
-            const type = visualTypes[i];
-            mappings[type] && mappings[type].applyVisual(
-                valueOrIndex, getVisual, setVisual
-            );
+    let val = valueOrIndex;
+    if (dimension != null && zrUtil.isArray(rawDataItem)) {
+        const rawVal = (rawDataItem as any[])[+dimension];
+        if (typeof rawVal === 'string') {
+        val = rawVal;
         }
     }
+
+    const valueState = getValueState.call(scope, val);
+    const mappings = visualMappings[valueState];
+    const visualTypes = visualTypesMap[valueState];
+
+    for (let i = 0, len = visualTypes.length; i < len; i++) {
+        const type = visualTypes[i];
+        mappings[type] && mappings[type].applyVisual(
+            val, getVisual, setVisual
+        );
+    }
+}
 }
 
 /**
@@ -234,9 +242,16 @@ export function incrementalApplyVisual<VisualState extends string>(
                     continue;
                 }
 
-                const value = dim != null
+                let value = dim != null
                     ? store.get(dimIndex, dataIndex)
                     : dataIndex;
+
+                if (dim != null && zrUtil.isArray(rawDataItem)) {
+                    const rawVal = (rawDataItem as any[])[dimIndex as number];
+                    if (typeof rawVal === 'string') {
+                        value = rawVal;
+                    }
+                }
 
                 const valueState = getValueState(value);
                 const mappings = visualMappings[valueState];

--- a/test/test_bug21714.html
+++ b/test/test_bug21714.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>VisualMap Bug #21714</title>
+    <!-- test फ़ोल्डर के अंदर होने के कारण ../dist/echarts.js लगेगा -->
+    <script src="../dist/echarts.js"></script>
+</head>
+<body>
+    <h2 style="text-align: center;">VisualMap Large String Bug (#21714)</h2>
+    <div id="main" style="width: 800px; height: 500px; margin: 0 auto; border: 1px solid #ccc;"></div>
+
+    <script type="text/javascript">
+        var chartDom = document.getElementById('main');
+        var myChart = echarts.init(chartDom);
+
+        var option = {
+            xAxis: [{ type: 'category', data: ['Point A'] }],
+            yAxis: [{ type: 'value' }],
+            series: [{
+                type: 'scatter',
+                symbolSize: 30,
+                data: [['Point A', 10, '6053822903760037657']]
+            }],
+            visualMap: [{
+                type: 'piecewise',
+                dimension: 2,
+                inRange: {
+                    color: ['#ff0000', '#00ff00'] // Red & Green
+                },
+                categories: ['6053822903760037657', '6053822903760037658']
+            }]
+        };
+
+        myChart.setOption(option);
+    </script>
+</body>
+</html>


### PR DESCRIPTION


<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Retains string type for raw categories in visualMap during evaluation to prevent precision loss on large integer strings.

### Fixed issues

- #21714: Large string categories fail to map visually due to number conversion precision loss.


## Details

### Before: What was the problem?

When large integer strings (e.g., '6053822903760037657') are passed as categories in visualMap, converting them to numbers causes precision loss, causing visual mapping and rendering to fail.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How does it behave after the fixing?

The raw string type is preserved during visualMap evaluation in applyVisual, maintaining exact category matching and rendering the chart items correctly.

<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/test_bug21714.html

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information
