### PR TITLE
fix(tree): avoid crashes when data is emptied or nodes are removed.

### DIFF
--- a/src/chart/tree/TreeView.ts
+++ b/src/chart/tree/TreeView.ts
@@ -267,6 +267,18 @@ class TreeView extends ChartView {
         const oldMin = this._min;
         const oldMax = this._max;
 
+        // `bbox.fromPoints` leaves `min`/`max` untouched when there is no valid point
+        // (e.g. `series.data` is empty, or no node has a layout yet). They would stay
+        // empty arrays, making `max[0] - min[0]` NaN, which the zero-size checks below
+        // do not correct, and the resulting dataRect yields a non-invertible view
+        // transform. Seed them so the checks below can expand a degenerate rect.
+        if (!points.length) {
+            min[0] = oldMin ? oldMin[0] : 0;
+            min[1] = oldMin ? oldMin[1] : 0;
+            max[0] = oldMax ? oldMax[0] : 0;
+            max[1] = oldMax ? oldMax[1] : 0;
+        }
+
         // If width or height is 0
         if (max[0] - min[0] === 0) {
             min[0] = oldMin ? oldMin[0] : min[0] - 1;
@@ -575,7 +587,9 @@ function removeNodeEdge(
     }
 
     const sourceSymbolEl = data.getItemGraphicEl(source.dataIndex) as TreeSymbol;
-    const sourceEdge = sourceSymbolEl.__edge;
+    // The source node may already have been removed in the same pass, which resets its
+    // graphic element to null (see `removeNode`). Guard it like `symbolEl` above.
+    const sourceEdge = sourceSymbolEl && sourceSymbolEl.__edge;
 
     // 1. when expand the sub tree, delete the children node should delete the edge of
     // the source at the same time. because the polyline edge shape is only owned by the source.

--- a/test/ut/spec/series/treeUpdate.test.ts
+++ b/test/ut/spec/series/treeUpdate.test.ts
@@ -1,0 +1,89 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { each } from 'zrender/src/core/util';
+import { createChart } from '../../core/utHelper';
+import { EChartsType } from '../../../../src/echarts';
+
+const FULL_TREE = [{
+    name: 'root',
+    children: [
+        {name: 'c1', children: [{name: 'g1'}, {name: 'g2'}]},
+        {name: 'c2', children: [{name: 'g3'}]}
+    ]
+}];
+
+describe('tree_update', function () {
+
+    let chart: EChartsType;
+    beforeEach(function () {
+        chart = createChart({width: 400, height: 300});
+    });
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    function setTree(data: unknown, animation: boolean, notMerge?: boolean) {
+        chart.setOption({
+            animation: animation,
+            series: [{type: 'tree', data: data}]
+        }, notMerge);
+    }
+
+    // `bbox.fromPoints` writes nothing when there is no point, so `min`/`max` stayed
+    // empty and the derived dataRect was NaN, making the view transform non-invertible.
+    it('should render a tree whose data is empty', function () {
+        expect(function () {
+            setTree([], false);
+        }).not.toThrow();
+    });
+
+    each([false, true], function (animation) {
+        it(`should render a tree emptied after having data (animation: ${animation})`, function () {
+            setTree(FULL_TREE, animation);
+            expect(function () {
+                setTree([], animation, true);
+            }).not.toThrow();
+        });
+    });
+
+    // Removing several nodes in one pass resets their graphic elements to null as it
+    // goes, so a node's source may already be gone when its edge is removed.
+    each([false, true], function (animation) {
+        each([
+            {name: 'a whole subtree', data: [{name: 'root', children: [{name: 'c2', children: [{name: 'g3'}]}]}]},
+            {name: 'all but the root', data: [{name: 'root'}]}
+        ], function (removeCase) {
+            it(`should remove ${removeCase.name} (animation: ${animation})`, function () {
+                setTree(FULL_TREE, animation);
+                expect(function () {
+                    setTree(removeCase.data, animation, true);
+                }).not.toThrow();
+            });
+        });
+    });
+
+    it('should render a tree that gets data after being empty', function () {
+        setTree([], false);
+        expect(function () {
+            setTree(FULL_TREE, false, true);
+        }).not.toThrow();
+    });
+
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Fixes two crashes in the tree series: rendering a tree with no laid-out nodes, and removing several nodes in one update.



### Fixed issues

<!-- No existing issue; found while auditing tree update paths. -->


## Details

### Before: What was the problem?

Two independent crashes, both hit by ordinary tree data updates.

**1. A tree with no nodes to lay out throws.**

```js
chart.setOption({series: [{type: 'tree', data: []}]});
```

```
TypeError: Cannot read properties of null (reading '0')
    at legacyCopyOverallTrans (src/coord/View.ts:567)
    at viewCoordSysUpdateOverallTrans (src/coord/View.ts:548)
    ...
    at TreeView._updateViewCoordSys (src/chart/tree/TreeView.ts)
```

`_updateViewCoordSys` collects node positions and computes their extent:

```js
const min: number[] = [];
const max: number[] = [];
bbox.fromPoints(points, min, max);
```

`bbox.fromPoints` returns immediately without writing anything when `points` is
empty, so `min` and `max` stay empty arrays. `max[0] - min[0]` is then `NaN`, the
existing zero-size corrections below only test `=== 0` so they never fire, and the
dataRect handed to the view coordinate system is `NaN`. That makes the resulting
matrix non-invertible, `matrix.invert` returns `null`, and `legacyCopyOverallTrans`
dereferences it.

This is not only the literal `data: []` case — it also covers a tree whose nodes
have no valid layout yet, e.g. rendering before an async fetch resolves, or after
filtering the data down to nothing.

**2. Removing several nodes in one update throws.**

```js
chart.setOption({animation: false, series: [{type: 'tree', data: fullTree}]});
// drop a subtree
chart.setOption({series: [{type: 'tree', data: smallerTree}]}, true);
```

```
TypeError: Cannot read properties of null (reading '__edge')
    at removeNodeEdge (src/chart/tree/TreeView.ts:590)
    at removeNode (src/chart/tree/TreeView.ts:690)
    at DataDiffer._remove
```

`removeNodeEdge` guards its own node's graphic element but not its source's:

```js
const symbolEl = data.getItemGraphicEl(node.dataIndex) as TreeSymbol;
if (!symbolEl) {
    return;
}
const sourceSymbolEl = data.getItemGraphicEl(source.dataIndex) as TreeSymbol;
const sourceEdge = sourceSymbolEl.__edge;   // <- source may already be gone
```

`removeNode` sets `data.setItemGraphicEl(dataIndex, null)` in the removal callback.
With `animation: false` that callback runs synchronously, so when a batch of nodes
is removed the source node's element is frequently already `null` by the time its
children's edges are cleaned up.

This one is independent of the empty-data case: it fires whenever removed nodes
include a parent, even when the resulting tree is not empty (dropping a subtree, or
collapsing back to just the root).

### After: How does it behave after the fixing?

1. `min`/`max` are seeded when there is no valid point — from the previous extent if
   there is one (the mechanism already used for the collapsed-root case), otherwise
   from zero. The existing zero-size corrections then expand it into a usable rect,
   so the view transform stays invertible.
2. `sourceSymbolEl` is guarded exactly like `symbolEl` immediately above it.
   `sourceEdge` is only used as a fallback and everything downstream is already
   behind `if (edge)`, so a missing source simply means there is no edge to remove.

Emptying a tree, refilling it, and removing subtrees all work with animation on and off.



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Added `test/ut/spec/series/treeUpdate.test.ts`, covering an initially empty tree, a
tree emptied after having data, removing a subtree, removing all but the root, and
refilling an empty tree — with `animation` both `false` and `true`.

On `master` the empty-data cases fail regardless of animation, and the node-removal
cases fail with `animation: false`. The `animation: true` removal cases pass before
and after, and are kept to document that the timing of the removal callback is what
exposes the second bug.

`npm run test`, `npx tsc --noEmit` and `eslint` on the changed file all pass.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

`src/chart/tree/TreeView.ts` is also touched by #18491, #21603 and #21681.
#18491 is in the same function as the second guard here and fixes the same crash
(more thoroughly — it threads the symbols through so `sourceSymbolEl` is never
null, and also fixes polyline edge cleanup when animation is off). If you would
rather land that one, I am happy to drop the `removeNodeEdge` hunk and scope this
PR to the empty-data crash, which #18491 does not cover. #21603 and #21681 are in
different functions; whichever lands first may need a trivial rebase.

Both crashes end in the same place from a user's point of view — clearing or
shrinking tree data — so they are fixed together rather than split across two PRs
that would conflict in the same file.
