### PR TITLE
fix(toolbox): reset dataZoom active state on restore

### DIFF
--- a/src/component/toolbox/feature/DataZoom.ts
+++ b/src/component/toolbox/feature/DataZoom.ts
@@ -295,6 +295,8 @@ function updateZoomBtnStatus(
     if (payload && payload.type === 'takeGlobalCursor') {
         zoomActive = payload.key === 'dataZoomSelect'
             ? payload.dataZoomSelectActive : false;
+    } else if (payload && payload.type === 'restore') {
+        zoomActive = false;
     }
 
     view._isZoomActive = zoomActive;


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing

### What does this PR do?

Resets the toolbox dataZoom feature's active state when the "restore" action is dispatched, so the zoom toggle behaves correctly after a chart restore.

### Fixed issues
- #21661: [Bug] Update from 5 to 6 causes trigger multiple toolbox datazoom

## Details

### Before: What was the problem?

After clicking "Enable drag zoom" (which dispatches `takeGlobalCursor` with `dataZoomSelectActive: true`), zooming, then clicking the toolbox "Restore" button, the `_isZoomActive` flag stayed `true`. Clicking "Enable drag zoom" again would toggle it off (because the `zoom` handler computes `!this._isZoomActive`), leaving the feature in a broken state where the second zoom produces a wrong result.

### After: How does it behave after the fixing?

Added a check for the "restore" payload type in `updateZoomBtnStatus`, resetting `zoomActive` to `false`. Now after restore the brush controller is properly disabled, and the next "Enable drag zoom" click correctly re-enables it, producing a correct zoom.

close #21661