### PR TITLE
fix(tooltip): guard against removed series in cached axis tooltip params (Fixes #21732)

### DIFF
--- a/src/component/tooltip/TooltipView.ts
+++ b/src/component/tooltip/TooltipView.ts
@@ -555,11 +555,11 @@ class TooltipView extends ComponentView {
             each(itemCoordSys.dataByAxis, function (axisItem) {
                 const axisModel = ecModel.getComponent(axisItem.axisDim + 'Axis', axisItem.axisIndex) as AxisBaseModel;
                 const axisValue = axisItem.value;
-                const axis = axisModel.axis;
-                const axisValueParsed = axis.scale.parse(axisValue);
                 if (!axisModel || axisValue == null) {
                     return;
                 }
+                const axis = axisModel.axis;
+                const axisValueParsed = axis.scale.parse(axisValue);
                 // FIXME: when using `tooltip.trigger: 'axis'`, the precision of the axis value displayed in tooltip
                 //  should match the original series values rather than using the default strategy in Interval.ts
                 //  (getPrecision(interval) + 2); otherwise it may cause confusion.
@@ -578,6 +578,9 @@ class TooltipView extends ComponentView {
 
                 each(axisItem.seriesDataIndices, function (idxItem) {
                     const series = ecModel.getSeriesByIndex(idxItem.seriesIndex);
+                    if (!series) {
+                        return;
+                    }
                     const dataIndex = idxItem.dataIndexInside;
                     const cbParams = series.getDataParams(dataIndex) as TooltipCallbackDataParams;
                     // Can't find data.


### PR DESCRIPTION
Fixes #21732

## Problem

`TooltipView._showAxisTooltip` iterates `axisItem.seriesDataIndices` whose `seriesIndex` values come from the cached pointer state (`_lastDataByCoordSys`). When a merged `setOption` removes series (e.g. `replaceMerge: ['series', ...]`) while the tooltip is still showing, those cached indices become stale and `ecModel.getSeriesByIndex(idxItem.seriesIndex)` returns `undefined`, causing:

```text
Uncaught TypeError: Cannot read properties of undefined (reading 'getDataParams')
    at TooltipView._showAxisTooltip
```

## Root cause

1. `TooltipView` caches the last hovered pointer state in `_lastX` / `_lastY` / `_lastDataByCoordSys`.
2. Every `setOption` runs `TooltipView.render()` → `_keepShow()`, which re-shows the tooltip with the cached `dataByCoordSys` after the update.
3. The new option has fewer series than the cached indices refer to → `getSeriesByIndex` returns `undefined` → `series.getDataParams(...)` throws.

## Fix

Two defensive guards in `_showAxisTooltip`:

1. Skip stale `seriesDataIndices` entries whose series no longer exists: `if (!series) { return; }`
2. Move the existing `!axisModel` guard **before** the `axisModel.axis` access (it was previously checked after being dereferenced), so a removed axis also short-circuits instead of crashing.

## Test

With `tooltip: {trigger: 'axis'}`, hover to show the tooltip, then `setOption` with fewer series in merge mode — the tooltip no longer throws and safely skips removed series.
