### PR TITLE
fix(radar): distinguish missing dimensions from zero

### DIFF
--- a/src/chart/radar/RadarPath.ts
+++ b/src/chart/radar/RadarPath.ts
@@ -1,0 +1,84 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { VectorArray } from 'zrender/src/core/vector';
+import { extend } from 'zrender/src/core/util';
+import Polygon, { PolygonShape } from 'zrender/src/graphic/shape/Polygon';
+import Polyline, { PolylineShape } from 'zrender/src/graphic/shape/Polyline';
+
+
+type RadarPathShape = PolygonShape | PolylineShape;
+
+export function isValidRadarPoint(point: VectorArray): boolean {
+    return !!point && !isNaN(point[0]) && !isNaN(point[1]);
+}
+
+function getValidPoints(points: VectorArray[]): VectorArray[] {
+    if (!points) {
+        return points;
+    }
+
+    let firstMissingIndex = -1;
+    for (let i = 0; i < points.length; i++) {
+        if (!isValidRadarPoint(points[i])) {
+            firstMissingIndex = i;
+            break;
+        }
+    }
+
+    if (firstMissingIndex < 0) {
+        return points;
+    }
+
+    const validPoints = points.slice(0, firstMissingIndex);
+    for (let i = firstMissingIndex + 1; i < points.length; i++) {
+        if (isValidRadarPoint(points[i])) {
+            validPoints.push(points[i]);
+        }
+    }
+    return validPoints;
+}
+
+function getRenderableShape<T extends RadarPathShape>(shape: T): T {
+    const validPoints = getValidPoints(shape.points);
+    if (validPoints === shape.points) {
+        return shape;
+    }
+
+    const renderableShape = extend({}, shape) as T;
+    renderableShape.points = validPoints;
+    return renderableShape;
+}
+
+/**
+ * Keep missing points in the animated shape so dimensions stay aligned, but
+ * omit them at the final path-building boundary. This makes neighboring radar
+ * dimensions connect without sending NaN coordinates to the path builder.
+ */
+export class RadarPolyline extends Polyline {
+    buildPath(ctx: CanvasRenderingContext2D, shape: PolylineShape) {
+        super.buildPath(ctx, getRenderableShape(shape));
+    }
+}
+
+export class RadarPolygon extends Polygon {
+    buildPath(ctx: CanvasRenderingContext2D, shape: PolygonShape) {
+        super.buildPath(ctx, getRenderableShape(shape));
+    }
+}

--- a/src/chart/radar/RadarView.ts
+++ b/src/chart/radar/RadarView.ts
@@ -31,6 +31,7 @@ import { VectorArray } from 'zrender/src/core/vector';
 import { setLabelStyle, getLabelStatesModels } from '../../label/labelStyle';
 import ZRImage from 'zrender/src/graphic/Image';
 import { saveOldStyle } from '../../animation/basicTransition';
