### PR TITLE
fix(toolbox): reset dataZoom active state after restore action (Fixes #21691)

### DIFF
--- a/src/component/toolbox/feature/DataZoom.ts
+++ b/src/component/toolbox/feature/DataZoom.ts
@@ -296,6 +296,14 @@ function updateZoomBtnStatus(
         zoomActive = payload.key === 'dataZoomSelect'
             ? payload.dataZoomSelectActive : false;
     }
+    else if (payload && payload.type === 'restore') {
+        // Reset zoom state after restore. The restore action re-creates all
+        // models via resetOption('recreate'), so the previous zoom state is
+        // no longer valid. Without this reset, _isZoomActive stays true and
+        // the next zoom button click toggles to false instead of true,
+        // causing the zoom/restore/zoom cycle to malfunction.
+        zoomActive = false;
+    }
 
     view._isZoomActive = zoomActive;
 


### PR DESCRIPTION
### Fixes #21691

**Problem**: After using the toolbox dataZoom zoom, clicking "Restore" and then attempting to zoom again, the chart area shows blank.

**Root cause**: The `restore` action calls `resetOption('recreate')` which re-creates all chart models, but `_isZoomActive` in the dataZoom feature was never reset. After restore, `_isZoomActive` remained `true`, so the next zoom button click toggled it to `false` (disabling the brush). Additionally, the brush controller's internal state was stale after the model recreation, causing incorrect zoom range computation.

**Fix**: In `updateZoomBtnStatus`, handle the `restore` payload by resetting `zoomActive` to `false`. This ensures that after restore:
1. The zoom button is properly deactivated
2. The brush controller is disabled
3. The next zoom button click correctly activates the zoom mode

This is a regression in v6.1.0. The `takeGlobalCursor` action was already handled, but the `restore` action was not.