### PR TITLE
fix(type): allow null/undefined for axis `min` and `max` option

### DIFF
--- a/src/coord/axisCommonTypes.ts
+++ b/src/coord/axisCommonTypes.ts
@@ -105,14 +105,16 @@ export interface AxisBaseOptionCommon extends ComponentOption,
      * + 'dataMin': use the min value in data.
      * + null/undefined: auto decide min value (consider pretty look and boundaryGap).
      */
-    min?: ScaleDataValue | 'dataMin' | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
+    min?: ScaleDataValue | 'dataMin' | NullUndefined
+        | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
     /**
      * Max value of the axis. can be:
      * + ScaleDataValue
      * + 'dataMax': use the max value in data.
      * + null/undefined: auto decide max value (consider pretty look and boundaryGap).
      */
-    max?: ScaleDataValue | 'dataMax' | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
+    max?: ScaleDataValue | 'dataMax' | NullUndefined
+        | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
     /**
      * This is the start value of shape, such as bar. 0 by default.
      * `startValue` will be included in axis scale extent union.

--- a/test/types/esm/axisMinMaxNullable.ts
+++ b/test/types/esm/axisMinMaxNullable.ts
@@ -1,0 +1,42 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import * as echarts from 'echarts';
+
+const chart: echarts.EChartsType = echarts.init(document.createElement('div'));
+
+// `min`/`max` accept `null`/`undefined` to enable auto calculation.
+// See https://echarts.apache.org/en/option.html#yAxis.max
+const option: echarts.EChartsOption = {
+    xAxis: {
+        min: null,
+        max: undefined
+    },
+    yAxis: {
+        // Function returning null/undefined should also be allowed (fixed in #21313).
+        min: () => null,
+        max: () => undefined
+    },
+    series: [{
+        type: 'line',
+        data: [[1, 2], [2, 3]]
+    }]
+};
+
+chart.setOption(option);


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Allow `null`/`undefined` to be passed as direct values of the axis `min`/`max` option in the TypeScript type definitions, since they are already supported at runtime and documented.

### Fixed issues

- #21746

## Details

### Before: What was the problem?

Setting `xAxis`/`yAxis` `min`/`max` directly to `null`/`undefined` failed TypeScript compilation (with `strictNullChecks` enabled):

```ts
const option: echarts.EChartsOption = {
    yAxis: { min: null, max: null }
};
```

> Type '{ min: null; max: null; }' is not assignable to type 'YAXisOption | YAXisOption[] | undefined'.

#21313 added `NullUndefined` only to the **function return type** of `min`/`max`, but not to the direct value union. Since `ScaleDataValue` (`number | string | Date`) does not include `null`, passing it directly still failed the type check, although the JSDoc above the option documents `null/undefined: auto decide min value` and it works at runtime.

### After: How does it behave after the fixing?

Added `NullUndefined` to the direct value union of the `min`/`max` option type in `src/coord/axisCommonTypes.ts`:

```ts
min?: ScaleDataValue | 'dataMin' | NullUndefined
    | ((extent: {min: number, max: number}) => ScaleDataValue | NullUndefined);
```

`null`/`undefined` now type-check both as direct values and as function return values, matching the documented behavior (https://echarts.apache.org/en/option.html#yAxis.max).

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Added a type test case `test/types/esm/axisMinMaxNullable.ts`, which covers both the direct value form (`min: null`, `max: undefined`) and the function form (`min: () => null`, `max: () => undefined`), verified with `npm run test:dts:fast` under strict mode across TypeScript 3.5 – 5.9.

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
