### PR TITLE
fix(pie): correct label background width when backgroundColor and lineHeight both set with overflow break 

### DIFF
--- a/src/chart/pie/labelLayout.ts
+++ b/src/chart/pie/labelLayout.ts
@@ -292,6 +292,14 @@ function constrainTextWidth(
             // Temporarily set background to be null to calculate
             // the bounding box without background.
             label.setStyle('backgroundColor', null);
+            // Temporarily remove lineHeight to prevent the background
+            // rect from being created during measurement.
+            // zrender's needDrawBackground returns true when lineHeight
+            // is set, which creates a background rect at full availableWidth
+            // and inflates getBoundingRect().width.
+            // See https://github.com/apache/echarts/issues/21710
+            const savedLineHeight = (style as any).lineHeight;
+            label.setStyle('lineHeight', null);
             // Set constraining width
             label.setStyle('width', availableWidth - paddingH);
 
@@ -300,6 +308,7 @@ function constrainTextWidth(
 
             label.setStyle('width', Math.ceil(innerRect.width));
             label.setStyle('backgroundColor', bgColor);
+            label.setStyle('lineHeight', savedLineHeight);
         }
         else {
             const availableInnerWidth = availableWidth - paddingH;

--- a/test/ut/spec/series/pie-label.test.ts
+++ b/test/ut/spec/series/pie-label.test.ts
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { createChart } from '../../core/utHelper';
+
+describe('pie-label', function () {
+    it('should not inflate label background width when both backgroundColor and lineHeight are set with overflow break', function () {
+        const chart = createChart({ width: 800, height: 600 });
+
+        chart.setOption({
+            animation: false,
+            series: [{
+                type: 'pie',
+                radius: '60%',
+                center: ['50%', '50%'],
+                data: [
+                    { value: 40, name: '这是一段需要自动换行的超长文本标签' },
+                    { value: 30, name: '另一段长文本标签内容' },
+                    { value: 20, name: '短文本' }
+                ],
+                label: {
+                    show: true,
+                    backgroundColor: 'rgba(0,0,0,0.3)',
+                    overflow: 'break',
+                    lineHeight: 40,
+                    padding: [5, 10, 5, 10],
+                    fontSize: 14
+                },
+                labelLayout: {
+                    hideOverlap: false
+                }
+            }]
+        });
+
+        const model = (chart as any).getModel();
+        const series = model.getSeriesByIndex(0);
+        expect(series).not.toBeNull();
+
+        // Force layout to complete.
+        chart.getZr().refreshImmediately();
+
+        // Verify that each label's bounding rect width is constrained to the
+        // label text, not inflated to the full available width by the lineHeight
+        // background rect. The chart is 800px wide, so a correctly-sized label
+        // background should be well under 400px.
+        const data = series.getData();
+        data.each(function (idx) {
+            const sector = data.getItemGraphicEl(idx);
+            const label = sector && sector.getTextContent();
+            if (label) {
+                const rect = label.getBoundingRect();
+                expect(rect.width).toBeLessThan(400);
+            }
+        });
+    });
+});


### PR DESCRIPTION
fix(pie): correct label background width when backgroundColor and lineHeight both set with overflow break

## Problem
When a pie chart label has both `backgroundColor` and `overflow: 'break'` set,
and `lineHeight` is explicitly set, the label background width is abnormally
wide (inflated to the full available width).

## Root cause
In `constrainTextWidth`, when measuring the text bounding box for overflow
wrap, `backgroundColor` is temporarily set to `null`. However, zrender's
`needDrawBackground()` returns `true` when `lineHeight` is set, even without
`backgroundColor`. This creates a background rect at the full `availableWidth`,
which inflates `getBoundingRect().width`.

## Fix
Temporarily set `lineHeight` to `null` during measurement, preventing the
spurious background rect from being created. `lineHeight` only affects vertical
spacing and does not affect horizontal text wrapping width.

## Test
Added a unit test that creates a pie chart with label backgroundColor,
overflow: 'break', and lineHeight, then verifies the label bounding rect
width is not inflated beyond the label text width.

Closes #21710