### PR TITLE
fix(marker): use raw value without precision rounding when the mark line targets a specific axis value or is in `min/max` type

### DIFF
--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -71,39 +71,41 @@ const markLineTransform = function (
 ) {
     const data = seriesModel.getData();
 
-    let precision: number;
+    let useRawValue = false;
 
     let itemArray: MarkLineMergedItemOption[];
     if (!isArray(item)) {
-        // Special type markLine like 'min', 'max', 'average', 'median'
         const mlType = item.type;
-        if (
-            mlType === 'min' || mlType === 'max' || mlType === 'average' || mlType === 'median'
-            // In case
-            // data: [{
-            //   yAxis: 10
-            // }]
-            || (item.xAxis != null || item.yAxis != null)
-        ) {
+        // Special statistic type like 'min', 'max', 'average', 'median'
+        const isSpecialType = mlType === 'min' || mlType === 'max' || mlType === 'average' || mlType === 'median';
+        // In case
+        // data: [{
+        //   yAxis: 10
+        // }]
+        const isAxisValueType = item.xAxis != null || item.yAxis != null;
+        if (isSpecialType || isAxisValueType) {
 
             let valueAxis;
             let value;
 
-            if (item.yAxis != null || item.xAxis != null) {
+            if (isAxisValueType) {
                 valueAxis = coordSys.getAxis(item.yAxis != null ? 'y' : 'x');
                 value = retrieve(item.yAxis, item.xAxis);
-                // retrieve mark line precision from value rather than default precision when it targets axis value
+
+                // use raw value without precision rounding when targeting axis value
                 // to ensure it is at the expected position
-                if (isNumber(value)) {
-                    precision = numberUtil.getPrecision(value);
-                }
+                useRawValue = true;
             }
             else {
                 const axisInfo = markerHelper.getAxisInfo(item, data, coordSys, seriesModel);
                 valueAxis = axisInfo.valueAxis;
                 const valueDataDim = getStackedDimension(data, axisInfo.valueDataDim);
                 value = markerHelper.numCalculate(data, valueDataDim, mlType);
-                // PENDING: auto precision for special type (min/max...) and consider supporting precision for single marker item?
+                // PENDING:
+                // consider supporting precision for single marker item and auto precision for statistic type (average/median)?
+
+                // use raw value for min/max value
+                useRawValue = mlType === 'min' || mlType === 'max';
             }
             const valueIndex = valueAxis.dim === 'x' ? 0 : 1;
             const baseIndex = 1 - valueIndex;
@@ -120,11 +122,11 @@ const markLineTransform = function (
             mlFrom.coord[baseIndex] = -Infinity;
             mlTo.coord[baseIndex] = Infinity;
 
-            if (precision == null) {
-                precision = mlModel.get('precision');
-            }
-            if (precision >= 0 && isNumber(value)) {
-                value = numberUtil.round(value, precision);
+            if (!useRawValue) {
+                const precision = mlModel.get('precision');
+                if (precision >= 0 && isNumber(value)) {
+                    value = numberUtil.round(value, precision);
+                }
             }
 
             mlFrom.coord[valueIndex] = mlTo.coord[valueIndex] = value;

--- a/src/component/marker/MarkLineView.ts
+++ b/src/component/marker/MarkLineView.ts
@@ -71,6 +71,8 @@ const markLineTransform = function (
 ) {
     const data = seriesModel.getData();
 
+    let precision: number;
+
     let itemArray: MarkLineMergedItemOption[];
     if (!isArray(item)) {
         // Special type markLine like 'min', 'max', 'average', 'median'
@@ -90,12 +92,18 @@ const markLineTransform = function (
             if (item.yAxis != null || item.xAxis != null) {
                 valueAxis = coordSys.getAxis(item.yAxis != null ? 'y' : 'x');
                 value = retrieve(item.yAxis, item.xAxis);
+                // retrieve mark line precision from value rather than default precision when it targets axis value
+                // to ensure it is at the expected position
+                if (isNumber(value)) {
+                    precision = numberUtil.getPrecision(value);
+                }
             }
             else {
                 const axisInfo = markerHelper.getAxisInfo(item, data, coordSys, seriesModel);
                 valueAxis = axisInfo.valueAxis;
                 const valueDataDim = getStackedDimension(data, axisInfo.valueDataDim);
                 value = markerHelper.numCalculate(data, valueDataDim, mlType);
+                // PENDING: auto precision for special type (min/max...) and consider supporting precision for single marker item?
             }
             const valueIndex = valueAxis.dim === 'x' ? 0 : 1;
             const baseIndex = 1 - valueIndex;
@@ -112,9 +120,11 @@ const markLineTransform = function (
             mlFrom.coord[baseIndex] = -Infinity;
             mlTo.coord[baseIndex] = Infinity;
 
-            const precision = mlModel.get('precision');
+            if (precision == null) {
+                precision = mlModel.get('precision');
+            }
             if (precision >= 0 && isNumber(value)) {
-                value = +value.toFixed(Math.min(precision, 20));
+                value = numberUtil.round(value, precision);
             }
 
             mlFrom.coord[valueIndex] = mlTo.coord[valueIndex] = value;

--- a/test/markLine-precision.html
+++ b/test/markLine-precision.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="lib/canteen.js"></script> -->
+        <!-- <script src="lib/draggable.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+            html {
+                /* Fix the line-height to integer to avoid it varying across clients and
+                   causing visual test failures. Some clients may not support fractional px. */
+                line-height: 18px;
+            }
+        </style>
+
+        <div id="main0"></div>
+
+        <script>
+
+            require([
+                'echarts',
+            ], function (echarts /*, data */) {
+
+                var  option = {
+                    tooltip: {
+                        trigger: 'axis',
+                    },
+                    grid: {
+                        right: '20%',
+                        containLabel: true
+                    },
+                    xAxis: {
+                        type: 'category',
+                        boundaryGap: false,
+                        data: [
+                            '26/08/20 12:20:15',
+                            '26/08/20 12:25:15',
+                            '26/08/20 12:30:15',
+                            '26/08/20 12:35:15',
+                            '26/08/20 12:40:15',
+                            '26/08/20 12:45:16',
+                            '26/08/20 12:50:15',
+                            '26/08/20 12:55:15',
+                            '26/08/20 13:00:15',
+                            '26/08/20 13:05:16',
+                            '26/08/20 13:10:15',
+                            '26/08/20 13:15:15',
+                            '26/08/20 13:20:15',
+                            '26/08/20 13:25:15',
+                            '26/08/20 13:30:15',
+                            '26/08/20 13:35:15',
+                            '26/08/20 13:40:15',
+                            '26/08/20 13:45:15',
+                            '26/08/20 13:50:15',
+                            '26/08/20 13:55:15',
+                            '26/08/20 14:00:16',
+                            '26/08/20 14:05:15',
+                            '26/08/20 14:06:11',
+                            '26/08/20 14:10:15',
+                            '26/08/20 14:10:15',
+                            '26/08/20 14:15:15',
+                            '26/08/20 14:20:15',
+                            '26/08/20 14:25:15'
+                        ]
+                    },
+                    yAxis: {
+                        type: 'value',
+                        scale: true,
+                        min: 2.015
+                    },
+                    series: {
+                        data: [
+                            2.024, 2.024, 2.025, 2.02, 2.026, 2.025, 2.019, 2.024, 2.023, 2.022,
+                            2.024, 2.018, 2.02, 2.022, 2.02, 2.027, 2.026, 2.027, 2.027, 2.025,
+                            2.027, 2.026, 2.027, 2.027, 2.029, 2.031, 2.025, 2.027
+                        ],
+                        type: 'line',
+                        markLine: {
+                            // precision: 3,
+                            data: [
+                                {
+                                    xAxis: 3,
+                                    label: {
+                                        formatter: 'xAxis: {c}'
+                                    }
+                                },
+                                {
+                                    xAxis: '26/08/20 13:35:15',
+                                    label: {
+                                        formatter: 'xAxis: {c}'
+                                    }
+                                },
+                                {
+                                    yAxis: 2.0156,
+                                    label: {
+                                        formatter: 'yAxis: {c}'
+                                    }
+                                },
+                                {
+                                    type: 'average',
+                                    label: {
+                                        formatter: 'average: {c}',
+                                        position: 'insideMiddleTop'
+                                    }
+                                },
+                                {
+                                    type: 'median',
+                                    label: {
+                                        formatter: 'median: {c}',
+                                        position: 'insideMiddleBottom'
+                                    }
+                                },
+                                {
+                                    type: 'min',
+                                    label: {
+                                        formatter: 'min: {c}',
+                                        position: 'insideEndTop'
+                                    }
+                                },
+                                {
+                                    type: 'max',
+                                    label: {
+                                        formatter: 'max: {c}',
+                                        position: 'insideEndBottom'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                };
+
+                var chart = testHelper.create(echarts, 'main0', {
+                    title: [
+                        'Use value precision for marker line that targets axis value'
+                    ],
+                    option: option
+                });
+
+            }); // End of `require`
+
+
+        </script>
+
+
+    </body>
+</html>
+

--- a/test/markLine-precision.html
+++ b/test/markLine-precision.html
@@ -100,7 +100,7 @@ under the License.
                         data: [
                             2.024, 2.024, 2.025, 2.02, 2.026, 2.025, 2.019, 2.024, 2.023, 2.022,
                             2.024, 2.018, 2.02, 2.022, 2.02, 2.027, 2.026, 2.027, 2.027, 2.025,
-                            2.027, 2.026, 2.027, 2.027, 2.029, 2.031, 2.025, 2.027
+                            2.027, 2.026, 2.027, 2.027, 2.029, 2.03194, 2.025, 2.027
                         ],
                         type: 'line',
                         markLine: {
@@ -159,7 +159,7 @@ under the License.
 
                 var chart = testHelper.create(echarts, 'main0', {
                     title: [
-                        'Use value precision for marker line that targets axis value'
+                        'Use raw value without precision rounding when the mark line **targets a specific axis value** or is **in `min/max` type**'
                     ],
                     option: option
                 });


### PR DESCRIPTION

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

**[Behavior Change]**

1. Fix the mark line is not at the expected position due to precision rounding when it targets a specific axis value.
2. The mark line in `min` / `max` type is now also using the raw value without precision conversion.

For example: 
```ts
{
  yAxis: 2.0156
}
```

Since `precision` defaults to `2`, the mark line above is rounded to `2.02`. So it appears in an unexpected position and even disappears when `yAxis.min` is `2.015`.

### Fixed issues

Fixes #21743

## Comparison

| Before | After |
| :----: | :----: |
| <img width="800" height="600" alt="Before" src="https://github.com/user-attachments/assets/0296c182-0b83-42d3-8f71-0c2bbcfc3424" /> | <img width="800" height="600" alt="After" src="https://github.com/user-attachments/assets/22f0aaa5-ce4c-42c4-ba27-6fe13a9fa5fa" /> |

## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx


## Misc

### Security Checking

- [ ] This PR uses security-sensitive Web APIs.

<!-- PLEASE CHECK IT AGAINST: <https://github.com/apache/echarts/wiki/Security-Checklist-for-Code-Contributors> -->

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

test/markLine-precision.html

### Merging options

- [ ] Please squash the commits into a single one when merging.

### Other information