### PR TITLE
fix(scatter): apply jitter on both category axes when both configured (Fixes #21728)

### DIFF
--- a/src/chart/scatter/jitterLayout.ts
+++ b/src/chart/scatter/jitterLayout.ts
@@ -43,7 +43,17 @@ export default function jitterLayout(): StageHandler {
             }
             const baseAxis = coordSys.getBaseAxis && coordSys.getBaseAxis() as Axis2D | SingleAxis;
             const hasJitter = baseAxis && needFixJitter(seriesModel, baseAxis);
-            if (!hasJitter) {
+
+            // Also check the other axis (e.g. yAxis when baseAxis is xAxis) for jitter.
+            // This enables jittering on both axis directions when both axes are
+            // category (ordinal) with jitter configured, like JMP scatter plots.
+            const otherAxis = baseAxis && coordSys.getOtherAxis
+                ? coordSys.getOtherAxis(baseAxis) as Axis2D | SingleAxis
+                : null;
+            const hasOtherJitter = otherAxis
+                && needFixJitter(seriesModel, otherAxis);
+
+            if (!hasJitter && !hasOtherJitter) {
                 return;
             }
 
@@ -54,7 +64,7 @@ export default function jitterLayout(): StageHandler {
 
             const jitterOnY = dim === 'y' || (dim === 'single' && isSingleY);
             const jitterOnX = dim === 'x' || (dim === 'single' && !isSingleY);
-            if (!jitterOnY && !jitterOnX) {
+            if (!jitterOnY && !jitterOnX && !hasOtherJitter) {
                 return;
             }
 
@@ -76,6 +86,30 @@ export default function jitterLayout(): StageHandler {
 
                         const rawSize = data.getItemVisual(i, 'symbolSize');
                         const size = rawSize instanceof Array ? (rawSize[1] + rawSize[0]) / 2 : rawSize;
+
+                        // Jitter along the other axis direction first (e.g. y when base is x)
+                        if (hasOtherJitter && otherAxis) {
+                            if (otherAxis.dim === 'y') {
+                                // x is fixed, and y is floating
+                                const jittered = fixJitter(otherAxis, layout[0], layout[1], size / 2);
+                                if (hasPoints) {
+                                    points[offset + 1] = jittered;
+                                }
+                                else {
+                                    layout[1] = jittered;
+                                }
+                            }
+                            else if (otherAxis.dim === 'x') {
+                                // y is fixed, and x is floating
+                                const jittered = fixJitter(otherAxis, layout[1], layout[0], size / 2);
+                                if (hasPoints) {
+                                    points[offset] = jittered;
+                                }
+                                else {
+                                    layout[0] = jittered;
+                                }
+                            }
+                        }
 
                         if (jitterOnY) {
                             // x is fixed, and y is floating


### PR DESCRIPTION
Fixes #21728

## Problem

The jitterLayout stage only checked the base axis (returned by `getBaseAxis()`) for jitter configuration. When both axes were category (ordinal) with `jitter` configured, only the base axis direction was jittered. The other axis jitter configuration was completely ignored.

For example, with:
```js
xAxis: { type: 'category', data: ['a'], jitter: 300 },
yAxis: { type: 'category', data: ['xx'], jitter: 300 },
```

Only the x-axis jitter was applied, and the y-axis scatter points had no random offset.

## Changes

In `jitterLayout.ts`:
1. After checking the base axis for jitter, also check the **other axis** (e.g. yAxis when baseAxis is xAxis) using `coordSys.getOtherAxis()`
2. If the other axis is ordinal and has `jitter > 0`, apply jitter along that axis direction too
3. The early-return guard now checks both axes: `if (!hasJitter && !hasOtherJitter) return;`

This enables jittering on both axis directions when both axes are category with jitter configured, matching the behavior of JMP-style scatter plots where points spread in both x and y directions.

## Test

Scatter plot with both category axes, each with jitter: 300, should now show random offset in both x and y directions.
