### PR TITLE
fix(dataZoom): keep slider handle label visible when mouse stays over handle after drag end

### DIFF
--- a/src/component/dataZoom/SliderZoomView.ts
+++ b/src/component/dataZoom/SliderZoomView.ts
@@ -928,7 +928,7 @@ class SliderZoomView extends DataZoomView {
 
     private _onActualMoveZoneDragEnd(event: ZRElementEvent) {
         (event.target as Displayable).attr('cursor', 'grab');
-        this._onDragEnd();
+        this._onDragEnd(event);
     }
 
     private _onDragMove(handleIndex: 0 | 1 | 'all', dx: number, dy: number, event: ZRElementEvent) {
@@ -952,12 +952,23 @@ class SliderZoomView extends DataZoomView {
         changed && realtime && this._dispatchZoomAction(true);
     }
 
-    private _onDragEnd() {
+    private _onDragEnd(e?: ZRElementEvent) {
         this._dragging = false;
 
         if (!this._isOverDataInfoTriggerArea) {
             // Drag end may occur on draggable bars, where data info should be still shown.
-            this._showDataInfo(false);
+            // When the drag ends, if the mouse is still over a handle or the move zone
+            // (e.g. the user releases without moving the mouse away), keep the label visible.
+            // This prevents the label from disappearing after a drag-and-release where
+            // the mouse stays over the handle (mouseout may have fired during drag).
+            const target = e && e.target;
+            const displayables = this._displayables;
+            const isOverDraggable = target === displayables.handles[0]
+                || target === displayables.handles[1]
+                || target === displayables.moveZone;
+            if (!isOverDraggable) {
+                this._showDataInfo(false);
+            }
         }
 
         // While in realtime mode and stream mode, dispatch action when


### PR DESCRIPTION
Fixes #20178

## Problem

When dragging a dataZoom slider handle and releasing the mouse **without moving it away** (i.e. the mouse stays over the handle), the handle's label disappears even though the pointer is still over the handle.

## Root cause

During a drag, the handle's `onmouseout` can fire (the pointer briefly leaves the handle hit area as it moves), which sets `SliderZoomView._isOverDataInfoTriggerArea = false`. On `dragend`, `_onDragEnd()` checks that flag and, because it is `false`, calls `_showDataInfo(false)` which hides the label — even though the mouse is still sitting over the handle.

## Fix

Accept the `dragend` event in `_onDragEnd(e)`. When the flag is `false`, only hide the label if the drag did **not** end on a handle or the move zone. If the drag released over a handle / move zone, keep the label visible so it matches the "mouse is still over the handle" expectation.

This also forwards the event from `_onActualMoveZoneDragEnd` so the move-zone drag path behaves the same way.