### PR TITLE
fix(format): preserve literal replacement characters in values

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -144,7 +144,7 @@ export function formatTpl(
             const val = paramsList[seriesIdx][$vars[k]];
             tpl = tpl.replace(
                 wrapVar(TPL_VAR_ALIAS[k], seriesIdx),
-                encode ? encodeHTML(val) : val
+                () => (encode ? encodeHTML(val) : val)
             );
         }
     }
@@ -159,7 +159,7 @@ export function formatTplSimple(tpl: string, param: Dictionary<any>, encode?: bo
     zrUtil.each(param, function (value, key) {
         tpl = tpl.replace(
             '{' + key + '}',
-            encode ? encodeHTML(value) : value
+            () => (encode ? encodeHTML(value) : value)
         );
     });
     return tpl;

--- a/test/ut/spec/util/format.test.ts
+++ b/test/ut/spec/util/format.test.ts
@@ -1,0 +1,53 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import { formatTpl, formatTplSimple, encodeHTML } from '@/src/util/format';
+
+describe('template values', function () {
+    const values = ['Price $&', 'Price $$', 'Price $\'', 'Price $`', '<b>$&</b>'];
+
+    it('preserves replacement characters in series values', function () {
+        for (const value of values) {
+            for (const encode of [false, true]) {
+                const text = encode ? encodeHTML(value) : value;
+                expect(formatTpl('before {a} after', {
+                    $vars: ['seriesName'], seriesName: value
+                }, encode)).toBe('before ' + text + ' after');
+            }
+        }
+    });
+
+    it('preserves replacement characters in simple values', function () {
+        for (const value of values) {
+            for (const encode of [false, true]) {
+                const text = encode ? encodeHTML(value) : value;
+                expect(formatTplSimple('before {name} after', {name: value}, encode))
+                    .toBe('before ' + text + ' after');
+            }
+        }
+    });
+
+    it('keeps indexed series and numeric values', function () {
+        expect(formatTpl('{a0}: {c0}; {a1}: {c1}', [
+            {$vars: ['seriesName', 'name', 'value'], seriesName: '$$', value: 12},
+            {$vars: ['seriesName', 'name', 'value'], seriesName: '$&', value: 34}
+        ])).toBe('$$: 12; $&: 34');
+        expect(formatTplSimple('{value}', {value: 12})).toBe('12');
+    });
+});


### PR DESCRIPTION
## Brief Information

- [x] bug fixing
- [ ] new feature
- [ ] others

### What does this PR do?

Preserves literal dollar sequences in values inserted into formatter templates.

## Details

### Before: What was the problem?

Formatting `{a}` with a series name of `Price $$` returns `Price $`. A name containing `$&` can reinsert the placeholder instead of displaying the name, including when HTML encoding is enabled.

Both `formatTpl` and `formatTplSimple` pass values directly as replacement strings, so `String.replace` interprets these sequences.

### After: How does it behave after the fixing?

Callback replacements insert the values literally. HTML encoding and indexed series formatting stay unchanged.

## Document Info

- [x] This PR doesn't relate to document changes

## Misc

### Related test cases or examples to use the new APIs

Three tests cover literal replacement sequences with and without HTML encoding, simple templates, indexed series, and numeric values. All three fail before the fix.

Validation: 197 unit tests pass; `npm run build:lib`, `npm run checktype`, ESLint on the changed files, and `git diff --check` pass. Browser visual tests were not run.

### Merging options

- [x] Please squash the commits into a single one when merging.