### PR TITLE
fix(MarkLineView): skip invalid markLine items that were normalized to undefined

### DIFF
--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -175,6 +175,10 @@ function markLineFilter(
     coordSys: CoordinateSystem,
     item: MarkLine2DDataItemOption
 ) {
+    // Skip invalid items where markLineTransform returned undefined (e.g. empty data entry)
+    if (!item[0] || !item[1]) {
+        return false;
+    }
     if (coordSys.type === 'cartesian2d') {
         const fromCoord = item[0].coord;
         const toCoord = item[1].coord;


### PR DESCRIPTION
## Fix: skip invalid markLine items that were normalized to undefined

### Issue
Fixes #21683

### Problem
When a markLine data entry is an empty object `{}`:
```js
markLine: {
    data: [
        { yAxis: 1 },
        {},          // <-- empty entry
        { yAxis: 3 }
    ]
}
```

`markLineTransform` normalizes the empty object to `[undefined, undefined, {...}]`.
The subsequent `markLineFilter` call then crashes on `item[0].coord` because `item[0]` is `undefined`,
causing **no markLines to be rendered at all** — not even the valid ones.

### Root Cause
In `markLineTransform`, the `else` branch (invalid data) sets `itemArray = []`, but the function continues to construct `normalizedItem` from `itemArray[0]`, `itemArray[1]`, `itemArray[2]` — all of which are `undefined`. The filter then crashes on the undefined values.

### Fix
Added a guard in `markLineFilter` to return `false` (skip) when `item[0]` or `item[1]` is undefined, which is the expected behavior: invalid entries should be silently skipped and valid entries should still render.

### Verification
- Valid markLines continue to render when no empty entries exist
- An empty `{}` entry is silently skipped without error
- Other valid markLines in the same data array still render normally
