### PR TITLE
fix(marker): respect markLine z2 when computing label z2 in traverseUpdateZ (Fixes #21650)

### DIFF
--- a/src/component/marker/MarkerView.ts
+++ b/src/component/marker/MarkerView.ts
@@ -115,7 +115,8 @@ function updateZ(
 
         if (markerModel && markerDraw && markerDraw.group) {
             const { z, zlevel } = retrieveZInfo(markerModel);
-            traverseUpdateZ(markerDraw.group, z, zlevel);
+            const z2 = markerModel.get('z2');
+            traverseUpdateZ(markerDraw.group, z, zlevel, z2);
         }
     });
 }

--- a/src/util/graphic.ts
+++ b/src/util/graphic.ts
@@ -843,8 +843,9 @@ export function traverseUpdateZ(
     el: Element,
     z: number,
     zlevel: number,
+    modelZ2?: number,
 ): void {
-    doUpdateZ(el, z, zlevel, -Infinity);
+    doUpdateZ(el, z, zlevel, modelZ2 != null ? modelZ2 : -Infinity);
 }
 
 function doUpdateZ(


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing

### What does this PR do?

When the user sets a `z2` value on a markLine, the label's `z2` should reflect this value so the label stacks correctly relative to other series elements.

### Root cause

`traverseUpdateZ` uses `-Infinity` as the initial `maxZ2` value, and the label's `z2` is computed as `maxZ2 + 2` from child elements. If the child elements' `z2` is not set (or set to 0) before `traverseUpdateZ` runs, the label gets a default `z2` of 2, regardless of the markLine's `z2` setting.

### Fix

1. `src/util/graphic.ts`: Added an optional `modelZ2` parameter to `traverseUpdateZ()`. When provided, it seeds the `maxZ2` starting value, ensuring the label's `z2` is at least `modelZ2 + 2`.

2. `src/component/marker/MarkerView.ts`: The `updateZ` function now reads the marker model's `z2` value and passes it to `traverseUpdateZ()`.

### Fixed issues
- Fixes #21650: Markline z2 is not effect on label

### Before: What was the problem?

Setting `markLine.z2` had no effect on the label's z-order. The label would always render at a default z2 level regardless of the markLine's z2 configuration.

### After: How does it fix the problem?

The label's z2 now respects the markLine's z2 setting. The label's z2 is computed as `max(modelZ2, childZ2) + 2`, ensuring the label is always above the markLine elements and respects the user's z2 configuration.

### Other information

This is a minimal fix that only affects the marker (markLine/markPoint/markArea) components. The `traverseUpdateZ` function's existing behavior is preserved for all other callers (the `modelZ2` parameter is optional).