+import { isValidRadarPoint, RadarPolygon, RadarPolyline } from './RadarPath';
 
 type RadarSymbol = ReturnType<typeof symbolUtil.createSymbol> & {
     __dimIdx: number
@@ -84,10 +85,13 @@ class RadarView extends ChartView {
             // Simply rerender all
             symbolGroup.removeAll();
             for (let i = 0; i < newPoints.length - 1; i++) {
+                if (!isValidRadarPoint(newPoints[i])) {
+                    continue;
+                }
                 const symbolPath = createSymbol(data, idx);
                 if (symbolPath) {
                     symbolPath.__dimIdx = i;
-                    if (oldPoints[i]) {
+                    if (oldPoints[i] && isValidRadarPoint(oldPoints[i])) {
                         symbolPath.setPosition(oldPoints[i]);
                         graphic[isInit ? 'initProps' : 'updateProps'](
                             symbolPath, {
@@ -106,7 +110,7 @@ class RadarView extends ChartView {
 
         function getInitialPoints(points: number[][]) {
             return zrUtil.map(points, function (pt) {
-                return [polar.cx, polar.cy];
+                return isValidRadarPoint(pt) ? [polar.cx, polar.cy] : [NaN, NaN];
             });
         }
         data.diff(oldData)
@@ -115,8 +119,8 @@ class RadarView extends ChartView {
                 if (!points) {
                     return;
                 }
-                const polygon = new graphic.Polygon();
-                const polyline = new graphic.Polyline();
+                const polygon = new RadarPolygon();
+                const polyline = new RadarPolyline();
                 const target = {
                     shape: {
                         points: points

--- a/src/chart/radar/radarLayout.ts
+++ b/src/chart/radar/radarLayout.ts
@@ -20,8 +20,8 @@
 import * as zrUtil from 'zrender/src/core/util';
 import GlobalModel from '../../model/Global';
 import RadarSeriesModel, { SERIES_TYPE_RADAR } from './RadarSeries';
-import Radar from '../../coord/radar/Radar';
 import { createSimpleOverallStageHandler } from '../../util/model';
+import { isValidRadarPoint } from './RadarPath';
 
 type Point = number[];
 
@@ -42,33 +42,19 @@ function radarLayout(ecModel: GlobalModel) {
             data.each(data.mapDimension(axes[axisIndex].dim), function (val, dataIndex) {
                 points[dataIndex] = points[dataIndex] || [];
                 const point = coordSys.dataToPoint(val, axisIndex);
-                points[dataIndex][axisIndex] = isValidPoint(point)
-                    ? point : getValueMissingPoint(coordSys);
+                points[dataIndex][axisIndex] = point;
             });
         });
 
         // Close polygon
         data.each(function (idx) {
-            // TODO
-            // Is it appropriate to connect to the next data when some data is missing?
-            // Or, should trade it like `connectNull` in line chart?
             const firstPoint = zrUtil.find(points[idx], function (point) {
-                return isValidPoint(point);
-            }) || getValueMissingPoint(coordSys);
+                return isValidRadarPoint(point);
+            }) || [NaN, NaN];
 
             // Copy the first actual point to the end of the array
             points[idx].push(firstPoint.slice());
             data.setItemLayout(idx, points[idx]);
         });
     });
-}
-
-function isValidPoint(point: Point) {
-    return !isNaN(point[0]) && !isNaN(point[1]);
-}
-
-function getValueMissingPoint(coordSys: Radar): Point {
-    // It is error-prone to input [NaN, NaN] into polygon, polygon.
-    // (probably cause problem when refreshing or animating)
-    return [coordSys.cx, coordSys.cy];
 }

--- a/test/radar-missing-value.html
+++ b/test/radar-missing-value.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="lib/simpleRequire.js"></script>
+    <script src="lib/config.js"></script>
+    <script src="lib/jquery.min.js"></script>
+    <script src="lib/facePrint.js"></script>
+    <script src="lib/testHelper.js"></script>
+    <link rel="stylesheet" href="lib/reset.css" />
+</head>
+
+<body>
+    <div id="main0"></div>
+    <div id="main1"></div>
+
+    <script>
+        require(['echarts'], function (echarts) {
+            var radar = {
+                radius: '65%',
+                indicator: [
+                    { name: 'A', max: 100 },
+                    { name: 'B', max: 100 },
+                    { name: 'C', max: 100 },
+                    { name: 'D', max: 100 },
+                    { name: 'E', max: 100 },
+                    { name: 'F', max: 100 }
+                ]
+            };
+
+            testHelper.create(echarts, 'main0', {
+                title: [
+                    'Missing radar dimensions must not be rendered as zero',
+                    'The orange line should connect A to C and D to F, with no symbols at B or E.',
+                    'The real zero at D should still have a symbol at the center.',
+                    'The complete blue series should be unchanged.'
+                ],
+                height: 500,
+                option: {
+                    animation: false,
+                    color: ['#5470c6', '#ee6666'],
+                    tooltip: {
+                        trigger: 'item'
+                    },
+                    legend: {
+                        bottom: 5
+                    },
+                    radar: radar,
+                    series: [{
+                        type: 'radar',
+                        symbolSize: 10,
+                        data: [{
+                            name: 'Complete data',
+                            value: [55, 70, 45, 60, 75, 65],
+                            areaStyle: {
+                                opacity: 0.15
+                            }
+                        }, {
+                            name: 'Missing B and E; D is zero',
+                            value: [80, null, 65, 0, undefined, 50],
+                            areaStyle: {
+                                opacity: 0.25
+                            }
+                        }]
+                    }]
+                }
+            });
+
+            testHelper.create(echarts, 'main1', {
+                title: [
+                    'All radar dimensions are missing',
+                    'Only the radar axes should be visible.',
+                    'There should be no series line, area, or symbols at the center.'
+                ],
+                height: 420,
+                option: {
+                    animation: false,
+                    radar: radar,
+                    series: [{
+                        type: 'radar',
+                        symbolSize: 16,
+                        areaStyle: {
+                            opacity: 0.5
+                        },
+                        data: [{
+                            value: [null, undefined, NaN, '-', null, undefined]
+                        }]
+                    }]
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/test/ut/spec/series/radar.test.ts
+++ b/test/ut/spec/series/radar.test.ts
@@ -1,0 +1,196 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { EChartsType } from '@/src/echarts';
+import Group from 'zrender/src/graphic/Group';
+import Polygon from 'zrender/src/graphic/shape/Polygon';
+import Polyline from 'zrender/src/graphic/shape/Polyline';
+import { createChart, getViewGroup } from '../../core/utHelper';
+
+
+type Point = number[];
+type DrawCall = [string, ...number[]];
+
+const INDICATORS = [
+    { name: 'A', max: 100 },
+    { name: 'B', max: 100 },
+    { name: 'C', max: 100 },
+    { name: 'D', max: 100 },
+    { name: 'E', max: 100 },
+    { name: 'F', max: 100 }
+];
+
+function setRadarData(chart: EChartsType, values: unknown[]) {
+    chart.setOption({
+        animation: false,
+        radar: {
+            center: [200, 200],
+            radius: 150,
+            indicator: INDICATORS
+        },
+        series: [{
+            type: 'radar',
+            data: [{ value: values }]
+        }]
+    });
+}
+
+function getRadarGraphic(chart: EChartsType) {
+    const seriesGroup = getViewGroup(chart, 'series', 0);
+    const itemGroup = seriesGroup.childAt(0) as Group;
+
+    return {
+        polyline: itemGroup.childAt(0) as Polyline,
+        polygon: itemGroup.childAt(1) as Polygon,
+        symbolGroup: itemGroup.childAt(2) as Group
+    };
+}
+
+function getLayout(chart: EChartsType): Point[] {
+    return getSeriesModel(chart).getData().getItemLayout(0);
+}
+
+function getSeriesModel(chart: EChartsType) {
+    return (chart as any).getModel().getSeriesByIndex(0);
+}
+
+function recordPath(path: Polyline | Polygon): DrawCall[] {
+    const calls: DrawCall[] = [];
+    const context = {
+        moveTo(x: number, y: number) {
+            calls.push(['moveTo', x, y]);
+        },
+        lineTo(x: number, y: number) {
+            calls.push(['lineTo', x, y]);
+        },
+        bezierCurveTo() {
+            throw new Error('Radar paths are not expected to be smoothed.');
+        },
+        closePath() {
+            calls.push(['closePath']);
+        }
+    };
+
+    path.buildPath(context as any, path.shape);
+    return calls;
+}
+
+function expectedPolylineCalls(points: Point[], validIndices: number[]): DrawCall[] {
+    return validIndices.map((pointIndex, validIndex) => [
+        validIndex === 0 ? 'moveTo' : 'lineTo',
+        points[pointIndex][0],
+        points[pointIndex][1]
+    ]);
+}
+
+
+describe('radar', function () {
+
+    let chart: EChartsType;
+
+    beforeEach(function () {
+        chart = createChart({ width: 400, height: 400 });
+    });
+
+    afterEach(function () {
+        chart.dispose();
+    });
+
+    it('connects neighboring values without coercing missing dimensions to zero', function () {
+        setRadarData(chart, [80, null, 40, 0, undefined, 20]);
+
+        const points = getLayout(chart);
+        const graphic = getRadarGraphic(chart);
+
+        expect(points).toHaveLength(INDICATORS.length + 1);
+        expect(points[1][0]).toBeNaN();
+        expect(points[1][1]).toBeNaN();
+        expect(points[4][0]).toBeNaN();
+        expect(points[4][1]).toBeNaN();
+
+        // A real zero remains a drawable value at the radar center.
+        expect(points[3]).toEqual([200, 200]);
+
+        // The last point closes the line at the first valid dimension.
+        expect(points[6]).toEqual(points[0]);
+
+        const expectedCalls = expectedPolylineCalls(points, [0, 2, 3, 5, 6]);
+        expect(recordPath(graphic.polyline)).toEqual(expectedCalls);
+        expect(recordPath(graphic.polygon)).toEqual([
+            ...expectedCalls,
+            ['closePath']
+        ]);
+        expect(graphic.symbolGroup.children()).toHaveLength(4);
+
+        const tooltip = getSeriesModel(chart).formatTooltip(0);
+        expect(tooltip.blocks.map((block: any) => block.value)).toEqual([
+            80, NaN, 40, 0, NaN, 20
+        ]);
+    });
+
+    it('does not render geometry or symbols when every dimension is missing', function () {
+        setRadarData(chart, [null, undefined, NaN, '-', null, undefined]);
+
+        const points = getLayout(chart);
+        const graphic = getRadarGraphic(chart);
+
+        expect(points).toHaveLength(INDICATORS.length + 1);
+        points.forEach(function (point) {
+            expect(point[0]).toBeNaN();
+            expect(point[1]).toBeNaN();
+        });
+        expect(recordPath(graphic.polyline)).toEqual([]);
+        expect(recordPath(graphic.polygon)).toEqual([]);
+        expect(graphic.symbolGroup.children()).toHaveLength(0);
+    });
+
+    it('rebuilds connected geometry when the missing dimensions change', function () {
+        setRadarData(chart, [80, null, 40, 30, undefined, 20]);
+        setRadarData(chart, [null, 0, undefined, 60, 50, 20]);
+
+        const points = getLayout(chart);
+        const graphic = getRadarGraphic(chart);
+
+        expect(points[0][0]).toBeNaN();
+        expect(points[2][0]).toBeNaN();
+        expect(points[1]).toEqual([200, 200]);
+        expect(points[6]).toEqual(points[1]);
+
+        expect(recordPath(graphic.polyline)).toEqual(
+            expectedPolylineCalls(points, [1, 3, 4, 5, 6])
+        );
+        expect(graphic.symbolGroup.children()).toHaveLength(4);
+    });
+
+    it('keeps complete numeric radar geometry unchanged', function () {
+        setRadarData(chart, [100, 80, 60, 40, 20, 0]);
+
+        const points = getLayout(chart);
+        const graphic = getRadarGraphic(chart);
+
+        points.forEach(function (point) {
+            expect(Number.isFinite(point[0])).toBe(true);
+            expect(Number.isFinite(point[1])).toBe(true);
+        });
+        expect(recordPath(graphic.polyline)).toEqual(
+            expectedPolylineCalls(points, [0, 1, 2, 3, 4, 5, 6])
+        );
+        expect(graphic.symbolGroup.children()).toHaveLength(6);
+    });
+});


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

This PR keeps missing radar dimensions absent from the rendered geometry instead of drawing them as real zero values at the radar center.

### Fixed issues

- Closes #20811 and also addresses the same missing-data request in #20654.

## Details

### Before: What was the problem?

Radar layout replaced `null`, `undefined`, `NaN`, and `'-'` values with the coordinate-system center before rendering. This made missing observations indistinguishable from actual numeric zeroes: they changed the polygon shape, produced symbols at the center, and could visually suggest measurements that were never present.

The center fallback originally protected the generic polygon renderer from `NaN` coordinates, so simply removing it would reintroduce unstable path and animation behavior.

### After: How does it behave after the fixing?

The layout now preserves one point per radar dimension and represents missing dimensions with invalid coordinates. Radar-specific polyline and polygon paths filter those coordinates only at the path-building boundary, retaining fixed-dimension shapes for animation while connecting neighboring valid dimensions without passing `NaN` values to the renderer.

Symbols are created only for valid dimensions. A real numeric zero still renders at the center, all-missing data renders no series geometry, tooltip values remain unchanged, and complete numeric radar data follows the existing fast path.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

- `test/ut/spec/series/radar.test.ts` covers mixed missing values, real zeroes, path construction, symbols, tooltip data, all-missing input, updates that move the missing dimensions, and the unchanged complete-data path.
- `test/radar-missing-value.html` provides side-by-side visual cases for partial and all-missing data.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information

Validation performed on Node.js 20.20.2:

- `npm test -- --runInBand` (27 suites, 198 tests)
- `npm run lint`
- `npm run checktype`
- `npm run test:dts` (TypeScript 4.7 through 5.9)
- `npm run release`
- Chrome 151 browser verification of the visual case with both Canvas and SVG renderers, including path-command, symbol, and console-error assertions

AI assistance (OpenAI Codex) was used for issue analysis, implementation, test authoring, and local verification. I reviewed and understand the complete change and the validation above.
