### PR TITLE
fix: correct 'becuase' typo in code comments

### DIFF
--- a/src/chart/treemap/treemapLayout.ts
+++ b/src/chart/treemap/treemapLayout.ts
@@ -181,7 +181,7 @@ export default {
         seriesModel.setLayoutInfo(layoutInfo);
 
         // FIXME: narrow down pruning boungding rect.
-        // Currently ec width/height is used becuases clip is not supported.
+        // Currently ec width/height is used because clip is not supported.
         prunning(
             treeRoot,
             // Transform to base element coordinate system.

--- a/src/component/helper/cursorHelper.ts
+++ b/src/component/helper/cursorHelper.ts
@@ -46,7 +46,7 @@ export function onIrrelevantElement(
     }
 
     // At present the `true` return is conservative. That is, the caller, such as a RoamController,
-    // is more likely to get a `false` return and start a roam behavior, becuase even if the
+    // is more likely to get a `false` return and start a roam behavior, because even if the
     // `model.coordinateSystem` does not exist, the `e.topTarget` may be also a relevant element,
     // such as axis split line/area or series elements, where roam should be available. Otherwise,
     // if a dataZoom-served cartesian is full of series elements, the dataZoom-roaming can hardly

--- a/src/coord/matrix/Matrix.ts
+++ b/src/coord/matrix/Matrix.ts
@@ -185,7 +185,7 @@ class Matrix implements CoordinateSystem, CoordinateSystemMaster {
             clamp?: MatrixClampOption | NullUndefined;
             // Expand if cell merging is encountered.
             //  - `false`: If intersecting with a rect of merged cells, expand the result to cover it.
-            //      This is the default option, becuase `series.data` do not support the format
+            //      This is the default option, because `series.data` do not support the format
             //      `MatrixCoordRangeOption` (e.g., `[[3,5], [5,8]]`), thus merged cells can only
             //      be located by single cell locators (e.g., `[3, 5]`).
             //  - `true`: regardless of cell merging, even if the resulting rect spans accorss the merged cells.


### PR DESCRIPTION
Fix the misspelling of \ecuase\ in three code comments:

- \src/component/helper/cursorHelper.ts\
- \src/coord/matrix/Matrix.ts\
- \src/chart/treemap/treemapLayout.ts\

## Verification

- Checked the diff of each changed file via the GitHub compare API; only the typo on the comment lines was changed.