### PR TITLE
fix(legend): use bottom:0 default so legend no longer overlaps axis labels

### DIFF
--- a/src/component/legend/LegendModel.ts
+++ b/src/component/legend/LegendModel.ts
@@ -457,7 +457,7 @@ class LegendModel<Ops extends LegendOption = LegendOption> extends ComponentMode
         left: 'center',
         // right: 'center',
         // top: 0,
-        bottom: tokens.size.m,
+        bottom: 0,
 
         align: 'auto',
 


### PR DESCRIPTION
## Problem

When the chart has a grid with a `bottom` offset (or `containLabel: true`), the legend overlaps with the x-axis labels. This is because the default legend position is `bottom: tokens.size.m` (15px from the container bottom), which places the legend too close to the grid's bottom edge where axis labels are rendered.

### Steps to Reproduce

1. Create a stacked line chart with `grid: { bottom: 80 }` (or any explicit bottom value)
2. Observe the legend overlapping with the x-axis labels

### Current Behavior

Legend overlaps axis labels when the grid has a bottom offset.

### Workaround

```js
legend: {
  bottom: 0,
  padding: [0, 0, 2, 0]
}
```

## Fix

Changed the default `bottom` from `tokens.size.m` (15px) to `0`. This pushes the legend to the container's bottom edge, leaving the space between the grid and the legend to the axis labels. Users can still override with an explicit `bottom` value.

## Related

Closes #21662