### PR TITLE
fix(roam): respect globalPan mutex in mouseup/mousedown to keep zoom cursor

### DIFF
--- a/src/component/helper/RoamController.ts
+++ b/src/component/helper/RoamController.ts
@@ -279,6 +279,7 @@ class RoamController extends Eventful<RoamEventDefinition> {
 
     private _mousedownHandler(e: ZRElementEvent) {
         if (eventTool.isMiddleOrRightButtonOnMouseUpDown(e)
+            || interactionMutex.isTaken(this._zr, 'globalPan')
             || eventConsumed(e)
         ) {
             return;
@@ -349,7 +350,9 @@ class RoamController extends Eventful<RoamEventDefinition> {
     }
 
     private _mouseupHandler(e: ZRElementEvent) {
-        if (eventConsumed(e)) {
+        if (interactionMutex.isTaken(this._zr, 'globalPan')
+            || eventConsumed(e)
+        ) {
             return;
         }
         const zr = this._zr;


### PR DESCRIPTION
### Problem

When the toolbox dataZoom button is active and the user clicks on the chart to zoom, the cursor changes to a default/gesture state after releasing the mouse. The expected behavior is that the cursor should remain as the zoom crosshair cursor while the dataZoom tool is active.

### Root Cause

The `RoamController._mousemoveHandler` properly checks `interactionMutex.isTaken(zr, 'globalPan')` and defers to the BrushController when the dataZoom brush is active. However, `_mousedownHandler` and `_mouseupHandler` were not checking this mutex:

- `_mousedownHandler` would set `this._dragging = true` even when the dataZoom brush owns the interaction
- `_mouseupHandler` would reset the cursor to `'default'` (via `_decideCursorStyle`) on mouse release, overriding the zoom crosshair cursor

### Fix

Add the same `interactionMutex.isTaken(zr, 'globalPan')` guard to `_mousedownHandler` and `_mouseupHandler`, consistent with the existing check in `_mousemoveHandler`. This prevents the RoamController from interfering with the cursor when the BrushController (dataZoom) holds the globalPan mutex.

### How to Reproduce

1. Open the line-smooth chart example with toolbox dataZoom enabled
2. Click the zoom button in the toolbox area
3. Hover over the chart — cursor should be crosshair (zoom cursor) ✓
4. Click and drag on the chart to select a zoom region
5. Release the mouse — cursor should remain as crosshair, NOT change to default/gesture

Closes #21723