### PR TITLE
fix(model): don't require TimelineComponent for media-only option. close #21686

### DIFF
--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -141,7 +141,11 @@ const componetsMissingLogPrinted: Record<string, boolean> = {};
 
 function checkMissingComponents(option: ECUnitOption) {
     each(option, function (componentOption, mainType: ComponentMainType) {
-        if (!ComponentModel.hasClass(mainType)) {
+        // A `null`/`undefined` option value means the component is not actually
+        // used and should not be reported as missing. For example, `parseRawOption`
+        // injects an empty `timeline` entry into `baseOption` when using the
+        // `{ baseOption, media }` form without a `timeline`. See #21686.
+        if (componentOption != null && !ComponentModel.hasClass(mainType)) {
             const componentImportName = BUITIN_COMPONENTS_MAP[mainType as keyof typeof BUITIN_COMPONENTS_MAP];
             if (componentImportName && !componetsMissingLogPrinted[componentImportName]) {
                 error(`Component ${mainType} is used but not imported.

--- a/test/ut/spec/model/componentMissing.test.ts
+++ b/test/ut/spec/model/componentMissing.test.ts
@@ -149,4 +149,33 @@ describe('model_componentMissing', function () {
 
         console.error = oldConsoleErr;
     });
+
+    it('Should not report timeline component missing error for media-only option without timeline', function () {
+        // See #21686: when using the full `{ baseOption, media }` form without a
+        // `timeline`, an empty `timeline` entry was injected into `baseOption`,
+        // which was wrongly reported as a missing `TimelineComponent`.
+        const chart = createChart();
+        console.error = jest.fn();
+        chart.setOption<EChartsOption>({
+            baseOption: {
+                series: [{
+                    type: 'pie'
+                }]
+            },
+            media: [{
+                query: { maxWidth: 500 },
+                option: {
+                    series: [{
+                        type: 'pie',
+                        radius: '50%'
+                    }]
+                }
+            }]
+        });
+        expect(console.error).not.toHaveBeenCalledWith(
+            makeComponentError('timeline', 'TimelineComponent')
+        );
+
+        console.error = oldConsoleErr;
+    });
 });


### PR DESCRIPTION
## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Stops ECharts from wrongly requiring `TimelineComponent` when an option uses the `{ baseOption, media }` form without a `timeline`.

### Fixed issues

- #21686: `baseOption` with `media` incorrectly requires `TimelineComponent` when no timeline is configured

## Details

### Before: What was the problem?

Using the modular build without registering `TimelineComponent`, an option structured with `baseOption` + `media` but **no** `timeline` reported:

```text
Component timeline is used but not imported.
import { TimelineComponent } from 'echarts/components';
echarts.use([TimelineComponent]);
```

Depending on the environment this surfaces as an exception during `setOption`, forcing users to register a component they don't use.

**Root cause:** in `OptionManager.parseRawOption`, when a `baseOption` is declared, the parser injects the root timeline into it for merge purposes:

```ts
if (!baseOption.timeline) {
    baseOption.timeline = timelineOnRoot; // `undefined` when no timeline is configured
}
```

This leaves an own `timeline` key on `baseOption` whose value is `undefined`. `checkMissingComponents` then iterates every key of the option and reports any `mainType` whose class isn't registered — so the empty `timeline` entry is wrongly flagged as a missing `TimelineComponent`. It only reproduces with the `{ baseOption, media }` form because the plain root-option path doesn't inject that key.

### After: How does it behave after the fixing?

`checkMissingComponents` now skips component options whose value is `null`/`undefined`, since such an entry means the component isn't actually used. An option with `baseOption` + `media` and no `timeline` works with the modular build without registering `TimelineComponent`. Genuine missing-component reporting is unchanged (a real `timeline: {...}` still reports when unregistered).

```ts
each(option, function (componentOption, mainType) {
    // A `null`/`undefined` option value means the component is not actually used.
    if (componentOption != null && !ComponentModel.hasClass(mainType)) {
        // ...report as missing...
    }
});
```

The fix is guarded by `__DEV__` (this check only runs in development builds), so there is no production behavior change.

### Regression test

Added a case to `test/ut/spec/model/componentMissing.test.ts` asserting that a `{ baseOption, media }` option without a timeline does **not** report `TimelineComponent` as missing. Verified it fails on `master` (reproduces the bug) and passes with this fix. The full `test/ut/spec/model` suite passes, along with `npm run lint` and `npm run checktype`.

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx

## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

Added a Jest regression test in `test/ut/spec/model/componentMissing.test.ts`.

