### PR TITLE
fix(geo): respect tooltip.show=false in geo region tooltip config (Fixes #20232)

### DIFF
--- a/src/component/helper/MapDraw.ts
+++ b/src/component/helper/MapDraw.ts
@@ -808,12 +808,18 @@ function resetTooltipForRegion(
     regionModel: RegionModel
 ): void {
     if (!data) {
+        const itemTooltipOption = regionModel.get('tooltip');
+        // Skip tooltip config if the tooltip is explicitly disabled
+        // for this region (geo.tooltip.show = false)
+        if (itemTooltipOption && !isString(itemTooltipOption) && itemTooltipOption.show === false) {
+            return;
+        }
         graphic.setTooltipConfig({
             el: el,
             componentModel: mapOrGeoModel,
             itemName: regionName,
             // @ts-ignore FIXME:TS fix the "compatible with each other"?
-            itemTooltipOption: regionModel.get('tooltip')
+            itemTooltipOption: itemTooltipOption
         });
     }
 }


### PR DESCRIPTION
### Problem

When `geo.tooltip.show` is set to `false`, the tooltip still shows when hovering over geo regions because `resetTooltipForRegion` unconditionally sets the tooltip config on each region element.

### Root Cause

In `src/component/helper/MapDraw.ts`, the `resetTooltipForRegion` function always calls `graphic.setTooltipConfig()` with the region's tooltip option, without checking whether `show: false` is explicitly set.

### Fix

Added a guard in `resetTooltipForRegion` to check if the tooltip option has `show: false` before setting the tooltip config. If the tooltip is explicitly disabled, the function returns early without setting the config, so the tooltip component will not show a tooltip for that region.

### Related Issue

Fixes #20232